### PR TITLE
Improve accessible SWU collection filing workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ coverage/
 .tmp/
 .sass-cache/
 .stylelintcache
+.superpowers/
 
 # ---- Env / secrets (commit an .env.example instead) ----
 .env

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,5 @@
 dist
 node_modules
 public/sets
+.claude/worktrees
+.superpowers

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can check it out at: [https://swu.mattyflix.com/](https://swu.mattyflix.com/
 - ➕➖ **Inventory tracking**: per-card counts with +/− controls (1× cap for Leaders/Bases; 3× default for others).
 - ⌨️ **Keyboard-first filing**: arrow keys move the selected card through the grid, while `+`/`-` adjust its quantity.
 - ⚙️ **Personal filing preference**: Settings can automatically open the selected card’s enlarged physical page; this is enabled by default and saved locally.
-- 🗂️ **All-sets import/export**: JSON, CSV, and XLSX imports normalize alternate printings to their base cards; one JSON export rolls up all eight supported sets.
+- 🗂️ **All-sets import/export**: supported app, SWUDB, and SW-Unlimited exports normalize alternate printings to their base cards; one JSON export rolls up all eight supported sets.
 - 🐳 **Docker**: build once, run anywhere.
 
 ---
@@ -38,7 +38,7 @@ npm run preview
 # visit http://localhost:4173
 ```
 
-Run the complete automated verification gate:
+Verification commands:
 
 ```bash
 npm test
@@ -47,6 +47,8 @@ npm run lint
 npm run format:check
 npm run build
 ```
+
+Tests, TypeScript, ESLint, and the production build currently pass. The repository-wide `npm run format:check` command still reports 34 committed baseline files; this iteration does not normalize or hide that existing formatting debt.
 
 ---
 
@@ -139,7 +141,8 @@ Only **Name**, **Number**, **Aspects[0]**, and **Type** are required for UI & in
 }
 ```
 
-- **Import formats:** JSON, CSV, and XLSX feed the same canonical inventory path. The import preview reports recognized and skipped entries and lets you merge counts or replace data for the imported sets.
+- **Accepted import schemas:** the app’s version-one JSON export (`version: 1` with a `sets` object); SWUDB CSV with `Set`, `CardNumber`, and `Count` columns; and SW-Unlimited CSV or XLSX with `Set`, `Base card id`, and `Normal` columns. Header matching tolerates differences in case, spaces, and underscores, but arbitrary CSV/XLSX layouts are not supported.
+- **Import preview:** supported imports feed the same canonical inventory path. The preview reports recognized and skipped entries and lets you merge counts or replace data for the imported sets.
 - **Canonical counts:** alternate printings are mapped to their base card, combined, and capped only after aggregation. Unknown or malformed entries are skipped. Exports store one quantity per base card while retaining the version-one JSON shape shown above.
 - **Silent migration:** on the first load after upgrading, existing local inventory is normalized once. Before any normalized inventory is written, the app creates a recoverable local backup of the original `inv:<set>` records. The migration does not display a notice and does not repeat after its schema marker is stored.
 - Collection data, settings, the migration backup, and schema marker remain in this browser’s local storage. They are not cloud-synchronized.
@@ -151,7 +154,7 @@ Only **Name**, **Number**, **Aspects[0]**, and **Type** are required for UI & in
 
 - Arrow keys move the selected card through the binder grid, including existing page-edge wrapping.
 - `+` / `-` adjust the selected card quantity.
-- `,` / `.` move to the previous or next spread.
+- `,` / `.` move to the previous or next spread while **Spread** mode is active; they do nothing in **Single Page** mode.
 - `/` focuses search and Enter selects the highlighted result.
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SWU Organizer
 
-A fast, local-first web app to organize **Star Wars: Unlimited** binders. Pick a set, search by name or number, and see the card’s **Page / Row / Column** on a visual 8×3 spread (two 4×3 pages) with aspect colors. Track inventory, filter for missing cards, and export/import your counts. Docker-ready.
+A fast, local-first web app for organizing a personal **Star Wars: Unlimited** collection. Pick a set, search by name or number, and use the centered locator to read the card’s physical **Page / Row / Column** before filing it. Track inventory, filter for missing cards, and export or import counts without sending collection data to a server. Docker-ready.
 
 You can check it out at: [https://swu.mattyflix.com/](https://swu.mattyflix.com/)
 
@@ -9,13 +9,13 @@ You can check it out at: [https://swu.mattyflix.com/](https://swu.mattyflix.com/
 ## Features
 
 - 🔎 **Smart search**: search by **name** (typeahead) or **number** (handles leading zeros like `003`).
-- 🗺️ **Visual binder**: 8×3 spread; Page 1 shows only the right page, then spreads `2/3`, `4/5`, etc.
+- 🗺️ **Visual binder**: switch between a large 4×3 physical page and an 8×3 two-page spread; Page 1 stands alone, followed by spreads `2/3`, `4/5`, etc.
 - 🎨 **Aspect colors**: cells tinted by the card’s first aspect (Vigilance/Command/Aggression/Cunning/Heroism/Villainy).
-- 🧭 **Click & jump**: click any slot to select that card; selection shows Page/Row/Column.
+- 🧭 **Readable filing locator**: selecting a card shows its name, number, quantity, and physical Page/Row/Column in a centered, high-readability panel.
 - ➕➖ **Inventory tracking**: per-card counts with +/− controls (1× cap for Leaders/Bases; 3× default for others).
-- ⌨️ **Keyboard shortcuts**:  
-  `/` focus search, **Enter** run search, **←/→** flip spread, **+/-** adjust selected card.
-- 🗂️ **All-sets import/export**: single JSON file rolls up inventory across SOR, SHD, TWI, JTL, LOF.
+- ⌨️ **Keyboard-first filing**: arrow keys move the selected card through the grid, while `+`/`-` adjust its quantity.
+- ⚙️ **Personal filing preference**: Settings can automatically open the selected card’s enlarged physical page; this is enabled by default and saved locally.
+- 🗂️ **All-sets import/export**: JSON, CSV, and XLSX imports normalize alternate printings to their base cards; one JSON export rolls up all eight supported sets.
 - 🐳 **Docker**: build once, run anywhere.
 
 ---
@@ -38,11 +38,22 @@ npm run preview
 # visit http://localhost:4173
 ```
 
+Run the complete automated verification gate:
+
+```bash
+npm test
+npx tsc --noEmit
+npm run lint
+npm run format:check
+npm run build
+```
+
 ---
 
 ## Docker
 
 **Build & run:**
+
 ```bash
 docker build -t swu-organizer .
 docker run --rm -p 8080:8080 swu-organizer
@@ -50,27 +61,32 @@ docker run --rm -p 8080:8080 swu-organizer
 ```
 
 **docker-compose.yml:**
+
 ```yaml
 services:
   swu-organizer:
     build: .
     ports:
-      - "8080:8080"
+      - '8080:8080'
 ```
 
 ---
 
 ## Using the App
 
-1. **Choose a set** (SOR, SHD, TWI, JTL, LOF).  
-2. **Search** by name or number (press `/` to focus; **Enter** to go).  
-3. View the card’s **Page / Row / Column** and see it highlighted on the binder spread.  
-4. Adjust **quantities** with +/− on any filled slot.  
+1. **Choose a set** (SOR, SHD, TWI, JTL, LOF, SEC, LAW, or ASH).
+2. **Search** by name or number (press `/` to focus; **Enter** to go).
+3. Read the centered locator’s **Page / Row / Column** and find the highlighted slot in the binder. Columns are the four physical columns on a page (`1`–`4`), not the internal eight-column spread position.
+4. Adjust **quantities** with +/− on any filled slot or with the large controls in the locator.
 5. **Export** your inventory (all sets) to JSON; **Import** it later to restore.
 
-**Spread navigation:**  
-- Pager shows `Page 1` and then spreads `Page 2/3`, `Page 4/5`, …  
-- **←/→** flips one spread at a time.
+### Filing view and Settings
+
+- **Single Page** displays one enlarged four-column physical page. **Spread** displays the two-page eight-column overview.
+- Selecting a card opens its Single Page view by default. The enlarged page follows the selection when arrow-key navigation crosses a page boundary.
+- Open **Settings** to disable or re-enable **Automatically open enlarged page after selecting a card**. The preference is saved in local storage and defaults to enabled on first use.
+- Disabling the setting prevents the automatic switch; the **Single Page / Spread** control remains available at any time.
+- Spread navigation shows `Page 1` and then `Page 2/3`, `Page 4/5`, and so on.
 
 ---
 
@@ -78,7 +94,14 @@ services:
 
 Included set files live under `public/sets/`:
 
-- `SWU-SOR.json`, `SWU-SHD.json`, `SWU-TWI.json`, `SWU-JTL.json`, `SWU-LOF.json`
+- `SWU-SOR.json` — Spark of Rebellion (SOR)
+- `SWU-SHD.json` — Shadows of the Galaxy (SHD)
+- `SWU-TWI.json` — Twilight of the Republic (TWI)
+- `SWU-JTL.json` — Jump to Lightspeed (JTL)
+- `SWU-LOF.json` — Legends of the Force (LOF)
+- `SWU-SEC.json` — Secrets of Power (SEC)
+- `SWU-LAW.json` — A Lawless Time (LAW)
+- `SWU-ASH.json` — Ashes of the Empire (ASH)
 
 The app reads these fields per card:
 
@@ -95,7 +118,7 @@ Only **Name**, **Number**, **Aspects[0]**, and **Type** are required for UI & in
 
 ---
 
-## Inventory (All Sets)
+## Inventory, Imports, and Local Migration
 
 - **Caps:** Leaders/Bases = **1×**, other types = **3×** (configurable in code).
 - **Export** produces a single JSON like:
@@ -108,30 +131,36 @@ Only **Name**, **Number**, **Aspects[0]**, and **Type** are required for UI & in
     "SHD": {},
     "TWI": {},
     "JTL": {},
-    "LOF": { "212": 1 }
+    "LOF": { "212": 1 },
+    "SEC": {},
+    "LAW": {},
+    "ASH": {}
   }
 }
 ```
 
-- **Import** replaces stored counts per set (zeros are pruned).  
+- **Import formats:** JSON, CSV, and XLSX feed the same canonical inventory path. The import preview reports recognized and skipped entries and lets you merge counts or replace data for the imported sets.
+- **Canonical counts:** alternate printings are mapped to their base card, combined, and capped only after aggregation. Unknown or malformed entries are skipped. Exports store one quantity per base card while retaining the version-one JSON shape shown above.
+- **Silent migration:** on the first load after upgrading, existing local inventory is normalized once. Before any normalized inventory is written, the app creates a recoverable local backup of the original `inv:<set>` records. The migration does not display a notice and does not repeat after its schema marker is stored.
+- Collection data, settings, the migration backup, and schema marker remain in this browser’s local storage. They are not cloud-synchronized.
 - Setting a card back to **0** removes it from the inventory list and storage.
 
 ---
 
 ## Keyboard Shortcuts
 
-- `/` — focus search  
-- **Enter** — run search / choose highlighted suggestion (and blur field)  
-- **← / →** — previous/next spread  
-- **+ / −** — increment/decrement **selected** card’s quantity
+- Arrow keys move the selected card through the binder grid, including existing page-edge wrapping.
+- `+` / `-` adjust the selected card quantity.
+- `,` / `.` move to the previous or next spread.
+- `/` focuses search and Enter selects the highlighted result.
 
 ---
 
 ## Roadmap / Ideas
 
-- Progress bars per page & per set  
-- Filters by **Aspect**/**Type**  
-- Printable checklist / CSV export  
+- Progress bars per page & per set
+- Filters by **Aspect**/**Type**
+- Printable checklist / CSV export
 - PWA install & offline cache
 
 ---

--- a/docs/superpowers/plans/2026-07-16-accessibility-correctness-iteration.md
+++ b/docs/superpowers/plans/2026-07-16-accessibility-correctness-iteration.md
@@ -1,0 +1,1033 @@
+# Accessibility and Correctness Iteration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deliver a centered, high-readability filing locator with optional automatic single-page focus while preserving keyboard navigation, correcting exact search selection and physical columns, canonicalizing inventory safely, and adding regression tests.
+
+**Architecture:** Extract binder, search, inventory, and settings behavior into pure TypeScript modules with explicit interfaces. Keep `App.tsx` as the orchestrator, add two focused React components, and extend the existing binder renderer with a four-column presentation instead of rewriting the application.
+
+**Tech Stack:** React 18, TypeScript 5, Vite 7, Vitest, jsdom, Testing Library, browser localStorage.
+
+## Global Constraints
+
+- Remain a personal, local-first Star Wars: Unlimited collection organizer.
+- Preserve existing inventory data and create a one-time pre-migration backup.
+- Preserve current arrow-key selection, edge wrapping, comma/period navigation, and `+`/`-` quantity shortcuts.
+- Continue supporting JSON, CSV, and XLSX imports.
+- Physical columns displayed to the user are always 1-4; spread columns 1-8 are internal navigation state.
+- `Automatically open enlarged page after selecting a card` defaults to enabled and persists locally.
+- Cloud synchronization, accounts, multi-user support, deck building, and social features remain out of scope.
+
+## File Structure
+
+- Create `src/core/types.ts`: shared card, set, inventory, parsed-catalog, and selection types.
+- Create `src/core/binder.ts`: binder coordinates, spread/page conversions, and keyboard movement.
+- Create `src/core/search.ts`: stable search suggestions, ranking, and submission selection.
+- Create `src/core/inventory.ts`: canonical catalog index, quota enforcement, imports, and migration.
+- Create `src/core/settings.ts`: settings defaults, parsing, reading, and writing.
+- Create `src/components/LocatorPanel.tsx`: centered locator and quantity controls.
+- Create `src/components/SettingsModal.tsx`: accessible settings dialog.
+- Create colocated `*.test.ts` and `*.test.tsx` files for each module/component.
+- Modify `src/App.tsx`: consume extracted modules and coordinate selection, settings, focus mode, imports, and migration.
+- Modify `index.html`: locator, settings, focus-view, and responsive styles.
+- Modify `package.json`, `package-lock.json`, `vite.config.ts`, `eslint.config.js`, `.prettierignore`, and `README.md` for tooling and documentation.
+
+---
+
+### Task 1: Test Foundation and Binder Geometry
+
+**Files:**
+- Modify: `package.json`
+- Modify: `package-lock.json`
+- Modify: `vite.config.ts`
+- Create: `src/core/types.ts`
+- Create: `src/core/binder.test.ts`
+- Create: `src/core/binder.ts`
+- Modify: `src/App.tsx:4-17,142-167,1286-1363`
+
+**Interfaces:**
+- Produces `Card`, `Inventory`, `SetKey`, `SetMeta`, `ActiveSelection`, and `BinderPosition` from `src/core/types.ts`.
+- Produces `binderLayout(number)`, `getSpreadCoords(page,row,column)`, `numberFromPagePosition(page,row,column)`, `pageToSpread(page)`, `spreadToPrimaryPage(spread)`, and `moveBinderSelection(selection,direction,totalPages)` from `src/core/binder.ts`.
+- Later tasks consume these shared types and geometry functions.
+
+- [ ] **Step 1: Add the test runner dependencies and scripts**
+
+Run:
+
+```powershell
+npm install --save-dev vitest jsdom @testing-library/react @testing-library/user-event
+```
+
+Update `package.json` scripts to include:
+
+```json
+"test": "vitest run",
+"test:watch": "vitest"
+```
+
+Update `vite.config.ts` to:
+
+```ts
+/// <reference types="vitest/config" />
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+  },
+})
+```
+
+- [ ] **Step 2: Write failing binder geometry and movement tests**
+
+Create `src/core/binder.test.ts` with explicit cases:
+
+```ts
+import { describe, expect, it } from 'vitest'
+import {
+  binderLayout,
+  getSpreadCoords,
+  moveBinderSelection,
+  pageToSpread,
+} from './binder'
+
+describe('binder geometry', () => {
+  it.each([
+    [1, { page: 1, row: 1, column: 1 }],
+    [4, { page: 1, row: 1, column: 4 }],
+    [5, { page: 1, row: 2, column: 1 }],
+    [12, { page: 1, row: 3, column: 4 }],
+    [13, { page: 2, row: 1, column: 1 }],
+  ])('maps card %i to its physical position', (number, expected) => {
+    expect(binderLayout(number)).toEqual(expected)
+  })
+
+  it('keeps physical and spread columns distinct', () => {
+    expect(getSpreadCoords(1, 1, 1)).toEqual({ spreadCol: 5, spreadRow: 1 })
+    expect(binderLayout(1).column).toBe(1)
+  })
+
+  it('moves right from the final column to the adjacent physical page', () => {
+    const selection = { ...binderLayout(16), number: 16 }
+    expect(moveBinderSelection(selection, 'right', 10)).toMatchObject({
+      number: 25,
+      page: 3,
+      row: 1,
+      column: 1,
+    })
+  })
+
+  it('preserves vertical spread wrapping', () => {
+    const selection = { ...binderLayout(24), number: 24 }
+    expect(moveBinderSelection(selection, 'down', 10)).toMatchObject({
+      page: 4,
+      row: 1,
+      column: 4,
+    })
+  })
+
+  it('does not move beyond the first or last spread', () => {
+    const first = { ...binderLayout(1), number: 1 }
+    expect(moveBinderSelection(first, 'left', 1)).toEqual(first)
+    expect(pageToSpread(1)).toBe(0)
+  })
+})
+```
+
+- [ ] **Step 3: Run the binder tests and verify RED**
+
+Run: `npm test -- src/core/binder.test.ts`
+
+Expected: FAIL because `src/core/binder.ts` does not exist.
+
+- [ ] **Step 4: Implement the shared types and binder module**
+
+Create `src/core/types.ts`:
+
+```ts
+export type Card = {
+  Name: string
+  Subtitle?: string
+  Number: number
+  Aspects?: string[]
+  Type?: string
+  Rarity?: string
+  MarketPrice?: number
+  Set: string
+}
+
+export type Inventory = Record<number, number>
+export type SetKey = string
+export type SetMeta = { key: string; label: string; file: string }
+export type BinderPosition = { number: number; page: number; row: number; column: number }
+export type ActiveSelection = BinderPosition & {
+  card: Card
+  spreadCol: number
+  spreadRow: number
+}
+```
+
+Create `src/core/binder.ts` by moving the existing coordinate functions and the current movement algorithm out of `App.tsx`. Export this API:
+
+```ts
+import type { BinderPosition } from './types'
+
+export type MoveDirection = 'left' | 'right' | 'up' | 'down'
+
+export function binderLayout(number: number): Omit<BinderPosition, 'number'>
+export function getSpreadCoords(page: number, row: number, column: number): {
+  spreadCol: number
+  spreadRow: number
+}
+export function numberFromPagePosition(page: number, row: number, column: number): number
+export function pageToSpread(page: number): number
+export function spreadToPrimaryPage(spread: number): number
+export function moveBinderSelection(
+  selection: BinderPosition,
+  direction: MoveDirection,
+  totalPages: number,
+): BinderPosition
+```
+
+`moveBinderSelection` must reproduce the existing 8-column spread navigation before converting the result back to physical page coordinates. When a movement would leave the valid spread range, return the original selection unchanged.
+
+- [ ] **Step 5: Run the binder test and full typecheck**
+
+Run: `npm test -- src/core/binder.test.ts`
+
+Expected: PASS with five binder behavior groups.
+
+Run: `npx tsc --noEmit`
+
+Expected: PASS after replacing the duplicate geometry helpers and movement body in `App.tsx` with imports from `src/core/binder.ts`.
+
+- [ ] **Step 6: Commit binder extraction**
+
+```powershell
+git add package.json package-lock.json vite.config.ts src/core src/App.tsx
+git commit -m "test: cover binder geometry and navigation"
+```
+
+---
+
+### Task 2: Stable Search Identity and Ranking
+
+**Files:**
+- Create: `src/core/search.test.ts`
+- Create: `src/core/search.ts`
+- Modify: `src/App.tsx:675-785,801-803,1083-1262`
+
+**Interfaces:**
+- Consumes `Card` and `SetKey` from `src/core/types.ts`.
+- Produces `SearchCatalog`, `SearchSuggestion`, `buildSearchSuggestions(query,catalogs,currentSetKey,limit)`, and `submittedSuggestion(suggestions,highlightIndex)`.
+- `App.tsx` selects cards only from `SearchSuggestion.setKey` and `SearchSuggestion.baseNumber`.
+
+- [ ] **Step 1: Write failing search behavior tests**
+
+Create `src/core/search.test.ts` with catalogs containing both Darth Vader cards and Brain Invaders:
+
+```ts
+import { describe, expect, it } from 'vitest'
+import { buildSearchSuggestions, submittedSuggestion } from './search'
+
+const catalogs = [
+  {
+    setKey: 'SOR',
+    cards: [
+      { Name: 'Darth Vader', Subtitle: 'Dark Lord of the Sith', Number: 10, Type: 'Leader', Set: 'SOR' },
+      { Name: 'Darth Vader', Subtitle: 'Commanding the First Legion', Number: 87, Type: 'Unit', Set: 'SOR' },
+    ],
+    printingNumbersByBase: new Map([[10, [10]], [87, [87, 351]]]),
+    baseByPrintingNumber: new Map([[10, 10], [87, 87], [351, 87]]),
+  },
+  {
+    setKey: 'TWI',
+    cards: [{ Name: 'Brain Invaders', Number: 255, Type: 'Unit', Set: 'TWI' }],
+    printingNumbersByBase: new Map([[255, [255]]]),
+    baseByPrintingNumber: new Map([[255, 255]]),
+  },
+]
+
+describe('search suggestions', () => {
+  it('keeps duplicate names as distinct stable card identities', () => {
+    const results = buildSearchSuggestions('Darth Vader', catalogs, 'SOR')
+    expect(results.map(result => result.baseNumber)).toEqual([10, 87])
+  })
+
+  it('ranks intentional word starts before incidental normalized substrings', () => {
+    const results = buildSearchSuggestions('Vader', catalogs, 'SOR')
+    expect(results[0]).toMatchObject({ setKey: 'SOR', baseNumber: 10 })
+    expect(results.at(-1)?.name).toBe('Brain Invaders')
+  })
+
+  it('resolves an alternate printing number to its base card', () => {
+    expect(buildSearchSuggestions('351', catalogs, 'SOR')[0]).toMatchObject({
+      setKey: 'SOR',
+      baseNumber: 87,
+    })
+  })
+
+  it('submits the highlighted result and falls back to the first', () => {
+    const results = buildSearchSuggestions('Darth Vader', catalogs, 'SOR')
+    expect(submittedSuggestion(results, 1)?.baseNumber).toBe(87)
+    expect(submittedSuggestion(results, 99)?.baseNumber).toBe(10)
+  })
+})
+```
+
+- [ ] **Step 2: Run the search tests and verify RED**
+
+Run: `npm test -- src/core/search.test.ts`
+
+Expected: FAIL because `src/core/search.ts` does not exist.
+
+- [ ] **Step 3: Implement stable search suggestions**
+
+Create `src/core/search.ts` with these public types:
+
+```ts
+import type { Card, SetKey } from './types'
+
+export type SearchCatalog = {
+  setKey: SetKey
+  cards: Card[]
+  printingNumbersByBase: Map<number, number[]>
+  baseByPrintingNumber: Map<number, number>
+}
+
+export type SearchSuggestion = {
+  kind: 'name' | 'number'
+  setKey: SetKey
+  baseNumber: number
+  name: string
+  subtitle?: string
+  type?: string
+  printingNumbers: number[]
+  label: string
+}
+```
+
+Implement ranking with a numeric score: exact printing number first, current set before other sets, exact normalized name, word-start name, substring name, subtitle match, then incidental normalized substring. Sort ties by name, subtitle, and base number. Deduplicate only by `${setKey}:${baseNumber}`.
+
+Implement submission as:
+
+```ts
+export function submittedSuggestion(
+  suggestions: SearchSuggestion[],
+  highlightIndex: number,
+): SearchSuggestion | null {
+  if (!suggestions.length) return null
+  return suggestions[highlightIndex] ?? suggestions[0]
+}
+```
+
+- [ ] **Step 4: Run search tests and verify GREEN**
+
+Run: `npm test -- src/core/search.test.ts`
+
+Expected: PASS with four search tests.
+
+- [ ] **Step 5: Integrate search into App**
+
+Replace the component-local `Suggestion` type and `suggestions` memo with `buildSearchSuggestions`. Replace `baseByName`, `goFromName`, `goFromNumberString`, and `onChoose` branching with one selection path:
+
+```ts
+function chooseSuggestion(suggestion: SearchSuggestion) {
+  if (suggestion.setKey !== setKey) {
+    setPendingSelection({
+      setKey: suggestion.setKey,
+      baseNumber: suggestion.baseNumber,
+    })
+    setSetKey(suggestion.setKey)
+    setQuery('')
+    setOpenSug(false)
+    return
+  }
+  selectCardByNumber(suggestion.baseNumber)
+  setQuery('')
+  setOpenSug(false)
+}
+
+function submitSearch() {
+  const suggestion = submittedSuggestion(suggestions, highlightIdx)
+  if (!suggestion) {
+    setError(query.trim() ? 'No matching card found.' : 'Enter a name or number.')
+    return
+  }
+  chooseSuggestion(suggestion)
+}
+```
+
+Use `submitSearch` from Enter and the search icon. Change pending selection to `{ setKey: SetKey; baseNumber: number }` and resolve it by number after the destination catalog loads.
+
+- [ ] **Step 6: Run search, binder, and type tests**
+
+Run: `npm test -- src/core/search.test.ts src/core/binder.test.ts`
+
+Expected: PASS.
+
+Run: `npx tsc --noEmit`
+
+Expected: PASS with no `baseByName` or `goFromName` references.
+
+- [ ] **Step 7: Commit exact search selection**
+
+```powershell
+git add src/core/search.ts src/core/search.test.ts src/App.tsx
+git commit -m "fix: select exact cards from search results"
+```
+
+---
+
+### Task 3: Canonical Inventory, Imports, and Silent Migration
+
+**Files:**
+- Create: `src/core/inventory.test.ts`
+- Create: `src/core/inventory.ts`
+- Modify: `src/App.tsx:158-160,420-646,805-815,1399-1423,1514-1685,1845-1949`
+
+**Interfaces:**
+- Consumes `Card`, `Inventory`, `SetKey` from `src/core/types.ts`.
+- Produces `CanonicalCardRef`, `CanonicalCatalog`, `quotaForType`, `canonicalizeInventory`, `applyImportedInventories`, and `migrateLegacyInventories`.
+- All UI inventory reads and writes use base numbers only after this task.
+
+- [ ] **Step 1: Write failing canonicalization and migration tests**
+
+Create `src/core/inventory.test.ts` using a small `MemoryStorage` implementation of the browser `Storage` subset. Cover:
+
+```ts
+import { describe, expect, it } from 'vitest'
+import {
+  applyImportedInventories,
+  canonicalizeInventory,
+  migrateLegacyInventories,
+} from './inventory'
+
+const catalog = new Map([
+  ['SOR:10', { setKey: 'SOR', printingNumber: 10, baseNumber: 10, type: 'Leader' }],
+  ['SOR:87', { setKey: 'SOR', printingNumber: 87, baseNumber: 87, type: 'Unit' }],
+  ['SOR:351', { setKey: 'SOR', printingNumber: 351, baseNumber: 87, type: 'Unit' }],
+  ['SHD:1', { setKey: 'SHD', printingNumber: 1, baseNumber: 1, type: 'Base' }],
+])
+
+it('combines printings at the base card and caps after aggregation', () => {
+  expect(canonicalizeInventory('SOR', { 87: 2, 351: 2 }, catalog)).toEqual({ 87: 3 })
+})
+
+it('uses the destination set quota during cross-set merge', () => {
+  const result = applyImportedInventories(
+    { SHD: { 1: 1 } },
+    { SHD: { 1: 2 } },
+    'merge',
+    catalog,
+  )
+  expect(result.inventories.SHD).toEqual({ 1: 1 })
+})
+
+it('skips unknown and malformed entries', () => {
+  const result = canonicalizeInventory('SOR', { 87: 1, 9999: 3, [-1]: 2 }, catalog)
+  expect(result).toEqual({ 87: 1 })
+})
+
+it('backs up and migrates legacy data only once', () => {
+  const storage = new MemoryStorage({
+    'inv:SOR': JSON.stringify({ 87: 2, 351: 2 }),
+  })
+  const first = migrateLegacyInventories(storage, ['SOR'], catalog)
+  expect(first.SOR).toEqual({ 87: 3 })
+  expect(storage.getItem('inv:migration:v2:backup')).toContain('351')
+  expect(storage.getItem('inv:schema-version')).toBe('2')
+
+  storage.setItem('inv:SOR', JSON.stringify({ 87: 1 }))
+  expect(migrateLegacyInventories(storage, ['SOR'], catalog).SOR).toEqual({ 87: 1 })
+})
+```
+
+The test file must include a complete `MemoryStorage` class implementing `getItem`, `setItem`, `removeItem`, `key`, `length`, and `clear` over a `Map<string,string>`.
+
+- [ ] **Step 2: Run inventory tests and verify RED**
+
+Run: `npm test -- src/core/inventory.test.ts`
+
+Expected: FAIL because `src/core/inventory.ts` does not exist.
+
+- [ ] **Step 3: Implement canonical inventory operations**
+
+Create `src/core/inventory.ts` with:
+
+```ts
+import type { Inventory, SetKey } from './types'
+
+export type CanonicalCardRef = {
+  setKey: SetKey
+  printingNumber: number
+  baseNumber: number
+  type?: string
+}
+
+export type CanonicalCatalog = Map<string, CanonicalCardRef>
+export type ImportMode = 'merge' | 'replace'
+export type ImportResult = {
+  inventories: Record<SetKey, Inventory>
+  recognized: number
+  skipped: number
+}
+
+export const INVENTORY_SCHEMA_VERSION = '2'
+export const INVENTORY_SCHEMA_KEY = 'inv:schema-version'
+export const INVENTORY_BACKUP_KEY = 'inv:migration:v2:backup'
+```
+
+`canonicalizeInventory(setKey, inventory, catalog)` must parse only positive integer printing numbers and positive finite quantities, look up every printing in `catalog`, aggregate by `baseNumber`, and cap once using `quotaForType(ref.type)`.
+
+`applyImportedInventories(current, imported, mode, catalog)` must canonicalize both sides. Replace starts from an empty destination inventory for every imported set. Merge adds canonical counts then caps by the destination base-card reference.
+
+`migrateLegacyInventories(storage, setKeys, catalog)` must:
+
+1. Return parsed canonical inventories without creating another backup when schema version is already `2`.
+2. Read and retain every original `inv:<set>` string in one JSON backup object.
+3. Store that backup before writing any normalized inventories.
+4. Write normalized `inv:<set>` values.
+5. Store schema version `2` only after all writes complete.
+
+- [ ] **Step 4: Run inventory tests and verify GREEN**
+
+Run: `npm test -- src/core/inventory.test.ts`
+
+Expected: PASS with canonicalization, cross-set quota, malformed input, backup, and idempotence coverage.
+
+- [ ] **Step 5: Route every import format through the canonical catalog**
+
+Replace `CardUtilities.fullCardIndex` with `CanonicalCatalog`. Build it after all sets parse:
+
+```ts
+function canonicalCatalogFromParsedSets(parsedSets: Iterable<ParsedSet>): CanonicalCatalog {
+  const catalog: CanonicalCatalog = new Map()
+  for (const parsed of parsedSets) {
+    for (const card of parsed.allCards) {
+      const baseNumber = parsed.altToBase.get(card.Number) ?? card.Number
+      const baseCard = parsed.byNumber.get(baseNumber)
+      catalog.set(`${parsed.key}:${card.Number}`, {
+        setKey: parsed.key,
+        printingNumber: card.Number,
+        baseNumber,
+        type: baseCard?.Type ?? card.Type,
+      })
+    }
+  }
+  return catalog
+}
+```
+
+CSV, XLSX, and JSON parsing must collect raw printing counts and then call `applyImportedInventories({}, rawImported, 'replace', catalog)` for one shared normalization path. Preserve `recognized` and `skipped` for the import preview and completion toast.
+
+- [ ] **Step 6: Integrate silent migration and base-only adjustments**
+
+After every set has been parsed, call `migrateLegacyInventories(localStorage, setKeys, catalog)` once. Load the current inventory from that returned canonical record. Replace `inc` and `dec` lookups so they resolve the active number through the catalog before updating:
+
+```ts
+function canonicalBaseNumber(set: SetKey, printingNumber: number): number | null {
+  return canonicalCatalog.get(`${set}:${printingNumber}`)?.baseNumber ?? null
+}
+```
+
+Remove base-plus-alt summation from filtered rows; read `inventory[baseNum]` directly. Export canonical inventories from storage.
+
+- [ ] **Step 7: Run full tests and typecheck**
+
+Run: `npm test`
+
+Expected: PASS.
+
+Run: `npx tsc --noEmit`
+
+Expected: PASS with no current-set-only quota lookup in import application.
+
+- [ ] **Step 8: Commit canonical inventory**
+
+```powershell
+git add src/core/inventory.ts src/core/inventory.test.ts src/App.tsx
+git commit -m "fix: canonicalize inventory across card printings"
+```
+
+---
+
+### Task 4: Persisted Settings and Accessible Modal
+
+**Files:**
+- Create: `src/core/settings.test.ts`
+- Create: `src/core/settings.ts`
+- Create: `src/components/SettingsModal.test.tsx`
+- Create: `src/components/SettingsModal.tsx`
+- Modify: `src/App.tsx:648-673,1992-2195,2568-2824`
+- Modify: `index.html`
+
+**Interfaces:**
+- Produces `AppSettings`, `DEFAULT_SETTINGS`, `readSettings(storage)`, and `writeSettings(storage,settings)`.
+- `SettingsModal` consumes `{ open, settings, onChange, onClose, returnFocusRef }`.
+- `App.tsx` owns the current settings state and writes changes immediately.
+
+- [ ] **Step 1: Write failing settings persistence tests**
+
+Create `src/core/settings.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest'
+import { DEFAULT_SETTINGS, readSettings, writeSettings } from './settings'
+
+it('enables automatic enlarged-page mode by default', () => {
+  expect(DEFAULT_SETTINGS.autoOpenSinglePage).toBe(true)
+})
+
+it('falls back to defaults for missing or malformed storage', () => {
+  expect(readSettings({ getItem: () => null })).toEqual(DEFAULT_SETTINGS)
+  expect(readSettings({ getItem: () => '{bad json' })).toEqual(DEFAULT_SETTINGS)
+})
+
+it('round-trips supported settings and ignores unknown values', () => {
+  let stored = ''
+  const storage = {
+    getItem: () => stored,
+    setItem: (_key: string, value: string) => { stored = value },
+  }
+  writeSettings(storage, { autoOpenSinglePage: false })
+  expect(readSettings(storage)).toEqual({ autoOpenSinglePage: false })
+})
+```
+
+- [ ] **Step 2: Run settings tests and verify RED**
+
+Run: `npm test -- src/core/settings.test.ts`
+
+Expected: FAIL because `src/core/settings.ts` does not exist.
+
+- [ ] **Step 3: Implement typed settings persistence**
+
+Create `src/core/settings.ts`:
+
+```ts
+export type AppSettings = {
+  autoOpenSinglePage: boolean
+}
+
+export const DEFAULT_SETTINGS: AppSettings = {
+  autoOpenSinglePage: true,
+}
+
+export const SETTINGS_STORAGE_KEY = 'swu:settings:v1'
+
+type ReadStorage = Pick<Storage, 'getItem'>
+type WriteStorage = Pick<Storage, 'setItem'>
+
+export function readSettings(storage: ReadStorage): AppSettings {
+  try {
+    const parsed = JSON.parse(storage.getItem(SETTINGS_STORAGE_KEY) ?? '{}') as Partial<AppSettings>
+    return {
+      autoOpenSinglePage:
+        typeof parsed.autoOpenSinglePage === 'boolean'
+          ? parsed.autoOpenSinglePage
+          : DEFAULT_SETTINGS.autoOpenSinglePage,
+    }
+  } catch {
+    return DEFAULT_SETTINGS
+  }
+}
+
+export function writeSettings(storage: WriteStorage, settings: AppSettings): void {
+  storage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(settings))
+}
+```
+
+- [ ] **Step 4: Run settings tests and verify GREEN**
+
+Run: `npm test -- src/core/settings.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Write a failing accessible modal test**
+
+Create `src/components/SettingsModal.test.tsx` with Testing Library. Assert the dialog has accessible name `Settings`, the checkbox is checked from props, clicking it calls `onChange({autoOpenSinglePage:false})`, Escape calls `onClose`, and the Close button calls `onClose`.
+
+Run: `npm test -- src/components/SettingsModal.test.tsx`
+
+Expected: FAIL because `SettingsModal.tsx` does not exist.
+
+- [ ] **Step 6: Implement SettingsModal**
+
+Create a semantic component using:
+
+```tsx
+<div className="modal-backdrop" onMouseDown={event => event.target === event.currentTarget && onClose()}>
+  <section
+    ref={dialogRef}
+    className="settings-modal"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="settings-title"
+    tabIndex={-1}
+  >
+    <h2 id="settings-title">Settings</h2>
+    <label className="settings-toggle">
+      <input
+        type="checkbox"
+        checked={settings.autoOpenSinglePage}
+        onChange={event => onChange({ ...settings, autoOpenSinglePage: event.target.checked })}
+      />
+      <span>Automatically open enlarged page after selecting a card</span>
+    </label>
+    <button type="button" className="tbtn" onClick={onClose}>Close</button>
+  </section>
+</div>
+```
+
+Use an effect to focus the dialog when opened, listen for Escape, and restore `returnFocusRef.current` on cleanup.
+
+- [ ] **Step 7: Integrate settings state and gear control**
+
+Initialize settings with `useState(() => readSettings(localStorage))`. Wrap writes in `try/catch`; update state even if storage fails and show an error toast. Add a gear button with `aria-label="Open settings"` to Inventory Controls and render `SettingsModal` at the application root.
+
+- [ ] **Step 8: Run settings/component tests and commit**
+
+Run: `npm test -- src/core/settings.test.ts src/components/SettingsModal.test.tsx`
+
+Expected: PASS.
+
+Run: `npx tsc --noEmit`
+
+Expected: PASS.
+
+```powershell
+git add src/core/settings.ts src/core/settings.test.ts src/components/SettingsModal.tsx src/components/SettingsModal.test.tsx src/App.tsx index.html
+git commit -m "feat: add persisted filing view settings"
+```
+
+---
+
+### Task 5: Centered Locator and Single-Page Focus View
+
+**Files:**
+- Create: `src/components/LocatorPanel.test.tsx`
+- Create: `src/components/LocatorPanel.tsx`
+- Modify: `src/App.tsx:834-841,1213-1363,2197-2215,2869-3376`
+- Modify: `index.html:22-515`
+
+**Interfaces:**
+- `LocatorPanel` consumes `{ selection, quantity, maximum, aspectBackground?, onDecrease, onIncrease }`.
+- Binder gains `{ viewMode: 'single' | 'spread', focusedPage: number, onViewModeChange }`.
+- App owns `binderViewMode` and updates it after selection based on settings.
+
+- [ ] **Step 1: Write a failing locator component test**
+
+Create `src/components/LocatorPanel.test.tsx`:
+
+```tsx
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { LocatorPanel } from './LocatorPanel'
+
+it('shows readable physical location and adjusts quantity', () => {
+  const onDecrease = vi.fn()
+  const onIncrease = vi.fn()
+  render(
+    <LocatorPanel
+      selection={{
+        card: { Name: 'Darth Vader', Subtitle: 'Dark Lord of the Sith', Number: 10, Type: 'Leader', Set: 'SOR' },
+        number: 10,
+        page: 1,
+        row: 3,
+        column: 2,
+        spreadCol: 6,
+        spreadRow: 3,
+      }}
+      quantity={0}
+      maximum={1}
+      onDecrease={onDecrease}
+      onIncrease={onIncrease}
+    />,
+  )
+
+  expect(screen.getByRole('heading', { name: 'Darth Vader' })).toBeTruthy()
+  expect(screen.getByText('Page')).toBeTruthy()
+  expect(screen.getByText('Column')).toBeTruthy()
+  expect(screen.getByText('2')).toBeTruthy()
+  expect(screen.queryByText('6')).toBeNull()
+  fireEvent.click(screen.getByRole('button', { name: 'Increase Darth Vader quantity' }))
+  expect(onIncrease).toHaveBeenCalledOnce()
+})
+```
+
+- [ ] **Step 2: Run locator test and verify RED**
+
+Run: `npm test -- src/components/LocatorPanel.test.tsx`
+
+Expected: FAIL because `LocatorPanel.tsx` does not exist.
+
+- [ ] **Step 3: Implement centered LocatorPanel**
+
+Create semantic markup with an `aria-live="polite"` container, an `h2` for the card name, subtitle and number, three labeled location values, and 44px minimum quantity buttons. Use `selection.column`, never `selection.spreadCol`, for the displayed Column value.
+
+- [ ] **Step 4: Run locator test and verify GREEN**
+
+Run: `npm test -- src/components/LocatorPanel.test.tsx`
+
+Expected: PASS.
+
+- [ ] **Step 5: Add binder view-mode state and selection behavior**
+
+Add:
+
+```ts
+type BinderViewMode = 'single' | 'spread'
+const [binderViewMode, setBinderViewMode] = useState<BinderViewMode>('spread')
+
+const activateCard = useCallback((card: Card, forceView?: BinderViewMode) => {
+  const position = binderLayout(card.Number)
+  const spread = getSpreadCoords(position.page, position.row, position.column)
+  setActive({ card, number: card.Number, ...position, ...spread })
+  setViewSpread(pageToSpread(position.page))
+  setBinderViewMode(
+    forceView ?? viewModeAfterSelection(settings, binderViewMode),
+  )
+}, [settings, binderViewMode])
+```
+
+Route search, slot clicks, table clicks, and pending cross-set selection through `activateCard`. Arrow navigation must update `active` and keep `binderViewMode` unchanged; the focused page derives from `active.page`.
+
+- [ ] **Step 6: Render a four-column single physical page**
+
+Refactor Binder grid dimensions from fixed constants to:
+
+```ts
+const singlePage = viewMode === 'single'
+const cols = singlePage ? 4 : 8
+const pageForCell = singlePage
+  ? focusedPage
+  : c <= 4
+    ? leftPage
+    : rightPage
+const columnOnPage = singlePage ? c : c <= 4 ? c : c - 4
+```
+
+In single mode, omit the blank left page, center divider, spread-only label, and internal 5-8 columns. Page navigation controls move one physical page at a time. In spread mode, preserve the current Page 1 and 2/3, 4/5 behavior and comma/period shortcuts.
+
+Add an accessible segmented control above the binder:
+
+```tsx
+<div className="toolbar-group" role="group" aria-label="Binder view">
+  <button aria-pressed={viewMode === 'single'} onClick={() => onViewModeChange('single')}>Single Page</button>
+  <button aria-pressed={viewMode === 'spread'} onClick={() => onViewModeChange('spread')}>Spread</button>
+</div>
+```
+
+- [ ] **Step 7: Add high-readability responsive styles**
+
+Add classes rather than inline sizing:
+
+```css
+.locator-panel { text-align:center; padding:20px; }
+.locator-name { font-size:clamp(2rem,4vw,3.25rem); line-height:1.05; }
+.locator-location { display:grid; grid-template-columns:repeat(3,minmax(110px,1fr)); gap:12px; max-width:720px; margin:18px auto; }
+.locator-value { font-size:clamp(1.8rem,4vw,3rem); font-weight:800; }
+.locator-qty button { min-width:44px; min-height:44px; }
+@media (max-width:760px) {
+  .locator-location { grid-template-columns:repeat(3,1fr); }
+  .locator-panel { padding:14px 8px; }
+  .controls-row .autocomplete { min-width:100%; }
+}
+```
+
+Ensure the SVG slot name remains readable in single mode by increasing its rendered width rather than adding more text inside slots.
+
+- [ ] **Step 8: Run component, core, and type tests**
+
+Run: `npm test`
+
+Expected: PASS.
+
+Run: `npx tsc --noEmit`
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit locator and focus mode**
+
+```powershell
+git add src/components/LocatorPanel.tsx src/components/LocatorPanel.test.tsx src/App.tsx index.html
+git commit -m "feat: add accessible centered card locator"
+```
+
+---
+
+### Task 6: Integration Coverage and Accessibility Cleanup
+
+**Files:**
+- Create: `src/core/selection.test.ts`
+- Create: `src/core/selection.ts`
+- Modify: `src/App.tsx`
+- Modify: `eslint.config.js`
+- Modify: `.prettierignore`
+- Modify: `index.html`
+
+**Interfaces:**
+- Produces `viewModeAfterSelection(settings,currentMode)` and `selectionAfterMove(active,direction,totalPages,byNumber)` for deterministic integration behavior.
+- `App.tsx` uses these helpers in keyboard and selection effects.
+
+- [ ] **Step 1: Write failing integration-state tests**
+
+Create tests proving:
+
+```ts
+expect(viewModeAfterSelection({ autoOpenSinglePage: true }, 'spread')).toBe('single')
+expect(viewModeAfterSelection({ autoOpenSinglePage: false }, 'spread')).toBe('spread')
+```
+
+Create a movement fixture where an active Page 2 Column 4 selection moves Right to Page 3 Column 1, resolves the exact destination card, and returns a selection whose locator page follows Page 3.
+
+- [ ] **Step 2: Run selection tests and verify RED**
+
+Run: `npm test -- src/core/selection.test.ts`
+
+Expected: FAIL because `src/core/selection.ts` does not exist.
+
+- [ ] **Step 3: Implement deterministic selection helpers**
+
+Create `src/core/selection.ts` with:
+
+```ts
+export type BinderViewMode = 'single' | 'spread'
+
+export function viewModeAfterSelection(
+  settings: AppSettings,
+  currentMode: BinderViewMode,
+): BinderViewMode {
+  return settings.autoOpenSinglePage ? 'single' : currentMode
+}
+```
+
+`selectionAfterMove` calls `moveBinderSelection`, resolves the resulting number from `byNumber`, and returns the original active selection when movement targets a missing slot. It must calculate both physical and spread coordinates for a valid result.
+
+- [ ] **Step 4: Run selection tests and verify GREEN**
+
+Run: `npm test -- src/core/selection.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Remove duplicated and stale component logic**
+
+Delete unused `NAME_MAX_LINES`, `normalizeType`, `resolveToBase`, `InventoryAll`, duplicate `qtyText`, and component-local coordinate/search/quota helpers. Replace `any` values in imports and card mapping with `unknown` plus narrow record types. Wrap render-created callbacks used by effects in `useCallback` or move their pure work to the new core modules.
+
+- [ ] **Step 6: Make validation ignore generated worktrees and assets**
+
+Update ESLint ignores:
+
+```ts
+{ ignores: ['dist', '.claude/worktrees/**', '.superpowers/**'] }
+```
+
+Update `.prettierignore`:
+
+```text
+dist
+node_modules
+public/sets
+.claude/worktrees
+.superpowers
+```
+
+- [ ] **Step 7: Run the complete automated gate**
+
+Run in order:
+
+```powershell
+npm test
+npx tsc --noEmit
+npm run lint
+npm run format
+npm run format:check
+npm run build
+```
+
+Expected: every command exits zero. Run `git diff --check` afterward and expect no output.
+
+- [ ] **Step 8: Commit integration cleanup**
+
+```powershell
+git add src/core/selection.ts src/core/selection.test.ts src/App.tsx eslint.config.js .prettierignore index.html
+git commit -m "refactor: integrate tested filing workflow state"
+```
+
+---
+
+### Task 7: Documentation and Manual Runtime Verification
+
+**Files:**
+- Modify: `README.md`
+
+**Interfaces:**
+- Documents the delivered settings, locator, keyboard behavior, migration, imports, and test commands.
+- Does not change application behavior.
+
+- [ ] **Step 1: Update README behavior and set list**
+
+Document all eight manifest sets: SOR, SHD, TWI, JTL, LOF, SEC, LAW, and ASH. Replace the old arrow-key page-flip wording with:
+
+```md
+- Arrow keys move the selected card through the binder grid, including existing page-edge wrapping.
+- `+` / `-` adjust the selected card quantity.
+- `,` / `.` move to the previous or next spread.
+- `/` focuses search and Enter selects the highlighted result.
+```
+
+Add sections for the centered locator, physical 1-4 columns, Single Page/Spread toggle, Settings default, canonical import behavior, and silent one-time local backup.
+
+- [ ] **Step 2: Document development verification**
+
+Add:
+
+```md
+npm test
+npx tsc --noEmit
+npm run lint
+npm run format:check
+npm run build
+```
+
+- [ ] **Step 3: Run final automated verification**
+
+Run the full Task 6 gate again from a clean terminal. Record exact test counts and build output for the handoff.
+
+- [ ] **Step 4: Run manual application checks**
+
+Start `npm run dev` and verify:
+
+1. Search `Darth Vader` in SOR and select both Leader #10 and Unit #87 independently.
+2. Click the search icon for a partial query and confirm it selects the highlighted suggestion.
+3. Select card #1 and confirm the locator displays physical Column 1, not spread Column 5.
+4. Confirm automatic single-page mode is enabled on first use.
+5. Disable it in Settings, select a card, and confirm the current spread view remains.
+6. Re-enable it, reload, and confirm the preference persists.
+7. Use every arrow direction across a page boundary and confirm the locator and focused page follow.
+8. Use keyboard and locator `+`/`-` controls and confirm canonical quantities remain capped.
+9. Import a fixture containing base and alternate printings and confirm the combined quantity is capped.
+10. Confirm migration backup and schema keys exist without displaying a migration notice.
+11. Inspect the layout at wide desktop and 800px viewport widths.
+
+- [ ] **Step 5: Commit documentation**
+
+```powershell
+git add README.md
+git commit -m "docs: explain accessible filing workflow"
+```
+
+- [ ] **Step 6: Inspect final branch state**
+
+Run:
+
+```powershell
+git status --short
+git log --oneline --decorate main..HEAD
+git diff --stat main...HEAD
+```
+
+Expected: clean status and a focused sequence of design, binder, search, inventory, settings, locator, integration, and documentation commits.

--- a/docs/superpowers/specs/2026-07-16-accessibility-correctness-iteration-design.md
+++ b/docs/superpowers/specs/2026-07-16-accessibility-correctness-iteration-design.md
@@ -1,0 +1,167 @@
+# Accessibility and Correctness Iteration Design
+
+## Goal
+
+Improve the personal card-filing workflow by making the selected card location substantially easier to read, preserving fast keyboard navigation, correcting search and physical location behavior, canonicalizing inventory data, and adding focused regression coverage.
+
+Cloud synchronization is explicitly outside this iteration. It will be scoped as the next project after this work is stable.
+
+## Product Constraints
+
+- The application remains a personal, local-first Star Wars: Unlimited collection organizer.
+- Existing collection data must be preserved during migration.
+- The current arrow-key grid navigation and `+`/`-` quantity shortcuts must remain available.
+- The application must continue to support JSON, CSV, and XLSX inventory imports.
+- No account, backend, multi-user, deck-building, or social features are added in this iteration.
+
+## Chosen Approach
+
+Use targeted modularization. Extract binder math, search resolution, inventory normalization, and settings persistence into small tested TypeScript modules while retaining the existing React application structure. Add only the UI components required for the centered locator and Settings modal. Avoid a comprehensive state-management or component rewrite.
+
+## Architecture
+
+### Core modules
+
+- `src/core/binder.ts` owns card-number to page, row, physical-column, spread-column, and keyboard-navigation calculations.
+- `src/core/search.ts` owns normalized search matching, result ranking, and stable result identity using `{ setKey, baseNumber }`.
+- `src/core/inventory.ts` owns printing-to-base normalization, quotas, import aggregation, merge/replace behavior, and legacy inventory migration.
+- `src/core/settings.ts` owns typed settings defaults, parsing, and local-storage serialization.
+
+### UI components
+
+- `src/components/LocatorPanel.tsx` renders the centered high-readability selected-card panel, including card identity, physical location, and large quantity controls.
+- `src/components/SettingsModal.tsx` renders local behavior and accessibility settings.
+- `src/App.tsx` continues to orchestrate set loading, active selection, search, inventory, imports, and top-level UI state.
+- The existing binder renderer gains a single-physical-page presentation without being comprehensively rewritten.
+
+## Locator and Binder Experience
+
+- With no active card, the binder opens in the existing two-page spread view.
+- Selecting a card by search, binder slot, inventory table, or missing-card table renders the centered locator.
+- The locator prominently displays:
+  - Card name and subtitle.
+  - Card number.
+  - Physical page.
+  - Physical row.
+  - Physical column in the range 1-4.
+  - Large decrease, quantity, and increase controls.
+- The internal spread column in the range 1-8 remains available for navigation calculations but is not labeled as the physical card column.
+- When `Automatically open enlarged page after selecting a card` is enabled, selecting a card switches the binder to the relevant four-column physical page.
+- The setting defaults to enabled and is stored locally.
+- A visible `Single Page / Spread` control allows the user to change presentation at any time.
+- Disabling automatic focus prevents the automatic view change but does not remove manual single-page mode.
+
+## Keyboard Behavior
+
+- Existing global arrow-key navigation remains the source of active-card movement.
+- The centered locator updates immediately as the active selection changes.
+- The enlarged physical page follows the selected card when keyboard navigation crosses a page boundary.
+- Existing page-edge wrapping is preserved. For example, moving Right from physical Column 4 continues to Column 1 on the adjacent page.
+- Existing `+`, `=`, numpad add, `-`, and numpad subtract shortcuts continue to modify the active card.
+- The centered locator and its controls do not steal keyboard focus during grid navigation.
+- Existing comma and period spread navigation remains available.
+
+## Search Behavior
+
+- Every search result carries a stable `{ setKey, baseNumber }` identity.
+- Choosing a result never resolves the card by name alone.
+- Duplicate names with different subtitles or card types select the exact result shown.
+- The search button, Enter key, and clicked suggestion share the same resolution path.
+- When suggestions are available, submission selects the highlighted result or the first result.
+- Exact card-number matches remain prioritized.
+- Name results rank word-start matches ahead of incidental normalized substrings, preventing results such as `Brain Invaders` from outranking intentional `Vader` matches.
+
+## Canonical Inventory Model
+
+- Stored inventory contains one quantity per base card number.
+- A catalog lookup maps `{ setKey, printingNumber }` to the associated base number and card type.
+- All manual adjustments and all import formats use that lookup.
+- Counts from multiple printings combine at the base card and are capped after aggregation.
+- Leader and Base cards cap at one copy; other types cap at three copies.
+- Merge and replace operations use the destination set's catalog, including when that set is not currently displayed.
+- Exports contain canonical base-number quantities while remaining compatible with the current version-one JSON shape.
+
+## Legacy Migration
+
+- A schema-version marker identifies whether canonical migration has run.
+- On the first load after this update, existing `inv:<set>` records are parsed and normalized silently.
+- Before any normalized data is written, the application stores one recoverable backup containing the original inventory records.
+- Variant counts are combined and capped by base-card type.
+- Invalid keys, non-finite values, negative values, and unknown card numbers are ignored.
+- Valid inventory entries continue loading if other entries are malformed.
+- Migration is idempotent and does not run again after the schema marker is stored.
+
+## Settings
+
+- A gear button in the top controls opens Settings.
+- The initial setting is `Automatically open enlarged page after selecting a card`.
+- Its default value is `true`.
+- Settings parsing accepts missing or malformed storage by returning defaults.
+- Settings changes persist immediately in local storage.
+- The modal supports Escape, backdrop dismissal, explicit Close, initial focus, focus restoration, and dialog semantics.
+
+## Imports and Error Handling
+
+- JSON, CSV, and XLSX parsing feed a shared canonical aggregation path.
+- Import preview reports recognized and skipped entries.
+- Invalid imports do not modify stored inventory.
+- Unknown printings are skipped instead of being assigned a default quota.
+- Set-data failures remain visible near the application controls.
+- Clipboard and storage failures use the existing toast system.
+- Settings read failures fall back to defaults.
+- Migration failures preserve the pre-migration backup and load all valid entries that can be recovered.
+
+## Testing Strategy
+
+Add Vitest as the project test runner and cover behavior with real functions rather than implementation mocks.
+
+### Binder tests
+
+- Card number to page, row, physical column, and spread column.
+- Page-one and later-spread calculations.
+- Keyboard movement within a page and across page boundaries.
+- Boundary behavior at the first and final available card slots.
+
+### Search tests
+
+- Duplicate names resolve to the exact base number.
+- Search submission uses the highlighted or first suggestion.
+- Partial-name search behaves consistently for button, Enter, and click paths.
+- Cross-set results retain the correct set identity.
+- Word-start matches rank ahead of incidental normalized substrings.
+
+### Inventory tests
+
+- Multiple printings normalize to one base card.
+- Aggregated counts cap correctly.
+- Leader/Base and standard-card quotas.
+- Same-set and cross-set merge behavior.
+- Replace behavior.
+- Unknown and malformed entries are skipped.
+- Legacy migration creates a backup, writes canonical inventory, stores its schema marker, and is idempotent.
+
+### Settings and UI tests
+
+- Automatic enlarged-page mode defaults to enabled.
+- Settings serialize, parse, and recover from malformed data.
+- Selection enters focus mode when enabled and remains in spread mode when disabled.
+- Arrow navigation updates the locator and followed page.
+- Quantity shortcuts update the canonical active card.
+- The locator renders readable physical location values and functional quantity controls.
+
+## Verification Gate
+
+The iteration is complete only when all of the following pass:
+
+- Complete Vitest suite.
+- TypeScript compilation.
+- ESLint.
+- Prettier formatting check.
+- Production Vite build.
+- Manual runtime verification of search selection, centered locator, keyboard navigation, focus-page following, Settings persistence, import migration, and responsive readability.
+
+## Documentation Updates
+
+- Update the README to describe the centered locator, single-page mode, Settings toggle, current set list, and correct keyboard shortcuts.
+- Document the silent canonical inventory migration and local backup behavior.
+- Add the test command to the development instructions.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint'
 import eslintConfigPrettier from 'eslint-config-prettier'
 
 export default tseslint.config(
-  { ignores: ['dist'] },
+  { ignores: ['dist', '.claude/worktrees/**', '.superpowers/**'] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ['**/*.{ts,tsx}'],
@@ -22,7 +22,10 @@ export default tseslint.config(
       ...reactHooks.configs.recommended.rules,
       'react-refresh/only-export-components': [
         'warn',
-        { allowConstantExport: true },
+        {
+          allowConstantExport: true,
+          allowExportNames: ['parseCsvData', 'parseXlsxData'],
+        },
       ],
       '@typescript-eslint/no-unused-vars': [
         'warn',

--- a/index.html
+++ b/index.html
@@ -202,6 +202,55 @@
 
       .tbtn-danger { color: #fca5a5; }
       .tbtn-danger:hover { background: rgba(127,29,29,0.25); }
+      .modal-backdrop {
+        position: fixed;
+        inset: 0;
+        z-index: 1500;
+        display: grid;
+        place-items: center;
+        padding: 20px;
+        background: rgba(4, 5, 9, 0.78);
+      }
+      .settings-modal {
+        width: min(520px, 100%);
+        padding: 24px;
+        border: 1px solid #424452;
+        border-radius: 14px;
+        background: #14161f;
+        color: #eaeaf0;
+        box-shadow: 0 24px 70px rgba(0, 0, 0, 0.55);
+      }
+      .settings-modal:focus-visible {
+        outline: 2px solid #8b5cf6;
+        outline-offset: 3px;
+      }
+      .settings-modal h2 {
+        margin: 0 0 18px;
+      }
+      .settings-toggle {
+        display: flex;
+        align-items: flex-start;
+        gap: 12px;
+        font-size: 16px;
+        line-height: 1.4;
+        cursor: pointer;
+      }
+      .settings-toggle input {
+        width: 20px;
+        height: 20px;
+        margin: 1px 0 0;
+        flex: 0 0 auto;
+        accent-color: #8b5cf6;
+      }
+      .settings-modal-actions {
+        display: flex;
+        justify-content: flex-end;
+        margin-top: 24px;
+      }
+      .settings-modal-actions .tbtn {
+        border: 1px solid #424452;
+        border-radius: 8px;
+      }
       /* slash key hint inside the search input */
       .autocomplete.search { position: relative; }
 

--- a/index.html
+++ b/index.html
@@ -551,6 +551,99 @@
         font-family: monospace;
       }
 
+      .locator-panel {
+        position: relative;
+        overflow: hidden;
+        text-align: center;
+        padding: 20px;
+        margin-bottom: 14px;
+        border: 1px solid #424452;
+        border-radius: 14px;
+        background: #11131c;
+      }
+      .locator-aspect {
+        position: absolute;
+        inset: 0 0 auto;
+        height: 6px;
+      }
+      .locator-name {
+        margin: 4px 0 0;
+        font-size: clamp(2rem, 4vw, 3.25rem);
+        line-height: 1.05;
+      }
+      .locator-subtitle,
+      .locator-number {
+        margin: 6px 0 0;
+        color: #c8ccd9;
+        font-size: 1.1rem;
+      }
+      .locator-number { font-weight: 700; }
+      .locator-location {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(110px, 1fr));
+        gap: 12px;
+        max-width: 720px;
+        margin: 18px auto;
+      }
+      .locator-location > div {
+        padding: 10px;
+        border-radius: 10px;
+        background: #1a1b26;
+      }
+      .locator-location dt {
+        color: #c8ccd9;
+        font-size: 0.95rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+      }
+      .locator-location dd { margin: 2px 0 0; }
+      .locator-value {
+        font-size: clamp(1.8rem, 4vw, 3rem);
+        font-weight: 800;
+      }
+      .locator-qty {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 16px;
+      }
+      .locator-qty button {
+        min-width: 48px;
+        min-height: 48px;
+        border: 1px solid #5d6277;
+        border-radius: 50%;
+        background: #25283a;
+        color: #fff;
+        font-size: 1.8rem;
+        cursor: pointer;
+      }
+      .locator-qty button:disabled { opacity: 0.4; cursor: not-allowed; }
+      .locator-qty output { min-width: 88px; font-size: 2rem; font-weight: 800; }
+      .binder-toolbar {
+        display: flex;
+        justify-content: center;
+        margin-bottom: 10px;
+      }
+      .toolbar-group {
+        display: inline-flex;
+        gap: 4px;
+        padding: 4px;
+        border: 1px solid #424452;
+        border-radius: 9px;
+        background: #11131c;
+      }
+      .toolbar-group .tbtn[aria-pressed="true"] {
+        background: #385da8;
+        color: #fff;
+      }
+
+      @media (max-width: 760px) {
+        .locator-location { grid-template-columns: repeat(3, 1fr); }
+        .locator-panel { padding: 14px 8px; }
+        .controls-row .autocomplete { min-width: 100%; }
+      }
+
       .modal-btn {
         border: none;
         border-radius: 4px;

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/babel__generator": "^7.27.0",
         "@types/babel__template": "^7.4.4",
         "@types/babel__traverse": "^7.28.0",
@@ -27,10 +29,78 @@
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.5.3",
         "globals": "^17.7.0",
+        "jsdom": "^29.1.1",
         "prettier": "^3.9.4",
         "typescript": "^5.3.3",
         "typescript-eslint": "^8.62.1",
-        "vite": "^7.1.2"
+        "vite": "^7.1.2",
+        "vitest": "^4.1.10"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
@@ -76,21 +146,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/core/node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core/node_modules/@babel/compat-data": {
@@ -258,13 +313,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@babel/core/node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
-      "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@babel/core/node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.29",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz",
@@ -330,13 +378,6 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/@babel/core/node_modules/convert-source-map": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@babel/core/node_modules/electron-to-chromium": {
       "version": "1.5.200",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.200.tgz",
@@ -363,13 +404,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@babel/core/node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@babel/core/node_modules/jsesc": {
       "version": "3.1.0",
@@ -413,13 +447,6 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@babel/core/node_modules/picocolors": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/@babel/core/node_modules/semver": {
       "version": "6.3.1",
@@ -480,9 +507,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -557,6 +584,16 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/types": {
       "version": "7.28.2",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
@@ -569,6 +606,159 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
+      "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+      "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -790,6 +980,24 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -856,12 +1064,97 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
       "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -907,6 +1200,24 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
@@ -1201,6 +1512,119 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.17.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
@@ -1250,6 +1674,17 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -1273,6 +1708,27 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -1281,6 +1737,16 @@
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -1317,6 +1783,16 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -1372,6 +1848,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/crc-32": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
@@ -1399,12 +1882,40 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1424,10 +1935,56 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1684,6 +2241,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -1692,6 +2259,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -1829,6 +2406,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -1889,12 +2479,25 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.3.0",
@@ -1917,6 +2520,47 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/json-buffer": {
@@ -1999,11 +2643,43 @@
         "loose-envify": "cli.js"
       }
     },
-    "node_modules/loose-envify/node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "license": "MIT"
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/minimatch": {
       "version": "10.2.5",
@@ -2034,6 +2710,20 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -2098,6 +2788,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2117,6 +2820,20 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.3",
@@ -2157,6 +2874,36 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2192,10 +2939,28 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
       "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2210,6 +2975,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -2257,6 +3035,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ssf": {
       "version": "0.11.2",
       "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
@@ -2268,6 +3063,20 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
@@ -2295,6 +3104,30 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -2310,6 +3143,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.8",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.8.tgz",
+      "integrity": "sha512-htwgN/8KRB3z3vnC0BOETVh2m499g5GmyTK9Wq5JBLX3FNz6tSBveAd+fQhzy9hkjif8vy2jwDMR1sGhLtZl2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.8"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.8",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.8.tgz",
+      "integrity": "sha512-c1P7u0EhACHj7lPy4MJm8iTFEU8+nB0LCtddH0fhP7noaVoXAqafMtOOeX+ulpuPBqnrRgRhw494RICT3mbhnw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -2374,6 +3263,16 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/uri-js": {
@@ -3266,13 +4165,6 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/vite/node_modules/picocolors": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/vite/node_modules/postcss": {
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
@@ -3342,14 +4234,142 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/vite/node_modules/source-map-js": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
       "dev": true,
-      "license": "BSD-3-Clause",
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
       "engines": {
-        "node": ">=0.10.0"
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -3366,6 +4386,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wmf": {
@@ -3416,6 +4453,23 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
@@ -23,6 +25,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/babel__generator": "^7.27.0",
     "@types/babel__template": "^7.4.4",
     "@types/babel__traverse": "^7.28.0",
@@ -35,9 +39,11 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.5.3",
     "globals": "^17.7.0",
+    "jsdom": "^29.1.1",
     "prettier": "^3.9.4",
     "typescript": "^5.3.3",
     "typescript-eslint": "^8.62.1",
-    "vite": "^7.1.2"
+    "vite": "^7.1.2",
+    "vitest": "^4.1.10"
   }
 }

--- a/src/App.keyboard.test.tsx
+++ b/src/App.keyboard.test.tsx
@@ -1,0 +1,66 @@
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import App from './App';
+
+const cards = Array.from({ length: 108 }, (_, index) => ({
+  Name: `Card ${index + 1}`,
+  Number: index + 1,
+  Type: 'Unit',
+  Set: 'TST',
+}));
+
+describe('App binder keyboard shortcuts', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith('/sets/manifest.json')) {
+        return {
+          ok: true,
+          json: async () => ({
+            sets: [{ key: 'TST', label: 'Test Set', file: 'test.json' }],
+          }),
+        } as Response;
+      }
+      if (url.endsWith('/sets/test.json')) {
+        return { ok: true, json: async () => cards } as Response;
+      }
+      return { ok: false, json: async () => ({}) } as Response;
+    }));
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it('uses the current spread anchor for repeated period and comma presses', async () => {
+    const { container } = render(<App />);
+    const subtitle = () => container.querySelector('.binder-subtitle')?.textContent ?? '';
+
+    await waitFor(() => expect(subtitle()).toContain('Spread: Page 1'));
+    await waitFor(() => {
+      const jump = screen.getByRole('combobox', { name: 'Jump to spread' });
+      expect(jump.querySelectorAll('option')).toHaveLength(5);
+    });
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '.', code: 'Period' }));
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '.', code: 'Period' }));
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '.', code: 'Period' }));
+    });
+    await waitFor(() => expect(subtitle()).toContain('Page 6 (left) | Page 7 (right)'));
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: ',', code: 'Comma' }));
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: ',', code: 'Comma' }));
+    });
+    await waitFor(() => expect(subtitle()).toContain('Page 2 (left) | Page 3 (right)'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Single Page' }));
+    await waitFor(() => expect(subtitle()).toContain('Binder — Page 3'));
+    fireEvent.keyDown(window, { key: '.', code: 'Period' });
+    fireEvent.keyDown(window, { key: ',', code: 'Comma' });
+    expect(subtitle()).toContain('Binder — Page 3');
+  });
+});

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -92,6 +92,31 @@ describe('search submission', () => {
 })
 
 describe('settings', () => {
+  it('falls back to defaults when initial local storage access is unavailable', () => {
+    stubSetFetch()
+    const availableStorage = window.localStorage
+    availableStorage.setItem('swu:settings:v1', JSON.stringify({ autoOpenSinglePage: false }))
+    let storageReads = 0
+    const storageGetter = vi.spyOn(window, 'localStorage', 'get').mockImplementation(() => {
+      storageReads += 1
+      if (storageReads === 1) throw new Error('storage access denied')
+      return availableStorage
+    })
+
+    try {
+      expect(() => render(<App />)).not.toThrow()
+      expect(storageReads).toBeGreaterThan(0)
+      fireEvent.click(screen.getByRole('button', { name: 'Open settings' }))
+      expect(
+        (screen.getByRole('checkbox', {
+          name: 'Automatically open enlarged page after selecting a card',
+        }) as HTMLInputElement).checked,
+      ).toBe(true)
+    } finally {
+      storageGetter.mockRestore()
+    }
+  })
+
   it('persists changes immediately and keeps them in component state', async () => {
     stubSetFetch()
     render(<App />)

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,92 @@
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import App from './App'
+
+const sorCards = [
+  { Name: 'Alpha Card', Subtitle: 'First Choice', Number: 1, Type: 'Unit' },
+  { Name: 'Beta Card', Subtitle: 'Second Choice', Number: 2, Type: 'Unit' },
+  {
+    Name: 'Darth Vader',
+    Subtitle: 'Dark Lord of the Sith',
+    Number: 10,
+    Type: 'Leader',
+  },
+  {
+    Name: 'Darth Vader',
+    Subtitle: 'Commanding the First Legion',
+    Number: 87,
+    Type: 'Unit',
+  },
+]
+
+const twiCards = [{ Name: 'Brain Invaders', Number: 255, Type: 'Unit' }]
+
+function response(body: unknown, ok = true): Response {
+  return { ok, json: async () => body } as Response
+}
+
+function stubSetFetch(includeTwi = false) {
+  const sets = [
+    { key: 'SOR', label: 'Spark of Rebellion (SOR)', file: 'SWU-SOR.json' },
+    ...(includeTwi
+      ? [{ key: 'TWI', label: 'Twilight of the Republic (TWI)', file: 'SWU-TWI.json' }]
+      : []),
+  ]
+
+  vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input)
+    if (url === '/sets/manifest.json') return response({ sets })
+    if (url === '/sets/SWU-SOR.json') return response(sorCards)
+    if (url === '/sets/SWU-TWI.json') return response(twiCards)
+    return response({}, false)
+  }))
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+    configurable: true,
+    value: vi.fn(),
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+describe('search submission', () => {
+  it('uses the current highlighted result after search loses focus', async () => {
+    stubSetFetch()
+    render(<App />)
+
+    const search = await screen.findByRole('textbox', { name: 'Search cards' })
+    fireEvent.change(search, { target: { value: 'Card' } })
+    await waitFor(() => expect(document.querySelectorAll('.sug-item')).toHaveLength(2))
+
+    fireEvent.keyDown(search, { key: 'ArrowDown' })
+    fireEvent.blur(search)
+    fireEvent.keyDown(window, { key: 'Enter' })
+
+    await waitFor(() => {
+      expect(screen.queryByText('No card selected')).toBeNull()
+      expect(screen.getByText((_, element) => element?.textContent === '— Second Choice')).toBeTruthy()
+    })
+  })
+
+  it('resolves a cross-set suggestion after the destination catalog becomes active', async () => {
+    stubSetFetch(true)
+    render(<App />)
+
+    const search = await screen.findByRole('textbox', { name: 'Search cards' })
+    fireEvent.change(search, { target: { value: 'Darth Vader' } })
+    const subtitle = await screen.findByText(/Dark Lord of the Sith/)
+    fireEvent.mouseDown(subtitle)
+
+    await waitFor(() => {
+      const setPicker = within(screen.getByRole('group', { name: 'Card set' })).getByRole('combobox')
+      expect((setPicker as HTMLSelectElement).value).toBe('SOR')
+      expect(screen.getByText((_, element) => element?.textContent === '— Dark Lord of the Sith')).toBeTruthy()
+    })
+  })
+})

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -90,3 +90,51 @@ describe('search submission', () => {
     })
   })
 })
+
+describe('settings', () => {
+  it('persists changes immediately and keeps them in component state', async () => {
+    stubSetFetch()
+    render(<App />)
+
+    const trigger = await screen.findByRole('button', { name: 'Open settings' })
+    fireEvent.click(trigger)
+    const checkbox = screen.getByRole('checkbox', {
+      name: 'Automatically open enlarged page after selecting a card',
+    })
+    expect((checkbox as HTMLInputElement).checked).toBe(true)
+
+    fireEvent.click(checkbox)
+
+    expect((checkbox as HTMLInputElement).checked).toBe(false)
+    expect(JSON.parse(localStorage.getItem('swu:settings:v1') ?? '{}')).toEqual({
+      autoOpenSinglePage: false,
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    fireEvent.click(trigger)
+    expect(
+      (screen.getByRole('checkbox', {
+        name: 'Automatically open enlarged page after selecting a card',
+      }) as HTMLInputElement).checked,
+    ).toBe(false)
+  })
+
+  it('keeps a changed setting and shows a toast when persistence fails', async () => {
+    stubSetFetch()
+    render(<App />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Open settings' }))
+    const checkbox = screen.getByRole('checkbox', {
+      name: 'Automatically open enlarged page after selecting a card',
+    })
+    const setItem = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('storage unavailable')
+    })
+
+    fireEvent.click(checkbox)
+
+    expect((checkbox as HTMLInputElement).checked).toBe(false)
+    expect(await screen.findByText('Settings could not be saved on this device.')).toBeTruthy()
+    setItem.mockRestore()
+  })
+})

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -163,3 +163,45 @@ describe('settings', () => {
     setItem.mockRestore()
   })
 })
+
+describe('local inventory safety', () => {
+  it('keeps an unsaved quantity in memory and reports an autosave failure', async () => {
+    stubSetFetch()
+    render(<App />)
+
+    const search = await screen.findByRole('textbox', { name: 'Search cards' })
+    fireEvent.change(search, { target: { value: 'Alpha Card' } })
+    await waitFor(() => expect(document.querySelector('.sug-item')).toBeTruthy())
+    fireEvent.mouseDown(document.querySelector('.sug-item')!)
+
+    const originalSetItem = Storage.prototype.setItem
+    const setItem = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (
+      this: Storage,
+      key,
+      value,
+    ) {
+      if (key === 'inv:SOR') throw new Error('quota exceeded')
+      return originalSetItem.call(this, key, value)
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Increase Alpha Card quantity' }))
+
+    expect((await screen.findByRole('status', { name: 'Quantity' })).textContent).toBe('1/3')
+    expect(await screen.findByText('Inventory could not be saved on this device.')).toBeTruthy()
+    setItem.mockRestore()
+  })
+
+  it('shows the set-data failure message for a 404 JSON response', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url === '/sets/manifest.json') {
+        return response({ sets: [{ key: 'SOR', label: 'SOR', file: 'SWU-SOR.json' }] })
+      }
+      return response({ error: 'not found' }, false)
+    }))
+
+    render(<App />)
+
+    expect(await screen.findByText('Failed to load set data.')).toBeTruthy()
+  })
+})

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,13 +26,26 @@ import {
   type ImportResult,
 } from './core/inventory';
 import { createLoadCommitGate } from './core/loadGuard';
-import { readSettings, writeSettings, type AppSettings } from './core/settings';
+import {
+  DEFAULT_SETTINGS,
+  readSettings,
+  writeSettings,
+  type AppSettings,
+} from './core/settings';
 import type { ActiveSelection, Card, Inventory, SetKey, SetMeta } from './core/types';
 import { SettingsModal } from './components/SettingsModal';
 
 /** Last entry in `manifest.json` is the newest set (release order). */
 function newestSetKeyFromManifest(list: SetMeta[]): SetKey {
   return list.length ? list[list.length - 1]!.key : 'SOR';
+}
+
+function initialSettings(): AppSettings {
+  try {
+    return readSettings(window.localStorage);
+  } catch {
+    return DEFAULT_SETTINGS;
+  }
 }
 
 const ASPECT_HEX: Record<string, string> = {
@@ -651,7 +664,7 @@ export default function App() {
   const submitSearchRef = useRef<() => void>(() => {});
   const importRef = useRef<HTMLInputElement>(null);
   const settingsButtonRef = useRef<HTMLButtonElement>(null);
-  const [settings, setSettings] = useState<AppSettings>(() => readSettings(localStorage));
+  const [settings, setSettings] = useState<AppSettings>(initialSettings);
   const [showSettingsModal, setShowSettingsModal] = useState(false);
   const closeSettingsModal = useCallback(() => setShowSettingsModal(false), []);
   const [showImportModal, setShowImportModal] = useState(false);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,6 @@ import * as XLSX from 'xlsx';
 import {
   binderLayout,
   getSpreadCoords,
-  moveBinderSelection,
   numberFromPagePosition,
   pageToSpread,
   spreadToPrimaryPage,
@@ -32,16 +31,17 @@ import {
   writeSettings,
   type AppSettings,
 } from './core/settings';
+import { focusedPageForSpread } from './core/binderView';
 import {
-  focusedPageForSpread,
+  selectionAfterMove,
   viewModeAfterSelection,
   type BinderViewMode,
-} from './core/binderView';
+} from './core/selection';
 import type { ActiveSelection, Card, Inventory, SetKey, SetMeta } from './core/types';
 import { LocatorPanel } from './components/LocatorPanel';
 import { SettingsModal } from './components/SettingsModal';
 
-export type { BinderViewMode } from './core/binderView';
+export type { BinderViewMode } from './core/selection';
 
 /** Last entry in `manifest.json` is the newest set (release order). */
 function newestSetKeyFromManifest(list: SetMeta[]): SetKey {
@@ -66,7 +66,6 @@ const ASPECT_HEX: Record<string, string> = {
 };
 const NEUTRAL = '#2f3545'; // for numbers that exist but have no aspect
 
-const NAME_MAX_LINES = 2;
 const QTY_FONT = 22;      // size of the centered "1/3"
 const QTY_Y_OFFSET = 4;   // nudge up/down if needed
 const QTY_SHIFT_DOWN = 14; // Shift QTY and buttons down by 20px
@@ -263,7 +262,7 @@ function FilterControls({ filters, setFilters }: FilterControlsProps) {
       } else if (category === 'rarity') {
         const rarityStyle = RARITY_STYLE[item as keyof typeof RARITY_STYLE];
         // If your map stores { color } or { backgroundColor }, support both:
-        highlightColor = (rarityStyle?.color || (rarityStyle as any)?.backgroundColor) || highlightColor;
+        highlightColor = rarityStyle?.color || highlightColor;
       }
 
       // Compute legible text color and outline for very dark backgrounds
@@ -483,7 +482,7 @@ export async function parseXlsxData(file: File, catalog: CanonicalCatalog): Prom
   if (!sheet) throw new Error('XLSX has no sheets.');
 
   // Read as rows with header row
-  const rows = XLSX.utils.sheet_to_json<Record<string, any>>(sheet, { defval: '' });
+  const rows = XLSX.utils.sheet_to_json<Record<string, unknown>>(sheet, { defval: '' });
   if (!rows.length) return normalizedImportResult(aggregatedData, catalog, malformedSkipped);
 
   // Normalize header names once
@@ -496,7 +495,7 @@ export async function parseXlsxData(file: File, catalog: CanonicalCatalog): Prom
   }
 
   // Construct column name resolvers (case/space tolerant)
-  const col = (wanted: string, obj: Record<string, any>) => {
+  const col = (wanted: string, obj: Record<string, unknown>) => {
     const k = Object.keys(obj).find(h => norm(h) === norm(wanted));
     return k ?? wanted; // fall back, but usually found
   };
@@ -647,6 +646,18 @@ type ParsedSet = {
   altToBase: Map<number, number>;
 };
 
+type UnknownRecord = Record<string, unknown>;
+
+function isUnknownRecord(value: unknown): value is UnknownRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function stringOrNamedValue(value: unknown): string | undefined {
+  if (typeof value === 'string') return value;
+  if (isUnknownRecord(value) && typeof value.Name === 'string') return value.Name;
+  return undefined;
+}
+
 function canonicalCatalogFromParsedSets(parsedSets: Iterable<ParsedSet>): CanonicalCatalog {
   const catalog: CanonicalCatalog = new Map();
   for (const parsed of parsedSets) {
@@ -736,11 +747,8 @@ export default function App() {
   // Data variants
   const [cardsAll, setCardsAll] = useState<Card[]>([]);     // unique by Number (used to color pages)
   const [cardsBase, setCardsBase] = useState<Card[]>([]);   // base printing per Name (lowest Number)
-  // alt maps for search: baseNumber -> all numbers (base first), altNumber -> baseNumber
-  const [baseToAll, setBaseToAll] = useState<Map<number, number[]>>(new Map());
-
   // Rarity normalization
-  function normalizeRarity(r: any): string | undefined {
+  function normalizeRarity(r: unknown): string | undefined {
     if (!r) return undefined;
     const v = String(r).trim();
     const k = v.toLowerCase();
@@ -758,14 +766,6 @@ export default function App() {
     return map[k] ?? v; // fall back to the original string
   }
 
-  //Type normalization
-  function normalizeType(t: any): string | undefined {
-    if (!t) return undefined;
-    if (typeof t === 'string') return t.trim();
-    if (typeof t?.Name === 'string') return t.Name.trim();
-    return undefined;
-  }
-
   // stable key for dedupe/show
   function keyNameType(c: {Name: string; Subtitle?: string; Type?: string}) {
     const sub = (c.Subtitle || '').trim().toLowerCase();
@@ -773,7 +773,7 @@ export default function App() {
   }
 
   // 2) collapse alt-arts: keep the LOWEST Number per (Name + Type)
-  function baseOnly(cards: Card[]): Card[] {
+  const baseOnly = useCallback((cards: Card[]): Card[] => {
     const byKey = new Map<string, Card>();
     for (const c of cards) {
       const k = keyNameType(c);
@@ -781,10 +781,10 @@ export default function App() {
       if (!prev || c.Number < prev.Number) byKey.set(k, c);
     }
     return Array.from(byKey.values()).sort((a,b)=>a.Number - b.Number);
-  }
+  }, []);
 
   // 3) Build alt maps for search display and number→base resolution
-  function buildAltMaps(allCards: Card[]) {
+  const buildAltMaps = useCallback((allCards: Card[]) => {
     // name+type → sorted numbers
     const ntToNums = new Map<string, number[]>();
     for (const c of allCards) {
@@ -807,7 +807,7 @@ export default function App() {
       }
     }
     return { baseToAll, altToBase };
-  }
+  }, []);
 
   // Datetime
   function tsStamp(utc = false) {
@@ -907,7 +907,7 @@ export default function App() {
 
   const binderRef = useRef<HTMLDivElement>(null); 
 
-  function activateCard(card: Card, forceView?: BinderViewMode) {
+  const activateCard = useCallback((card: Card, forceView?: BinderViewMode) => {
     const { page, row, column } = binderLayout(card.Number);
     const { spreadCol, spreadRow } = getSpreadCoords(page, row, column);
     setActive({ number: card.Number, card, page, row, column, spreadCol, spreadRow });
@@ -918,7 +918,7 @@ export default function App() {
 
     window.setTimeout(() => setHighlightedRowNumber(null), 500);
     binderRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-  }
+  }, [binderViewMode, settings]);
 
   // Suggestions dropdown
   const [openSug, setOpenSug] = useState(false);
@@ -967,7 +967,8 @@ export default function App() {
 
   // Load set JSON
     useEffect(() => {
-      const loadToken = loadCommitGateRef.current.begin();
+      const loadCommitGate = loadCommitGateRef.current;
+      const loadToken = loadCommitGate.begin();
       // Helper function defined inside useEffect to access local scope functions (like baseOnly)
       const parseAndCache = async (meta: SetMeta): Promise<ParsedSet> => {
         // Check cache first
@@ -977,8 +978,12 @@ export default function App() {
         
         const url = meta.file.startsWith('/') ? meta.file : `/sets/${meta.file}`;
         const res = await fetch(url);
-        const obj = await res.json();
-        const data = Array.isArray(obj) ? obj : obj.data;
+        const payload: unknown = await res.json();
+        const data = Array.isArray(payload)
+          ? payload
+          : isUnknownRecord(payload) && Array.isArray(payload.data)
+            ? payload.data
+            : [];
 
         const pricesName = meta.file.replace(/\.json$/i, '.prices.json');
         const pricesUrl = pricesName.startsWith('/') ? pricesName : `/sets/${pricesName}`;
@@ -986,16 +991,21 @@ export default function App() {
         try {
           const pr = await fetch(pricesUrl);
           if (pr.ok) {
-            const pj = await pr.json();
-            if (pj && typeof pj === 'object' && pj.prices && typeof pj.prices === 'object') {
-              priceByNumber = pj.prices as Record<string, number>;
+            const pricePayload: unknown = await pr.json();
+            if (isUnknownRecord(pricePayload) && isUnknownRecord(pricePayload.prices)) {
+              priceByNumber = Object.fromEntries(
+                Object.entries(pricePayload.prices)
+                  .map(([number, price]) => [number, Number(price)] as const)
+                  .filter(([, price]) => Number.isFinite(price)),
+              );
             }
           }
         } catch {
           /* optional overlay */
         }
 
-        const mapped: Card[] = data.map((c: any) => {
+        const mapped: Card[] = data.map((value: unknown) => {
+          const c = isUnknownRecord(value) ? value : {};
           const rawName = String(c.Name || '').trim();
           const rawSubtitle = String(c.Subtitle || '').trim();
           const cardName = rawName;
@@ -1012,12 +1022,13 @@ export default function App() {
             Name: cardName,
             Subtitle: rawSubtitle || undefined,
             Number: num,
-            Aspects: Array.isArray(c.Aspects) ? c.Aspects : [],
-            Type:
-              typeof c.Type === 'string'
-                ? c.Type
-                : (typeof c.Type?.Name === 'string' ? c.Type.Name : undefined),
-            Rarity: normalizeRarity(c.Rarity ?? c.rarity ?? c.RarityCode ?? c.Rarity?.Name),
+            Aspects: Array.isArray(c.Aspects)
+              ? c.Aspects.filter((aspect): aspect is string => typeof aspect === 'string')
+              : [],
+            Type: stringOrNamedValue(c.Type)?.trim(),
+            Rarity: normalizeRarity(
+              stringOrNamedValue(c.Rarity ?? c.rarity ?? c.RarityCode),
+            ),
             MarketPrice: marketPrice,
             Set: meta.key,
           };
@@ -1070,11 +1081,11 @@ export default function App() {
             .filter(s => s.key !== setKey)
             .map(parseAndCache)
         );
-        if (!loadCommitGateRef.current.canCommit(loadToken)) return;
+        if (!loadCommitGate.canCommit(loadToken)) return;
 
         const catalog = canonicalCatalogFromParsedSets(parsedCacheRef.current.values());
         const loadedInventory = loadInventoriesForPersistence(localStorage, setKeys, catalog);
-        if (!loadCommitGateRef.current.canCommit(loadToken)) return;
+        if (!loadCommitGate.canCommit(loadToken)) return;
 
         if (!loadedInventory.migrationSucceeded) {
           showToast(
@@ -1089,18 +1100,17 @@ export default function App() {
         setCanonicalCatalog(catalog);
         setCardsAll(currentSetData.allCards);
         setCardsBase(currentSetData.baseCards);
-        setBaseToAll(currentSetData.baseToAll);
         setInventory(loadedInventory.inventories[setKey] ?? {});
         setInventoryReadyForSet(loadedInventory.persistenceAllowed ? setKey : null);
 
         // REMOVED: Deferred navigation logic (moved to a new hook below)
       }
       load().catch(() => {
-        if (loadCommitGateRef.current.canCommit(loadToken)) setError('Failed to load set data.');
+        if (loadCommitGate.canCommit(loadToken)) setError('Failed to load set data.');
       });
-      return () => loadCommitGateRef.current.cancel(loadToken);
+      return () => loadCommitGate.cancel(loadToken);
     // Dependencies only include set changes (NO pendingSelection)
-    }, [setKey, sets, setKeys, showToast]);
+    }, [baseOnly, buildAltMaps, setKey, sets, setKeys, setViewSpread, showToast]);
 
     // Deferred Navigation Hook: Runs after new set data is loaded
     useEffect(() => {
@@ -1118,7 +1128,7 @@ export default function App() {
           const card = cardsBase.find(c => c.Number === pendingSelection.baseNumber);
 
           if (card) {
-              selectCardByNumber(pendingSelection.baseNumber);
+              activateCard(card);
               // Clear query so search bar looks clean after selection
               setQuery('');
           } else {
@@ -1129,7 +1139,7 @@ export default function App() {
           // Always clear the pending state after attempting selection
           setPendingSelection(null); 
       }
-    }, [pendingSelection, cardsBase, setKey, binderLayout, pageToSpread, setActive, setViewSpread, setError, setPendingSelection, setQuery]);
+    }, [activateCard, pendingSelection, cardsBase, setKey]);
   // Build coloring map + presence
   const presentNumbers = useMemo(() => new Set(cardsBase.map(c => c.Number)), [cardsBase]);
   const numToAspectSpec = useMemo(() => {
@@ -1143,8 +1153,9 @@ export default function App() {
 
   // Suggestions retain the exact set and base-card identity selected by the user.
   const searchCatalogs: SearchCatalog[] = useMemo(
-    () =>
-      Array.from(parsedCacheRef.current.entries()).map(([catalogSetKey, parsed]) => ({
+    () => {
+      if (canonicalCatalog.size === 0) return [];
+      return Array.from(parsedCacheRef.current.entries()).map(([catalogSetKey, parsed]) => ({
         setKey: catalogSetKey,
         cards: parsed.baseCards,
         printingNumbersByBase: parsed.baseToAll,
@@ -1152,8 +1163,9 @@ export default function App() {
           ...parsed.baseCards.map(card => [card.Number, card.Number] as const),
           ...parsed.altToBase.entries(),
         ]),
-      })),
-    [cardsBase, setKey],
+      }));
+    },
+    [canonicalCatalog],
   );
   const suggestions = useMemo(
     () => buildSearchSuggestions(query, searchCatalogs, setKey),
@@ -1162,7 +1174,13 @@ export default function App() {
   // Click outside to close dropdown
   useEffect(() => {
     const onDoc = (e: MouseEvent) => {
-      if (boxRef.current && !boxRef.current.contains(e.target as any)) setOpenSug(false);
+      if (
+        boxRef.current &&
+        e.target instanceof Node &&
+        !boxRef.current.contains(e.target)
+      ) {
+        setOpenSug(false);
+      }
     };
     document.addEventListener('mousedown', onDoc);
     return () => document.removeEventListener('mousedown', onDoc);
@@ -1213,24 +1231,12 @@ export default function App() {
         : deltaRow < 0
           ? 'up'
           : 'down';
-    const selection = {
-      number: active.card.Number,
-      page: active.page,
-      row: active.row,
-      column: active.column,
-    };
-    const next = moveBinderSelection(selection, direction, totalPages);
-    if (next === selection) return;
+    const next = selectionAfterMove(active, direction, totalPages, byNumber);
+    if (next === active) return;
 
-    const { spreadCol, spreadRow } = getSpreadCoords(next.page, next.row, next.column);
-    setActive({
-      ...next,
-      card: byNumber.get(next.number) || { ...active.card, Number: next.number },
-      spreadCol,
-      spreadRow,
-    });
+    setActive(next);
     setFocusedPage(next.page);
-  }, [active, totalPages, byNumber, setActive]);
+  }, [active, totalPages, byNumber]);
   
 
   const [prevSetKey, nextSetKey] = useMemo(() => {
@@ -1266,8 +1272,6 @@ export default function App() {
   }, [prevSetKey, nextSetKey, setSetKey, setQuery, setActive, setViewSpread]);
 
   // Inventory helpers
-  type InventoryAll = { version: 1; sets: Record<SetKey, Inventory> };
-
   function readSetInv(k: SetKey): Inventory {
     try {
       return canonicalizeInventory(
@@ -1281,11 +1285,8 @@ export default function App() {
   function writeSetInv(k: SetKey, inv: Inventory): boolean {
     return persistCanonicalInventory(localStorage, k, inv, canonicalCatalog);
   }
-  function canonicalBaseNumber(set: SetKey, printingNumber: number): number | null {
-    return canonicalCatalog.get(`${set}:${printingNumber}`)?.baseNumber ?? null;
-  }
-  function inc(n: number) {
-    const baseNumber = canonicalBaseNumber(setKey, n);
+  const inc = useCallback((n: number) => {
+    const baseNumber = canonicalCatalog.get(`${setKey}:${n}`)?.baseNumber ?? null;
     if (baseNumber === null) return;
     const ref = canonicalCatalog.get(`${setKey}:${baseNumber}`);
     const max = quotaForType(ref?.type);
@@ -1293,9 +1294,9 @@ export default function App() {
       ...prev,
       [baseNumber]: Math.min((prev[baseNumber] || 0) + 1, max),
     }));
-  }
-  function dec(n: number) {
-    const baseNumber = canonicalBaseNumber(setKey, n);
+  }, [canonicalCatalog, setKey]);
+  const dec = useCallback((n: number) => {
+    const baseNumber = canonicalCatalog.get(`${setKey}:${n}`)?.baseNumber ?? null;
     if (baseNumber === null) return;
     setInventory(prev => {
       const next = Math.max((prev[baseNumber] || 0) - 1, 0);
@@ -1305,7 +1306,7 @@ export default function App() {
       }
       return { ...prev, [baseNumber]: next };
     });
-  }
+  }, [canonicalCatalog, setKey]);
   function exportAllInv() {
     const payload = {
       version: 1 as const,
@@ -2999,7 +3000,6 @@ export function Binder({
                 let opacity = hidden ? 0.25 : 0.9;
                 let stroke = '#2b2d3d';
                 let strokeWidth = 2;
-                let qtyText = '';
 
                 if (!hidden && presentNumbers.has(n)) {
                   const spec = numToAspectSpec.get(n);
@@ -3010,9 +3010,6 @@ export function Binder({
                   } else {
                     fill = NEUTRAL;
                   }
-                  const qty = inventory[n] || 0;
-                  const max = quotaForType(cardAt?.Type);
-                  qtyText = `${qty}/${max}`;
                   const activeHere = isActive(pForCell, r, colOnPage);
                   opacity = activeHere ? 1.0 : 0.35;
                   stroke = activeHere ? '#ffffff' : '#2b2d3d';

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,7 +33,10 @@ import {
   type AppSettings,
 } from './core/settings';
 import type { ActiveSelection, Card, Inventory, SetKey, SetMeta } from './core/types';
+import { LocatorPanel } from './components/LocatorPanel';
 import { SettingsModal } from './components/SettingsModal';
+
+export type BinderViewMode = 'single' | 'spread';
 
 /** Last entry in `manifest.json` is the newest set (release order). */
 function newestSetKeyFromManifest(list: SetMeta[]): SetKey {
@@ -887,8 +890,24 @@ export default function App() {
   const totalPages = Math.max(1, Math.ceil(maxNumber / 12));
   const totalSpreads = 1 + Math.ceil(Math.max(0, totalPages - 1) / 2);
   const [viewSpread, setViewSpread] = useState<number>(0); // 0 => Page 1; >=1 => 2/3, 4/5, ...
+  const [binderViewMode, setBinderViewMode] = useState<BinderViewMode>('spread');
+  const [focusedPage, setFocusedPage] = useState(1);
 
   const binderRef = useRef<HTMLDivElement>(null); 
+
+  function activateCard(card: Card, forceView?: BinderViewMode) {
+    const { page, row, column } = binderLayout(card.Number);
+    const { spreadCol, spreadRow } = getSpreadCoords(page, row, column);
+    setActive({ number: card.Number, card, page, row, column, spreadCol, spreadRow });
+    setError('');
+    setViewSpread(pageToSpread(page));
+    setFocusedPage(page);
+    setBinderViewMode(forceView ?? (settings.autoOpenSinglePage ? 'single' : binderViewMode));
+    setHighlightedRowNumber(card.Number);
+
+    window.setTimeout(() => setHighlightedRowNumber(null), 500);
+    binderRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
 
   // Suggestions dropdown
   const [openSug, setOpenSug] = useState(false);
@@ -1171,20 +1190,7 @@ export default function App() {
       setError('Card not found in current set data.');
       return; 
     }
-    const { page, row, column } = binderLayout(baseNum);
-    const { spreadCol, spreadRow } = getSpreadCoords(page, row, column);
-    setActive({ number: card.Number, card, page, row, column, spreadCol, spreadRow });
-    setError('');
-    setViewSpread(pageToSpread(page));
-    setHighlightedRowNumber(baseNum);
-    
-    // Clear highlight after 500ms
-    setTimeout(() => setHighlightedRowNumber(null), 500);
-
-    // Scroll the binder into view if it's not fully visible
-    if (binderRef.current) {
-        binderRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    }
+    activateCard(card);
   }
 
   const updateActivePosition = useCallback((deltaCol: number, deltaRow: number) => {
@@ -1213,6 +1219,7 @@ export default function App() {
       spreadRow,
     });
     setViewSpread(pageToSpread(next.page));
+    setFocusedPage(next.page);
   }, [active, totalPages, byNumber, setActive, setViewSpread]);
   
 
@@ -1576,10 +1583,10 @@ export default function App() {
         let deltaSpread = 0;
         
         // NEW: Page flipping shortcuts ("," and ".")
-        if (e.key === ',' || e.key === '<') { // Comma
+        if ((e.key === ',' || e.key === '<') && binderViewMode === 'spread') { // Comma
           e.preventDefault();
           deltaSpread = -1;
-        } else if (e.key === '.' || e.key === '>') { // Period
+        } else if ((e.key === '.' || e.key === '>') && binderViewMode === 'spread') { // Period
           e.preventDefault();
           deltaSpread = 1;
         }
@@ -1659,7 +1666,7 @@ export default function App() {
 
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [active, query, setViewSpread, totalSpreads, updateActivePosition, inc, dec, byNumber, totalPages]);
+  }, [active, query, setViewSpread, totalSpreads, updateActivePosition, inc, dec, byNumber, totalPages, binderViewMode]);
 
   const fmtUSD = (n: number) =>
     n.toLocaleString('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 2 });
@@ -2041,12 +2048,32 @@ export default function App() {
 
       {/* Binder (with spread pager + dropdown) — minimal padding so the grid can use width */}
       <div className="card" ref={binderRef} style={{ padding: 8 }}>
+        {active && (
+          <LocatorPanel
+            selection={active}
+            quantity={inventory[active.number] || 0}
+            maximum={quotaForType(active.card.Type)}
+            aspectBackground={aspectSpecToCssBackground(numToAspectSpec.get(active.number))}
+            onDecrease={() => dec(active.number)}
+            onIncrease={() => inc(active.number)}
+          />
+        )}
         <Binder
           viewSpread={viewSpread}
           setViewSpread={setViewSpread}
           totalSpreads={totalSpreads}
+          totalPages={totalPages}
+          viewMode={binderViewMode}
+          focusedPage={focusedPage}
+          onFocusedPageChange={setFocusedPage}
+          onViewModeChange={mode => {
+            setBinderViewMode(mode);
+            if (mode === 'single') {
+              setFocusedPage(active?.page ?? spreadToPrimaryPage(viewSpread));
+            }
+          }}
+          onActivateCard={activateCard}
           active={active}
-          setActive={setActive}
           presentNumbers={presentNumbers}
           numToAspectSpec={numToAspectSpec}
           byNumber={byNumber}
@@ -2721,12 +2748,17 @@ export default function App() {
   );
 }
 
-function Binder({
+export function Binder({
   viewSpread,
   setViewSpread,
   totalSpreads,
+  totalPages,
+  viewMode,
+  focusedPage,
+  onFocusedPageChange,
+  onViewModeChange,
+  onActivateCard,
   active,
-  setActive,
   presentNumbers,
   numToAspectSpec,
   byNumber,
@@ -2740,8 +2772,13 @@ function Binder({
   viewSpread: number;
   setViewSpread: React.Dispatch<React.SetStateAction<number>>;
   totalSpreads: number;
+  totalPages: number;
+  viewMode: BinderViewMode;
+  focusedPage: number;
+  onFocusedPageChange: (page: number) => void;
+  onViewModeChange: (mode: BinderViewMode) => void;
+  onActivateCard: (card: Card) => void;
   active: ActiveSelection | null;
-  setActive: (v: ActiveSelection | null)=>void;
   presentNumbers: Set<number>;
   numToAspectSpec: Map<number, AspectFillSpec>;
   byNumber: Map<number, Card>;
@@ -2752,12 +2789,13 @@ function Binder({
   showHelpModal: boolean;
   setShowHelpModal: React.Dispatch<React.SetStateAction<boolean>>;
 }) {
+  const singlePage = viewMode === 'single';
   const page = spreadToPrimaryPage(viewSpread);     // 1, 2, 4, 6, ...
   const leftPage = page % 2 === 0 ? page : page - 1;
   const rightPage = page % 2 === 1 ? page : page + 1;
   const showLeft = leftPage >= 2;
 
-  const cols = 8, rows = 3;
+  const cols = singlePage ? 4 : 8, rows = 3;
   const cellW = 120, cellH = 170, gap = 12;
   const vbPad = 8;
   const vbW = cols * cellW + (cols - 1) * gap + vbPad * 2;
@@ -2767,6 +2805,7 @@ function Binder({
   const spreadLabel = page === 1
     ? 'Spread: Page 1'
     : `Spread: Page ${leftPage} (left) | Page ${rightPage} (right)`;
+  const binderLabel = singlePage ? `Page ${focusedPage}` : spreadLabel;
 
   const isActive = (p:number, r:number, c:number) =>
     active && p === active.page && r === active.row && c === active.column;
@@ -2780,6 +2819,10 @@ function Binder({
       return { value: i, label: `Page ${left}/${right}` };
     });
   }, [totalSpreads]);
+  const pageOptions = useMemo(
+    () => Array.from({ length: totalPages }, (_, index) => index + 1),
+    [totalPages],
+  );
 
   const binderGradientDefs = useMemo(() => {
     const out: { n: number; spec: Extract<AspectFillSpec, { kind: 'gradient' }> }[] = [];
@@ -2792,6 +2835,26 @@ function Binder({
 
   return (
     <>
+      <div className="binder-toolbar">
+        <div className="toolbar-group" role="group" aria-label="Binder view">
+          <button
+            type="button"
+            className="tbtn"
+            aria-pressed={singlePage}
+            onClick={() => onViewModeChange('single')}
+          >
+            Single Page
+          </button>
+          <button
+            type="button"
+            className="tbtn"
+            aria-pressed={!singlePage}
+            onClick={() => onViewModeChange('spread')}
+          >
+            Spread
+          </button>
+        </div>
+      </div>
       {/* Row 1: selection header + tip (right) */}
       <div
         className="row"
@@ -2827,8 +2890,8 @@ function Binder({
                 )}
               </div>
               <span className="pill">Page {active.page}</span>
-              <span className="pill">Column {active.spreadCol}</span>
-              <span className="pill">Row {active.spreadRow}</span>
+              <span className="pill">Column {active.column}</span>
+              <span className="pill">Row {active.row}</span>
             </>
           ) : (
             <div className="muted" style={{ fontSize: 25 }}>No card selected</div>
@@ -2887,19 +2950,32 @@ function Binder({
           >
             {setKey}
           </span>
-          <span style={{ fontWeight: 600 }}>Binder</span> — {spreadLabel}
+          <span style={{ fontWeight: 600 }}>Binder</span> — {binderLabel}
         </div>
         <div className="pager">
           <label className="spread-jump-label">
             <span className="spread-jump-hint">Jump</span>
-            <select
-              className="spread-jump-select"
-              value={viewSpread}
-              onChange={e => setViewSpread(Number(e.target.value))}
-              aria-label="Jump to spread"
-            >
-              {spreadOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-            </select>
+            {singlePage ? (
+              <select
+                className="spread-jump-select"
+                value={focusedPage}
+                onChange={event => onFocusedPageChange(Number(event.target.value))}
+                aria-label="Jump to page"
+              >
+                {pageOptions.map(option => <option key={option} value={option}>Page {option}</option>)}
+              </select>
+            ) : (
+              <select
+                className="spread-jump-select"
+                value={viewSpread}
+                onChange={event => setViewSpread(Number(event.target.value))}
+                aria-label="Jump to spread"
+              >
+                {spreadOptions.map(option => (
+                  <option key={option.value} value={option.value}>{option.label}</option>
+                ))}
+              </select>
+            )}
           </label>
         </div>
       </div>
@@ -2908,13 +2984,15 @@ function Binder({
         <button
           type="button"
           className="spread-nav-edge"
-          disabled={totalSpreads === 0 || viewSpread <= 0}
-          onClick={() => setViewSpread(s => Math.max(0, s - 1))}
-          aria-label="Previous spread, keyboard comma"
-          title="Previous spread — keyboard ,"
+          disabled={singlePage ? focusedPage <= 1 : totalSpreads === 0 || viewSpread <= 0}
+          onClick={() => singlePage
+            ? onFocusedPageChange(Math.max(1, focusedPage - 1))
+            : setViewSpread(spread => Math.max(0, spread - 1))}
+          aria-label={singlePage ? 'Previous page' : 'Previous spread, keyboard comma'}
+          title={singlePage ? 'Previous page' : 'Previous spread — keyboard ,'}
         >
           <span className="spread-nav-chevron" aria-hidden>‹</span>
-          <span className="key-pill">,</span>
+          {!singlePage && <span className="key-pill">,</span>}
         </button>
         <div className="grid-wrap">
         <svg viewBox={`0 0 ${vbW} ${vbH}`} style={{ width: '100%', height: 'auto' }} preserveAspectRatio="xMidYMid meet">
@@ -2944,10 +3022,10 @@ function Binder({
                 const x = cIdx * (cellW + gap);
                 const y = rIdx * (cellH + gap);
 
-                const isLeftHalf = c <= 4;
-                const pForCell = isLeftHalf ? leftPage : rightPage;
-                const colOnPage = isLeftHalf ? c : c - 4;
-                const hidden = isLeftHalf && !showLeft;
+                const isLeftHalf = !singlePage && c <= 4;
+                const pForCell = singlePage ? focusedPage : isLeftHalf ? leftPage : rightPage;
+                const colOnPage = singlePage ? c : isLeftHalf ? c : c - 4;
+                const hidden = !singlePage && isLeftHalf && !showLeft;
 
                 const n = numberFromPagePosition(pForCell, r, colOnPage);
                 const cardAt = byNumber.get(n);
@@ -2986,18 +3064,7 @@ function Binder({
                       const card = byNumber.get(n);      // exact card in this set
                       if (!card) return;
 
-                      const { page: bp, row: br, column: bc } = binderLayout(n);
-                      // FIX: Added spreadCol (c) and spreadRow (r) to complete the active state
-                      setActive({ 
-                        number: card.Number,
-                        card, 
-                        page: bp, 
-                        row: br, 
-                        column: bc, 
-                        spreadCol: c, 
-                        spreadRow: r 
-                      });
-                      setViewSpread(pageToSpread(bp));
+                      onActivateCard(card);
                     }}
                   >
                     {/* the card rectangle */}
@@ -3119,19 +3186,21 @@ function Binder({
                 );
               })
             )}
-            {/* dotted divider */}
-            <line
-              x1={(cellW + gap) * 4 - gap / 2}
-              y1={-8}
-              x2={(cellW + gap) * 4 - gap / 2}
-              y2={gridBottom + 8}
-              stroke="#424452ff"
-              strokeOpacity={0.75}
-              strokeWidth={4}
-              strokeDasharray="0 12"
-              strokeLinecap="round"
-              vectorEffect="non-scaling-stroke"
-            />
+            {!singlePage && (
+              <line
+                className="binder-divider"
+                x1={(cellW + gap) * 4 - gap / 2}
+                y1={-8}
+                x2={(cellW + gap) * 4 - gap / 2}
+                y2={gridBottom + 8}
+                stroke="#424452ff"
+                strokeOpacity={0.75}
+                strokeWidth={4}
+                strokeDasharray="0 12"
+                strokeLinecap="round"
+                vectorEffect="non-scaling-stroke"
+              />
+            )}
           </g>
         </svg>
         {/* NEW: Help Modal JSX */}
@@ -3204,13 +3273,15 @@ function Binder({
         <button
           type="button"
           className="spread-nav-edge"
-          disabled={totalSpreads === 0 || viewSpread >= totalSpreads - 1}
-          onClick={() => setViewSpread(s => Math.min(totalSpreads - 1, s + 1))}
-          aria-label="Next spread, keyboard period"
-          title="Next spread — keyboard ."
+          disabled={singlePage ? focusedPage >= totalPages : totalSpreads === 0 || viewSpread >= totalSpreads - 1}
+          onClick={() => singlePage
+            ? onFocusedPageChange(Math.min(totalPages, focusedPage + 1))
+            : setViewSpread(spread => Math.min(totalSpreads - 1, spread + 1))}
+          aria-label={singlePage ? 'Next page' : 'Next spread, keyboard period'}
+          title={singlePage ? 'Next page' : 'Next spread — keyboard .'}
         >
           <span className="spread-nav-chevron" aria-hidden>›</span>
-          <span className="key-pill">.</span>
+          {!singlePage && <span className="key-pill">.</span>}
         </button>
       </div>
     </>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,19 +1,14 @@
 import React, { useEffect, useMemo, useRef, useState, useCallback } from 'react';
 import * as XLSX from 'xlsx';
-
-type Card = {
-  Name: string;
-  Subtitle?: string;
-  Number: number;
-  Aspects?: string[];
-  Type?: string;
-  Rarity?: string;
-  MarketPrice?: number;
-  Set: string
-};
-type Inventory = Record<number, number>;
-type SetKey = string;
-type SetMeta = { key: string; label: string; file: string };
+import {
+  binderLayout,
+  getSpreadCoords,
+  moveBinderSelection,
+  numberFromPagePosition,
+  pageToSpread,
+  spreadToPrimaryPage,
+} from './core/binder';
+import type { ActiveSelection, Card, Inventory, SetKey, SetMeta } from './core/types';
 
 /** Last entry in `manifest.json` is the newest set (release order). */
 function newestSetKeyFromManifest(list: SetMeta[]): SetKey {
@@ -139,32 +134,10 @@ function rarityGlyph(r?: string) {
   return RARITY_STYLE[r] ?? null;
 }
 
-function binderLayout(n: number) {
-  const page = Math.floor((n - 1) / 12) + 1;
-  const row = Math.floor(((n - 1) % 12) / 4) + 1;
-  const column = ((n - 1) % 4) + 1;
-  return { page, row, column };
-}
-function getSpreadCoords(page: number, row: number, column: number) {
-  const isOddPage = page % 2 !== 0;
-  return {
-    spreadCol: isOddPage ? column + 4 : column,
-    spreadRow: row,
-  };
-}
-function numberFromPRC(page: number, row: number, col: number) {
-  return (page - 1) * 12 + (row - 1) * 4 + col;
-}
 function quotaForType(type?: string) {
   const t = (type || '').toLowerCase();
   return (t === 'leader' || t === 'base') ? 1 : 3;
 }
-
-// Spread math ---------------------------------------------------------------
-// spread 0 -> Page 1 (right-only)
-// spread 1 -> Pages 2/3, spread 2 -> 4/5, ...
-function pageToSpread(p: number) { return p <= 1 ? 0 : Math.floor((p - 2) / 2) + 1; }
-function spreadToPrimaryPage(s: number) { return s <= 0 ? 1 : 2 + (s - 1) * 2; } // even page
 
 /** Collection status for filter pills (same semantics as the Status column: ✓ / ! / ✕). */
 type CollectionStatusKey = 'complete' | 'partial' | 'none';
@@ -831,14 +804,7 @@ export default function App() {
   // UI state
   const [query, setQuery] = useState('');
   const [error, setError] = useState('');
-  const [active, setActive] = useState<{ 
-    card: Card; 
-    page: number; 
-    row: number; 
-    column: number; 
-    spreadCol: number; 
-    spreadRow: number; 
-  } | null>(null);
+  const [active, setActive] = useState<ActiveSelection | null>(null);
 
   // NEW: State to hold card details for selection after a set switch
   const [pendingSelection, setPendingSelection] = useState<{ name: string; number: number } | null>(null);
@@ -1056,7 +1022,7 @@ export default function App() {
           if (card) {
               const { page, row, column } = binderLayout(card.Number);
               const { spreadCol, spreadRow } = getSpreadCoords(page, row, column);
-              setActive({ card, page, row, column, spreadCol, spreadRow });
+              setActive({ number: card.Number, card, page, row, column, spreadCol, spreadRow });
               setViewSpread(pageToSpread(page));
               // Clear query so search bar looks clean after selection
               setQuery('');
@@ -1225,7 +1191,7 @@ export default function App() {
     // 3. Set the active state with all required properties
     const { page, row, column } = binderLayout(baseNum);
     const { spreadCol, spreadRow } = getSpreadCoords(page, row, column);
-    setActive({ card, page, row, column, spreadCol, spreadRow });
+    setActive({ number: card.Number, card, page, row, column, spreadCol, spreadRow });
     setError('');
     setViewSpread(pageToSpread(page));
   }
@@ -1234,7 +1200,7 @@ export default function App() {
     if (!base) { setError('Name not found in this set.'); return; }
     const { page, row, column } = binderLayout(base.Number);
     const { spreadCol, spreadRow } = getSpreadCoords(page, row, column);
-    setActive({ card: base, page, row, column, spreadCol, spreadRow });
+    setActive({ number: base.Number, card: base, page, row, column, spreadCol, spreadRow });
     setError('');
     setViewSpread(pageToSpread(page));
   }
@@ -1269,7 +1235,7 @@ export default function App() {
     }
     const { page, row, column } = binderLayout(baseNum);
     const { spreadCol, spreadRow } = getSpreadCoords(page, row, column);
-    setActive({ card, page, row, column, spreadCol, spreadRow });
+    setActive({ number: card.Number, card, page, row, column, spreadCol, spreadRow });
     setError('');
     setViewSpread(pageToSpread(page));
     setHighlightedRowNumber(baseNum);
@@ -1283,84 +1249,33 @@ export default function App() {
     }
   }
 
-  // Function to move the card selection based on visual coordinates (8 columns, 3 rows)
   const updateActivePosition = useCallback((deltaCol: number, deltaRow: number) => {
     if (!active) return;
-    
-    const currentNum = active.card.Number;
-    const { page } = binderLayout(currentNum);
-
-    // 1. Get current visual coordinates
-    let newSpreadCol = active.spreadCol + deltaCol;
-    let newSpreadRow = active.spreadRow + deltaRow;
-    let targetSpread = pageToSpread(page);
-
-    // 2. Implement Movement/Wrap Logic
-
-    // --- Horizontal Movement/Spread Wrap (X-axis) ---
-    if (deltaCol !== 0) {
-        if (newSpreadCol > 8) {
-            newSpreadCol = 1; 
-            targetSpread += 1; // Jumps to next spread
-        } else if (newSpreadCol < 1) {
-            newSpreadCol = 8; 
-            targetSpread -= 1; // Jumps to previous spread
-        }
-    }
-    
-    // --- Vertical Movement/Spread Wrap (Y-axis) ---
-    if (deltaRow !== 0) {
-        if (newSpreadRow > 3) {
-            newSpreadRow = 1;
-            targetSpread += 1; // Jumps to next spread
-        } else if (newSpreadRow < 1) {
-            newSpreadRow = 3;
-            targetSpread -= 1; // Jumps to previous spread
-        }
-    }
-    
-    // 3. Constraint Checks
-    if (targetSpread < 0 || targetSpread > totalSpreads - 1) return;
-
-    // 4. Convert Spread Coordinate back to Card Number
-    let targetPage = spreadToPrimaryPage(targetSpread);
-    let targetColOnPage = 0;
-
-    if (newSpreadCol <= 4) {
-      // Target is Left Page (SpreadCol 1-4)
-      targetColOnPage = newSpreadCol;
-      // If we landed on the left side of the spread, the page number must be even (P2, P4, P6...)
-      if (targetPage % 2 !== 0 && targetPage > 1) targetPage -= 1;
-      // Handle P1 edge case (Spread 0 is right-page only)
-      if (targetPage === 1 && newSpreadCol <= 4) return;
-    } else {
-      // Target is Right Page (SpreadCol 5-8)
-      targetColOnPage = newSpreadCol - 4;
-      // If we landed on the right side of the spread, the page number must be odd (P3, P5, P7...)
-      if (targetPage % 2 === 0) targetPage += 1;
-    }
-    
-    const newNumCandidate = numberFromPRC(targetPage, newSpreadRow, targetColOnPage);
-    
-    // Final boundary check against total card slots
-    if (newNumCandidate > totalPages * 12) return;
-
-    // 5. Apply Position
-    const newCard = byNumber.get(newNumCandidate);
-    
-    const newActiveState = {
-        card: newCard || { ...active.card, Number: newNumCandidate },
-        page: targetPage,
-        row: newSpreadRow,
-        column: targetColOnPage,
-        spreadCol: newSpreadCol,
-        spreadRow: newSpreadRow,
+    const direction = deltaCol < 0
+      ? 'left'
+      : deltaCol > 0
+        ? 'right'
+        : deltaRow < 0
+          ? 'up'
+          : 'down';
+    const selection = {
+      number: active.card.Number,
+      page: active.page,
+      row: active.row,
+      column: active.column,
     };
+    const next = moveBinderSelection(selection, direction, totalPages);
+    if (next === selection) return;
 
-    setActive(newActiveState);
-    setViewSpread(targetSpread);
-    
-  }, [active, totalPages, totalSpreads, byNumber, setActive, setViewSpread]);
+    const { spreadCol, spreadRow } = getSpreadCoords(next.page, next.row, next.column);
+    setActive({
+      ...next,
+      card: byNumber.get(next.number) || { ...active.card, Number: next.number },
+      spreadCol,
+      spreadRow,
+    });
+    setViewSpread(pageToSpread(next.page));
+  }, [active, totalPages, byNumber, setActive, setViewSpread]);
   
   const setKeys = useMemo(() => sets.map(s => s.key as SetKey), [sets]);
 
@@ -1767,7 +1682,7 @@ export default function App() {
                     if (newCard) {
                         const { page, row, column } = binderLayout(newCard.Number);
                         const { spreadCol, spreadRow } = getSpreadCoords(page, row, column); // CALCULATE SPREAD COORDS
-                        setActive({ card: newCard, page, row, column, spreadCol, spreadRow }); // PASS SPREAD COORDS
+                        setActive({ number: newCard.Number, card: newCard, page, row, column, spreadCol, spreadRow }); // PASS SPREAD COORDS
                     } else {
                         // If no card exists at the new relative position, select the first card on the new spread
                         const firstNumOnSpread = newSpread * 24 + 1;
@@ -1775,7 +1690,7 @@ export default function App() {
                         if(firstCardOnSpread) {
                            const { page, row, column } = binderLayout(firstCardOnSpread.Number);
                            const { spreadCol, spreadRow } = getSpreadCoords(page, row, column); // CALCULATE SPREAD COORDS
-                           setActive({ card: firstCardOnSpread, page, row, column, spreadCol, spreadRow }); // PASS SPREAD COORDS
+                           setActive({ number: firstCardOnSpread.Number, card: firstCardOnSpread, page, row, column, spreadCol, spreadRow }); // PASS SPREAD COORDS
                         } else {
                            setActive(null); // Clear selection if no card is found
                         }
@@ -2885,22 +2800,8 @@ function Binder({
   viewSpread: number;
   setViewSpread: React.Dispatch<React.SetStateAction<number>>;
   totalSpreads: number;
-  active: { 
-    card: Card; 
-    page: number; 
-    row: number; 
-    column: number; 
-    spreadCol: number; 
-    spreadRow: number; 
-  } | null;
-  setActive: (v: { 
-    card: Card; 
-    page: number; 
-    row: number; 
-    column: number; 
-    spreadCol: number; 
-    spreadRow: number; 
-  } | null)=>void;
+  active: ActiveSelection | null;
+  setActive: (v: ActiveSelection | null)=>void;
   presentNumbers: Set<number>;
   numToAspectSpec: Map<number, AspectFillSpec>;
   byNumber: Map<number, Card>;
@@ -3108,7 +3009,7 @@ function Binder({
                 const colOnPage = isLeftHalf ? c : c - 4;
                 const hidden = isLeftHalf && !showLeft;
 
-                const n = numberFromPRC(pForCell, r, colOnPage);
+                const n = numberFromPagePosition(pForCell, r, colOnPage);
                 const cardAt = byNumber.get(n);
 
                 let fill = '#0f1017';
@@ -3148,6 +3049,7 @@ function Binder({
                       const { page: bp, row: br, column: bc } = binderLayout(n);
                       // FIX: Added spreadCol (c) and spreadRow (r) to complete the active state
                       setActive({ 
+                        number: card.Number,
                         card, 
                         page: bp, 
                         row: br, 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import {
   applyImportedInventories,
   canonicalizeInventory,
   collectRawImportEntry,
+  createInventoryExportSnapshot,
   loadInventoriesForPersistence,
   persistCanonicalInventory,
   quotaForType,
@@ -25,6 +26,7 @@ import {
   type ImportResult,
 } from './core/inventory';
 import { createLoadCommitGate } from './core/loadGuard';
+import { fetchSetPayload } from './core/setData';
 import {
   DEFAULT_SETTINGS,
   readSettings,
@@ -833,9 +835,11 @@ export default function App() {
   const [inventoryReadyForSet, setInventoryReadyForSet] = useState<SetKey | null>(null);
   useEffect(() => {
     if (inventoryReadyForSet === setKey) {
-      persistCanonicalInventory(localStorage, setKey, inventory, canonicalCatalog);
+      if (!persistCanonicalInventory(localStorage, setKey, inventory, canonicalCatalog)) {
+        showToast('Inventory could not be saved on this device.', 'error');
+      }
     }
-  }, [canonicalCatalog, inventory, inventoryReadyForSet, setKey]);
+  }, [canonicalCatalog, inventory, inventoryReadyForSet, setKey, showToast]);
   const pruneZeros = (inv: Inventory) =>
     Object.fromEntries(Object.entries(inv).filter(([,q]) => (q as number) > 0)) as Inventory;
   useEffect(() => {
@@ -980,13 +984,7 @@ export default function App() {
         }
         
         const url = meta.file.startsWith('/') ? meta.file : `/sets/${meta.file}`;
-        const res = await fetch(url);
-        const payload: unknown = await res.json();
-        const data = Array.isArray(payload)
-          ? payload
-          : isUnknownRecord(payload) && Array.isArray(payload.data)
-            ? payload.data
-            : [];
+        const data = await fetchSetPayload(fetch, url);
 
         const pricesName = meta.file.replace(/\.json$/i, '.prices.json');
         const pricesUrl = pricesName.startsWith('/') ? pricesName : `/sets/${pricesName}`;
@@ -1311,17 +1309,27 @@ export default function App() {
     });
   }, [canonicalCatalog, setKey]);
   function exportAllInv() {
-    const payload = {
-      version: 1 as const,
-      sets: Object.fromEntries(setKeys.map(k => [k, readSetInv(k)])) as Record<SetKey, Inventory>,
-    };
-    const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = `SWU-Inventory-${tsStamp()}.json`;
-    a.click();
-    URL.revokeObjectURL(url);
+    try {
+      const payload = {
+        version: 1 as const,
+        sets: createInventoryExportSnapshot(
+          localStorage,
+          setKeys,
+          setKey,
+          inventory,
+          canonicalCatalog,
+        ),
+      };
+      const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `SWU-Inventory-${tsStamp()}.json`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch {
+      showToast('Inventory export could not be created because saved data is unreadable.', 'error');
+    }
   }
 
   function RarityBadge({ rarity }: { rarity?: string }) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,9 @@ import {
   canonicalizeInventory,
   collectRawImportEntry,
   loadInventoriesForPersistence,
+  persistCanonicalInventory,
   quotaForType,
+  removePersistedInventory,
   type CanonicalCatalog,
   type ImportResult,
 } from './core/inventory';
@@ -793,9 +795,9 @@ export default function App() {
   const [inventoryReadyForSet, setInventoryReadyForSet] = useState<SetKey | null>(null);
   useEffect(() => {
     if (inventoryReadyForSet === setKey) {
-      localStorage.setItem(`inv:${setKey}`, JSON.stringify(inventory));
+      persistCanonicalInventory(localStorage, setKey, inventory, canonicalCatalog);
     }
-  }, [inventory, inventoryReadyForSet, setKey]);
+  }, [canonicalCatalog, inventory, inventoryReadyForSet, setKey]);
   const pruneZeros = (inv: Inventory) =>
     Object.fromEntries(Object.entries(inv).filter(([,q]) => (q as number) > 0)) as Inventory;
   useEffect(() => {
@@ -1232,8 +1234,8 @@ export default function App() {
     }
     catch { return {}; }
   }
-  function writeSetInv(k: SetKey, inv: Inventory) {
-    localStorage.setItem(`inv:${k}`, JSON.stringify(canonicalizeInventory(k, inv, canonicalCatalog)));
+  function writeSetInv(k: SetKey, inv: Inventory): boolean {
+    return persistCanonicalInventory(localStorage, k, inv, canonicalCatalog);
   }
   function canonicalBaseNumber(set: SetKey, printingNumber: number): number | null {
     return canonicalCatalog.get(`${set}:${printingNumber}`)?.baseNumber ?? null;
@@ -1410,25 +1412,33 @@ export default function App() {
 
   const handleResetInventory = (scope: 'current' | 'all') => {
       if (scope === 'current') {
-          localStorage.removeItem(`inv:${setKey}`);
-          setInventory({});
-          showToast(`Inventory for the current set (${setKey}) has been cleared.`);
+          if (removePersistedInventory(localStorage, setKey, canonicalCatalog)) {
+              setInventory({});
+              showToast(`Inventory for the current set (${setKey}) has been cleared.`);
+          } else {
+              showToast('Inventory could not be cleared while protected persistence is locked.', 'warning');
+          }
       } else if (scope === 'all') {
+          let allRemoved = true;
           // Clear set inventories without deleting the migration backup or schema marker.
           if (!sets.length) {
               for (const key of Object.keys(localStorage)) {
                   if (/^inv:[A-Z0-9]+$/.test(key)) {
-                      localStorage.removeItem(key);
+                      allRemoved = removePersistedInventory(localStorage, key.slice(4), canonicalCatalog) && allRemoved;
                   }
               }
           } else {
               // Clear based on loaded set keys
               for (const set of sets) {
-                  localStorage.removeItem(`inv:${set.key}`);
+                  allRemoved = removePersistedInventory(localStorage, set.key, canonicalCatalog) && allRemoved;
               }
           }
-          setInventory({}); // Reset current view as well
-          showToast('Inventory for ALL sets has been cleared.');
+          if (allRemoved) {
+              setInventory({}); // Reset current view as well
+              showToast('Inventory for ALL sets has been cleared.');
+          } else {
+              showToast('Inventories could not be cleared while protected persistence is locked.', 'warning');
+          }
       }
       setShowResetModal(false);
   };
@@ -1445,18 +1455,27 @@ export default function App() {
       ) as Record<SetKey, Inventory>;
       const result = applyImportedInventories(current, safeImportData, mode, canonicalCatalog);
       let importedCount = 0;
+      let persistenceBlocked = false;
 
       for (const key of Object.keys(safeImportData) as SetKey[]) {
           if (!knownSetKeys.has(key)) continue;
           const nextInventory = pruneZeros(result.inventories[key] ?? {});
-          importedCount += Object.keys(nextInventory).length;
-          writeSetInv(key, nextInventory);
-          if (key === setKey) setInventory(nextInventory);
+          if (writeSetInv(key, nextInventory)) {
+              importedCount += Object.keys(nextInventory).length;
+              if (key === setKey) setInventory(nextInventory);
+          } else {
+              persistenceBlocked = true;
+          }
       }
       
       setShowImportModal(false);
       setImportData({});
-      showToast(`Applied ${importedCount} canonical card entries in ${mode} mode (${importStats.recognized} recognized, ${importStats.skipped} skipped).`);
+      showToast(
+        persistenceBlocked
+          ? 'Import was not saved while protected persistence is locked.'
+          : `Applied ${importedCount} canonical card entries in ${mode} mode (${importStats.recognized} recognized, ${importStats.skipped} skipped).`,
+        persistenceBlocked ? 'warning' : 'success',
+      );
       setImportStats({ recognized: 0, skipped: 0 });
   };
   

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -628,6 +628,7 @@ export default function App() {
   const [sets, setSets] = useState<SetMeta[]>([]);
   const [setKey, setSetKey] = useState<SetKey>('SOR'); // placeholder until manifest loads (then newest set)
   const searchRef = useRef<HTMLInputElement | null>(null);
+  const submitSearchRef = useRef<() => void>(() => {});
   const importRef = useRef<HTMLInputElement>(null);
   const [showImportModal, setShowImportModal] = useState(false);
   const [importData, setImportData] = useState<Record<SetKey, Inventory>>({});
@@ -1101,6 +1102,8 @@ export default function App() {
     }
     chooseSuggestion(suggestion);
   }
+  submitSearchRef.current = submitSearch;
+
   function selectCardByNumber(baseNum: number) {
     const card = byNumber.get(baseNum);
     if (!card) { 
@@ -1496,7 +1499,7 @@ export default function App() {
       if (e.key === 'Enter' && !typing) {
         if ((query || '').trim()) {
           e.preventDefault();
-          submitSearch();
+          submitSearchRef.current();
         }
         return;
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,7 +26,9 @@ import {
   type ImportResult,
 } from './core/inventory';
 import { createLoadCommitGate } from './core/loadGuard';
+import { readSettings, writeSettings, type AppSettings } from './core/settings';
 import type { ActiveSelection, Card, Inventory, SetKey, SetMeta } from './core/types';
+import { SettingsModal } from './components/SettingsModal';
 
 /** Last entry in `manifest.json` is the newest set (release order). */
 function newestSetKeyFromManifest(list: SetMeta[]): SetKey {
@@ -648,6 +650,10 @@ export default function App() {
   const searchRef = useRef<HTMLInputElement | null>(null);
   const submitSearchRef = useRef<() => void>(() => {});
   const importRef = useRef<HTMLInputElement>(null);
+  const settingsButtonRef = useRef<HTMLButtonElement>(null);
+  const [settings, setSettings] = useState<AppSettings>(() => readSettings(localStorage));
+  const [showSettingsModal, setShowSettingsModal] = useState(false);
+  const closeSettingsModal = useCallback(() => setShowSettingsModal(false), []);
   const [showImportModal, setShowImportModal] = useState(false);
   const [importData, setImportData] = useState<Record<SetKey, Inventory>>({});
   const [importStats, setImportStats] = useState({ recognized: 0, skipped: 0 });
@@ -670,6 +676,14 @@ export default function App() {
   const dismissToast = useCallback((id: number) => {
     setToasts(prev => prev.filter(t => t.id !== id));
   }, []);
+  const changeSettings = useCallback((nextSettings: AppSettings) => {
+    setSettings(nextSettings);
+    try {
+      writeSettings(localStorage, nextSettings);
+    } catch {
+      showToast('Settings could not be saved on this device.', 'error');
+    }
+  }, [showToast]);
 
   // cache parsed data for sets (so we don't refetch repeatedly)
   const parsedCacheRef = useRef<Map<string, ParsedSet>>(new Map());
@@ -1994,6 +2008,17 @@ export default function App() {
               > 
                   <span className="icon" aria-hidden="true">delete</span> <span>Reset</span> 
               </button>
+              <button
+                ref={settingsButtonRef}
+                type="button"
+                className="tbtn"
+                onClick={() => setShowSettingsModal(true)}
+                title="Settings"
+                aria-label="Open settings"
+              >
+                <span className="icon" aria-hidden="true">settings</span>
+                <span>Settings</span>
+              </button>
             </div>
           </div>
 
@@ -2672,6 +2697,13 @@ export default function App() {
           ))}
         </div>
       )}
+      <SettingsModal
+        open={showSettingsModal}
+        settings={settings}
+        onChange={changeSettings}
+        onClose={closeSettingsModal}
+        returnFocusRef={settingsButtonRef}
+      />
     </div>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,11 +32,16 @@ import {
   writeSettings,
   type AppSettings,
 } from './core/settings';
+import {
+  focusedPageForSpread,
+  viewModeAfterSelection,
+  type BinderViewMode,
+} from './core/binderView';
 import type { ActiveSelection, Card, Inventory, SetKey, SetMeta } from './core/types';
 import { LocatorPanel } from './components/LocatorPanel';
 import { SettingsModal } from './components/SettingsModal';
 
-export type BinderViewMode = 'single' | 'spread';
+export type { BinderViewMode } from './core/binderView';
 
 /** Last entry in `manifest.json` is the newest set (release order). */
 function newestSetKeyFromManifest(list: SetMeta[]): SetKey {
@@ -889,9 +894,16 @@ export default function App() {
   const maxNumber = useMemo(() => cardsBase.reduce((m,c)=>Math.max(m,c.Number), 0), [cardsBase]);
   const totalPages = Math.max(1, Math.ceil(maxNumber / 12));
   const totalSpreads = 1 + Math.ceil(Math.max(0, totalPages - 1) / 2);
-  const [viewSpread, setViewSpread] = useState<number>(0); // 0 => Page 1; >=1 => 2/3, 4/5, ...
   const [binderViewMode, setBinderViewMode] = useState<BinderViewMode>('spread');
   const [focusedPage, setFocusedPage] = useState(1);
+  const viewSpread = pageToSpread(focusedPage);
+  const setViewSpread = useCallback<React.Dispatch<React.SetStateAction<number>>>(next => {
+    setFocusedPage(currentPage => {
+      const currentSpread = pageToSpread(currentPage);
+      const requestedSpread = typeof next === 'function' ? next(currentSpread) : next;
+      return focusedPageForSpread(currentPage, requestedSpread, totalPages);
+    });
+  }, [totalPages]);
 
   const binderRef = useRef<HTMLDivElement>(null); 
 
@@ -900,9 +912,8 @@ export default function App() {
     const { spreadCol, spreadRow } = getSpreadCoords(page, row, column);
     setActive({ number: card.Number, card, page, row, column, spreadCol, spreadRow });
     setError('');
-    setViewSpread(pageToSpread(page));
     setFocusedPage(page);
-    setBinderViewMode(forceView ?? (settings.autoOpenSinglePage ? 'single' : binderViewMode));
+    setBinderViewMode(forceView ?? viewModeAfterSelection(settings, binderViewMode));
     setHighlightedRowNumber(card.Number);
 
     window.setTimeout(() => setHighlightedRowNumber(null), 500);
@@ -1218,9 +1229,8 @@ export default function App() {
       spreadCol,
       spreadRow,
     });
-    setViewSpread(pageToSpread(next.page));
     setFocusedPage(next.page);
-  }, [active, totalPages, byNumber, setActive, setViewSpread]);
+  }, [active, totalPages, byNumber, setActive]);
   
 
   const [prevSetKey, nextSetKey] = useMemo(() => {
@@ -1591,52 +1601,11 @@ export default function App() {
           deltaSpread = 1;
         }
         
-        // Handle Page Flip (if active, anchor the selection)
+        // Browsing changes the viewed anchor only; selection and locator remain stable.
         if (deltaSpread !== 0) {
-            const currentSpread = viewSpread;
-            const newSpread = Math.max(0, Math.min(totalSpreads - 1, currentSpread + deltaSpread));
-
-            if (newSpread !== currentSpread) {
-                // If a card is active, calculate its new position
-                if (active) {
-                    // 24 slots per spread (12 cards per page * 2 pages)
-                    const deltaNum = deltaSpread * 24;
-                    const currentNum = active.card.Number;
-                    let newNum = currentNum + deltaNum;
-
-                    // Edge Case: Page 1 (Spread 0) only has 12 slots.
-                    // If moving to spread 0, the minimum number is #1
-                    if (newSpread === 0) {
-                        newNum = Math.max(1, newNum);
-                    }
-                    
-                    // Constrain the number to the set's bounds
-                    const maxSetNum = totalPages * 12;
-                    newNum = Math.min(maxSetNum, newNum);
-
-                    // Find the nearest existing card near the new position (using the number itself is simplest)
-                    const newCard = byNumber.get(newNum) || byNumber.get(Math.max(1, newNum)); // Fallback to #1
-
-                    if (newCard) {
-                        const { page, row, column } = binderLayout(newCard.Number);
-                        const { spreadCol, spreadRow } = getSpreadCoords(page, row, column); // CALCULATE SPREAD COORDS
-                        setActive({ number: newCard.Number, card: newCard, page, row, column, spreadCol, spreadRow }); // PASS SPREAD COORDS
-                    } else {
-                        // If no card exists at the new relative position, select the first card on the new spread
-                        const firstNumOnSpread = newSpread * 24 + 1;
-                        const firstCardOnSpread = byNumber.get(firstNumOnSpread) || byNumber.get(Math.max(1, firstNumOnSpread));
-                        if(firstCardOnSpread) {
-                           const { page, row, column } = binderLayout(firstCardOnSpread.Number);
-                           const { spreadCol, spreadRow } = getSpreadCoords(page, row, column); // CALCULATE SPREAD COORDS
-                           setActive({ number: firstCardOnSpread.Number, card: firstCardOnSpread, page, row, column, spreadCol, spreadRow }); // PASS SPREAD COORDS
-                        } else {
-                           setActive(null); // Clear selection if no card is found
-                        }
-                    }
-                }
-                setViewSpread(newSpread);
-            }
-            return;
+          const newSpread = Math.max(0, Math.min(totalSpreads - 1, viewSpread + deltaSpread));
+          if (newSpread !== viewSpread) setViewSpread(newSpread);
+          return;
         } // End Page Flip Logic
 
         // Card selection movement (Arrow keys) and Qty Adjust
@@ -2066,12 +2035,7 @@ export default function App() {
           viewMode={binderViewMode}
           focusedPage={focusedPage}
           onFocusedPageChange={setFocusedPage}
-          onViewModeChange={mode => {
-            setBinderViewMode(mode);
-            if (mode === 'single') {
-              setFocusedPage(active?.page ?? spreadToPrimaryPage(viewSpread));
-            }
-          }}
+          onViewModeChange={setBinderViewMode}
           onActivateCard={activateCard}
           active={active}
           presentNumbers={presentNumbers}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1603,8 +1603,9 @@ export default function App() {
         
         // Browsing changes the viewed anchor only; selection and locator remain stable.
         if (deltaSpread !== 0) {
-          const newSpread = Math.max(0, Math.min(totalSpreads - 1, viewSpread + deltaSpread));
-          if (newSpread !== viewSpread) setViewSpread(newSpread);
+          setViewSpread(currentSpread => (
+            Math.max(0, Math.min(totalSpreads - 1, currentSpread + deltaSpread))
+          ));
           return;
         } // End Page Flip Logic
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,14 @@ import {
   type SearchCatalog,
   type SearchSuggestion,
 } from './core/search';
+import {
+  applyImportedInventories,
+  canonicalizeInventory,
+  migrateLegacyInventories,
+  quotaForType,
+  type CanonicalCatalog,
+  type ImportResult,
+} from './core/inventory';
 import type { ActiveSelection, Card, Inventory, SetKey, SetMeta } from './core/types';
 
 /** Last entry in `manifest.json` is the newest set (release order). */
@@ -138,11 +146,6 @@ function rarityOutlineForAspectHexes(hexes: string[]): string {
 function rarityGlyph(r?: string) {
   if (!r) return null;
   return RARITY_STYLE[r] ?? null;
-}
-
-function quotaForType(type?: string) {
-  const t = (type || '').toLowerCase();
-  return (t === 'leader' || t === 'base') ? 1 : 3;
 }
 
 /** Collection status for filter pills (same semantics as the Status column: ✓ / ! / ✕). */
@@ -396,29 +399,17 @@ function FilterControls({ filters, setFilters }: FilterControlsProps) {
   );
 }
 
-type CardUtilities = {
-    quotaForType: (type?: string) => number;
-    fullCardIndex: Map<string, { baseNumber: number, type?: string, name: string }>;
-};
-
-/** Shared aggregation used by every CSV/XLSX import format: look up the card, cap to its quota, and accumulate. */
-function addAggregatedCount(
+/** Collect raw printing counts before all import formats use the same canonicalization path. */
+function addRawCount(
   aggregatedData: Record<SetKey, Inventory>,
-  cardUtilities: CardUtilities,
   setKey: string,
   cardNumber: number,
   count: number,
 ) {
-  if (!setKey || !Number.isFinite(cardNumber) || cardNumber <= 0 || count <= 0) return;
-
-  const cardInfo = cardUtilities.fullCardIndex.get(`${setKey}:${String(cardNumber)}`);
-  if (!cardInfo) return;
-
-  const { baseNumber, type } = cardInfo;
-  const max = cardUtilities.quotaForType(type);
+  if (!setKey || !Number.isInteger(cardNumber) || cardNumber <= 0 || !Number.isFinite(count) || count <= 0) return;
 
   const inv = aggregatedData[setKey as SetKey] ?? (aggregatedData[setKey as SetKey] = {});
-  inv[baseNumber] = Math.min((inv[baseNumber] ?? 0) + count, max);
+  inv[cardNumber] = (inv[cardNumber] ?? 0) + count;
 }
 
 function parseCsvContent(fileContent: string): { headers: string[]; rows: string[][] } {
@@ -449,7 +440,7 @@ function parseCsvContent(fileContent: string): { headers: string[]; rows: string
     return { headers, rows };
 }
 
-async function parseXlsxData(file: File, cardUtilities: CardUtilities): Promise<Record<SetKey, Inventory>> {
+async function parseXlsxData(file: File, catalog: CanonicalCatalog): Promise<ImportResult> {
   const aggregatedData: Record<SetKey, Inventory> = {};
 
   const buf = await file.arrayBuffer();
@@ -459,7 +450,7 @@ async function parseXlsxData(file: File, cardUtilities: CardUtilities): Promise<
 
   // Read as rows with header row
   const rows = XLSX.utils.sheet_to_json<Record<string, any>>(sheet, { defval: '' });
-  if (!rows.length) return aggregatedData;
+  if (!rows.length) return applyImportedInventories({}, aggregatedData, 'replace', catalog);
 
   // Normalize header names once
   const norm = (s: string) => s.toLowerCase().replace(/[\s_]+/g, '');
@@ -496,18 +487,17 @@ async function parseXlsxData(file: File, cardUtilities: CardUtilities): Promise<
         if (Number.isFinite(n)) totalCount += n;
       }
     }
-    addAggregatedCount(aggregatedData, cardUtilities, setKey, baseIdNum, totalCount);
+    addRawCount(aggregatedData, setKey, baseIdNum, totalCount);
   }
 
-  return aggregatedData;
+  return applyImportedInventories({}, aggregatedData, 'replace', catalog);
 }
 
 function parseCsvData(
   fileName: string, // kept for signature compatibility; not used for detection
   fileContent: string,
-  cardUtilities: CardUtilities
-): Record<SetKey, Inventory> {
-  const { quotaForType, fullCardIndex } = cardUtilities;
+  catalog: CanonicalCatalog
+): ImportResult {
   const aggregatedData: Record<SetKey, Inventory> = {};
 
   // Parse CSV into headers + rows (rows are string[]; access via indices)
@@ -569,7 +559,7 @@ function parseCsvData(
         if (Number.isFinite(v)) totalCount += v;
       }
 
-      addAggregatedCount(aggregatedData, cardUtilities, setKey, baseIdNum, totalCount);
+      addRawCount(aggregatedData, setKey, baseIdNum, totalCount);
     }
 
   } else if (format === "swudb") {
@@ -592,7 +582,7 @@ function parseCsvData(
       // Strip leading zeros so keys match your index (e.g., "079" -> "79")
       const numericId = Number(cardNumRaw);
 
-      addAggregatedCount(aggregatedData, cardUtilities, setKey, numericId, count);
+      addRawCount(aggregatedData, setKey, numericId, count);
     }
 
   } else {
@@ -602,17 +592,11 @@ function parseCsvData(
       if (raw?.version === 1 && raw?.sets) {
         const jsonSets = raw.sets as Record<SetKey, Record<string, number>>;
         for (const k of Object.keys(jsonSets) as SetKey[]) {
-          if (!aggregatedData[k]) aggregatedData[k] = {};
           for (const [numStr, count] of Object.entries(jsonSets[k])) {
-            const baseNumber = Number(numStr);
-            if (!Number.isFinite(baseNumber)) continue;
-
-            const card = fullCardIndex.get(`${k}:${numStr}`);
-            const max = card ? quotaForType(card.type) : 3;
-            aggregatedData[k][baseNumber] = Math.min(Number(count) || 0, max);
+            addRawCount(aggregatedData, k, Number(numStr), Number(count));
           }
         }
-        return aggregatedData;
+        return applyImportedInventories({}, aggregatedData, 'replace', catalog);
       }
     } catch {
       // not JSON; fall through
@@ -621,17 +605,45 @@ function parseCsvData(
     throw new Error("File format not recognized. Expected a SWUDB or SW-Unlimited CSV (or a valid app JSON export).");
   }
 
-  return aggregatedData;
+  return applyImportedInventories({}, aggregatedData, 'replace', catalog);
+}
+
+type ParsedSet = {
+  key: SetKey;
+  allCards: Card[];
+  baseCards: Card[];
+  byNumber: Map<number, Card>;
+  baseToAll: Map<number, number[]>;
+  altToBase: Map<number, number>;
+};
+
+function canonicalCatalogFromParsedSets(parsedSets: Iterable<ParsedSet>): CanonicalCatalog {
+  const catalog: CanonicalCatalog = new Map();
+  for (const parsed of parsedSets) {
+    for (const card of parsed.allCards) {
+      const baseNumber = parsed.altToBase.get(card.Number) ?? card.Number;
+      const baseCard = parsed.byNumber.get(baseNumber);
+      catalog.set(`${parsed.key}:${card.Number}`, {
+        setKey: parsed.key,
+        printingNumber: card.Number,
+        baseNumber,
+        type: baseCard?.Type ?? card.Type,
+      });
+    }
+  }
+  return catalog;
 }
 
 export default function App() {
   const [sets, setSets] = useState<SetMeta[]>([]);
   const [setKey, setSetKey] = useState<SetKey>('SOR'); // placeholder until manifest loads (then newest set)
+  const setKeys = useMemo(() => sets.map(set => set.key as SetKey), [sets]);
   const searchRef = useRef<HTMLInputElement | null>(null);
   const submitSearchRef = useRef<() => void>(() => {});
   const importRef = useRef<HTMLInputElement>(null);
   const [showImportModal, setShowImportModal] = useState(false);
   const [importData, setImportData] = useState<Record<SetKey, Inventory>>({});
+  const [importStats, setImportStats] = useState({ recognized: 0, skipped: 0 });
   const [importingFileName, setImportingFileName] = useState('');
   const [showResetModal, setShowResetModal] = useState(false);
   const [listView, setListView] = React.useState<'inventory' | 'missing'>('inventory');
@@ -653,15 +665,8 @@ export default function App() {
   }, []);
 
   // cache parsed data for sets (so we don't refetch repeatedly)
-  type ParsedSet = {
-    key: SetKey;
-    allCards: Card[];                // All cards (unique by Number)
-    baseCards: Card[];               // Base cards (unique by Name+Subtitle+Type)
-    byNumber: Map<number, Card>;     // Map<BaseNumber, BaseCard>
-    baseToAll: Map<number, number[]>;
-    altToBase: Map<number, number>;
-  };
   const parsedCacheRef = useRef<Map<string, ParsedSet>>(new Map());
+  const [canonicalCatalog, setCanonicalCatalog] = useState<CanonicalCatalog>(new Map());
 
   useEffect(() => {
     fetch('/sets/manifest.json')
@@ -779,13 +784,12 @@ export default function App() {
 
   // Inventory
   const [inventory, setInventory] = useState<Inventory>({});
+  const [inventoryReadyForSet, setInventoryReadyForSet] = useState<SetKey | null>(null);
   useEffect(() => {
-    const raw = localStorage.getItem(`inv:${setKey}`);
-    try { setInventory(raw ? JSON.parse(raw) : {}); } catch { setInventory({}); }
-  }, [setKey]);
-  useEffect(() => {
-    localStorage.setItem(`inv:${setKey}`, JSON.stringify(inventory));
-  }, [inventory, setKey]);
+    if (inventoryReadyForSet === setKey) {
+      localStorage.setItem(`inv:${setKey}`, JSON.stringify(inventory));
+    }
+  }, [inventory, inventoryReadyForSet, setKey]);
   const pruneZeros = (inv: Inventory) =>
     Object.fromEntries(Object.entries(inv).filter(([,q]) => (q as number) > 0)) as Inventory;
   useEffect(() => {
@@ -986,6 +990,7 @@ export default function App() {
         setError(''); 
         setActive(null); 
         setViewSpread(0); 
+        setInventoryReadyForSet(null);
 
         const meta = sets.find(s => s.key === setKey);
         if (!meta) return;
@@ -1000,16 +1005,37 @@ export default function App() {
             .map(parseAndCache)
         );
 
+        const catalog = canonicalCatalogFromParsedSets(parsedCacheRef.current.values());
+        setCanonicalCatalog(catalog);
+
+        let migratedInventories: Record<SetKey, Inventory>;
+        try {
+          migratedInventories = migrateLegacyInventories(localStorage, setKeys, catalog);
+        } catch {
+          migratedInventories = Object.fromEntries(setKeys.map(key => {
+            let parsedInventory: Inventory = {};
+            try {
+              parsedInventory = JSON.parse(localStorage.getItem(`inv:${key}`) || '{}') as Inventory;
+            } catch {
+              // Recover the valid sets even when one stored record is malformed.
+            }
+            return [key, canonicalizeInventory(key, parsedInventory, catalog)];
+          })) as Record<SetKey, Inventory>;
+          showToast('Inventory migration could not be saved. Your original backup was preserved.', 'warning');
+        }
+
         // 3. Update the state for the current view
         setCardsAll(currentSetData.allCards);
         setCardsBase(currentSetData.baseCards);
         setBaseToAll(currentSetData.baseToAll);
+        setInventory(migratedInventories[setKey] ?? {});
+        setInventoryReadyForSet(setKey);
 
         // REMOVED: Deferred navigation logic (moved to a new hook below)
       }
       load().catch(() => setError('Failed to load set data.'));
     // Dependencies only include set changes (NO pendingSelection)
-    }, [setKey, sets]);
+    }, [setKey, sets, setKeys, showToast]);
 
     // Deferred Navigation Hook: Runs after new set data is loaded
     useEffect(() => {
@@ -1154,7 +1180,6 @@ export default function App() {
     setViewSpread(pageToSpread(next.page));
   }, [active, totalPages, byNumber, setActive, setViewSpread]);
   
-  const setKeys = useMemo(() => sets.map(s => s.key as SetKey), [sets]);
 
   const [prevSetKey, nextSetKey] = useMemo(() => {
       const currentIndex = sets.findIndex(s => s.key === setKey);
@@ -1192,25 +1217,41 @@ export default function App() {
   type InventoryAll = { version: 1; sets: Record<SetKey, Inventory> };
 
   function readSetInv(k: SetKey): Inventory {
-    try { return JSON.parse(localStorage.getItem(`inv:${k}`) || '{}'); }
+    try {
+      return canonicalizeInventory(
+        k,
+        JSON.parse(localStorage.getItem(`inv:${k}`) || '{}') as Inventory,
+        canonicalCatalog,
+      );
+    }
     catch { return {}; }
   }
   function writeSetInv(k: SetKey, inv: Inventory) {
-    localStorage.setItem(`inv:${k}`, JSON.stringify(inv));
+    localStorage.setItem(`inv:${k}`, JSON.stringify(canonicalizeInventory(k, inv, canonicalCatalog)));
+  }
+  function canonicalBaseNumber(set: SetKey, printingNumber: number): number | null {
+    return canonicalCatalog.get(`${set}:${printingNumber}`)?.baseNumber ?? null;
   }
   function inc(n: number) {
-    const c = byNumber.get(n) || cardsAll.find(x => x.Number === n);
-    const max = quotaForType(c?.Type);
-    setInventory(prev => ({ ...prev, [n]: Math.min((prev[n] || 0) + 1, max) }));
+    const baseNumber = canonicalBaseNumber(setKey, n);
+    if (baseNumber === null) return;
+    const ref = canonicalCatalog.get(`${setKey}:${baseNumber}`);
+    const max = quotaForType(ref?.type);
+    setInventory(prev => ({
+      ...prev,
+      [baseNumber]: Math.min((prev[baseNumber] || 0) + 1, max),
+    }));
   }
   function dec(n: number) {
+    const baseNumber = canonicalBaseNumber(setKey, n);
+    if (baseNumber === null) return;
     setInventory(prev => {
-      const next = Math.max((prev[n] || 0) - 1, 0);
+      const next = Math.max((prev[baseNumber] || 0) - 1, 0);
       if (next === 0) {
-        const { [n]: _removed, ...rest } = prev; // drop the key entirely
+        const { [baseNumber]: _removed, ...rest } = prev; // drop the key entirely
         return rest;
       }
-      return { ...prev, [n]: next };
+      return { ...prev, [baseNumber]: next };
     });
   }
   function exportAllInv() {
@@ -1367,10 +1408,10 @@ export default function App() {
           setInventory({});
           showToast(`Inventory for the current set (${setKey}) has been cleared.`);
       } else if (scope === 'all') {
-          // Iterate over all keys in localStorage and remove those that start with 'inv:'
+          // Clear set inventories without deleting the migration backup or schema marker.
           if (!sets.length) {
               for (const key of Object.keys(localStorage)) {
-                  if (key.startsWith('inv:')) {
+                  if (/^inv:[A-Z0-9]+$/.test(key)) {
                       localStorage.removeItem(key);
                   }
               }
@@ -1391,50 +1432,21 @@ export default function App() {
   }
 
   const applyImport = (mode: 'merge' | 'replace') => {
+      const current = Object.fromEntries(setKeys.map(key => [key, readSetInv(key)])) as Record<SetKey, Inventory>;
+      const result = applyImportedInventories(current, importData, mode, canonicalCatalog);
       let importedCount = 0;
-      
-      for (const [key, importedInv] of Object.entries(importData)) {
-          if (!key || Object.keys(importedInv).length === 0) continue;
 
-          const currentInv = readSetInv(key);
-          const newInv: Inventory = {};
-
-          // Start with current inventory if merging
-          if (mode === 'merge') {
-              Object.assign(newInv, currentInv);
-          }
-
-          // Apply imported counts (already capped to max in parseCsvData)
-          for (const [baseNumberStr, newCount] of Object.entries(importedInv)) {
-              const baseNumber = Number(baseNumberStr);
-              const currentCount = newInv[baseNumber] || 0;
-              
-              // Get max quota for final cap check (necessary because the card type needs context)
-              const card = cardsAll.find(c => c.Number === baseNumber && c.Set === key);
-              const max = quotaForType(card?.Type);
-              
-              const updatedCount = mode === 'merge' 
-                  ? Math.min(newCount + currentCount, max) 
-                  : Math.min(newCount, max);
-
-              if (updatedCount > 0) {
-                  newInv[baseNumber] = updatedCount;
-                  importedCount++;
-              } else if (newInv[baseNumber]) {
-                  delete newInv[baseNumber];
-              }
-          }
-          
-          writeSetInv(key, pruneZeros(newInv));
-
-          if (key === setKey) {
-              setInventory(pruneZeros(newInv));
-          }
+      for (const key of Object.keys(importData) as SetKey[]) {
+          const nextInventory = pruneZeros(result.inventories[key] ?? {});
+          importedCount += Object.keys(nextInventory).length;
+          writeSetInv(key, nextInventory);
+          if (key === setKey) setInventory(nextInventory);
       }
       
       setShowImportModal(false);
       setImportData({});
-      showToast(`Successfully applied import of ${importedCount} card entries in ${mode} mode.`);
+      showToast(`Applied ${importedCount} canonical card entries in ${mode} mode (${importStats.recognized} recognized, ${importStats.skipped} skipped).`);
+      setImportStats({ recognized: 0, skipped: 0 });
   };
   
   // File change handler to parse the file and open the modal
@@ -1448,26 +1460,14 @@ export default function App() {
       try {
           const ext = file.name.split('.').pop()?.toLowerCase();
           
-          const fullCardIndex = new Map<string, { baseNumber: number, type?: string, name: string }>();
-          const allSetCards: Card[] = Array.from(parsedCacheRef.current.values()).flatMap(p => p.allCards);
-
-          // Populate the lookup map with normalized data needed for parsing/capping
-          for (const card of allSetCards) {
-              const baseNum = card.Number; 
-              fullCardIndex.set(`${card.Set}:${card.Number}`, {
-                  baseNumber: baseNum,
-                  type: card.Type,
-                  name: card.Name
-              });
-          }
+          if (canonicalCatalog.size === 0) throw new Error('Card catalog is still loading. Please try again.');
           
-          const cardUtilities: CardUtilities = { quotaForType, fullCardIndex };
-          
-          const parsedInventory =
+          const parsedImport =
             ext === 'xlsx'
-              ? await parseXlsxData(file, cardUtilities)  // ← new XLSX path
-              : parseCsvData(file.name, await file.text(), cardUtilities); // existing CSV/JSON path
-          setImportData(parsedInventory);
+              ? await parseXlsxData(file, canonicalCatalog)
+              : parseCsvData(file.name, await file.text(), canonicalCatalog);
+          setImportData(parsedImport.inventories);
+          setImportStats({ recognized: parsedImport.recognized, skipped: parsedImport.skipped });
           setShowImportModal(true);
       } catch (e) {
           setError(`Import failed: ${e instanceof Error ? e.message : 'Invalid file format.'}`);
@@ -1632,13 +1632,12 @@ export default function App() {
     for (const baseCard of cardsBase) {
       if (!passesAllFilters(baseCard)) continue;
       const baseNum = baseCard.Number;
-      const nums = baseToAll.get(baseNum) || [baseNum];
-      const have = nums.reduce((sum, n) => sum + (inventory[n] || 0), 0);
+      const have = inventory[baseNum] || 0;
       const max = quotaForType(baseCard.Type);
       if (have < max) return true;
     }
     return false;
-  }, [cardsBase, baseToAll, inventory, passesAllFilters]);
+  }, [cardsBase, inventory, passesAllFilters]);
 
   // Build ONE list over base cards, then partition.
   // Each row has Qty (across base + alts), Max, Needed, and other fields you already use.
@@ -1659,8 +1658,7 @@ export default function App() {
       if (!passesAllFilters(baseCard)) continue;
 
       const baseNum = baseCard.Number;
-      const nums = baseToAll.get(baseNum) || [baseNum]; // base + alts
-      const have = nums.reduce((sum, n) => sum + (inventory[n] || 0), 0);
+      const have = inventory[baseNum] || 0;
       const max = quotaForType(baseCard.Type);
       const needed = Math.max(0, max - have);
       const collStatus = collectionStatusFromQty(have, max);
@@ -1680,7 +1678,7 @@ export default function App() {
     }
 
     return rows.sort((a, b) => a.Number - b.Number);
-  }, [cardsBase, baseToAll, inventory, passesAllFilters, filters.status]);
+  }, [cardsBase, inventory, passesAllFilters, filters.status]);
 
   // Projections for the two tabs (shape-compatible with your tables)
   const filteredInvRows = useMemo(() => {
@@ -2426,6 +2424,9 @@ export default function App() {
                   <h2 style={{ marginTop: 0, color: '#e5e7eb' }}>Import Options</h2>
                   <p style={{ opacity: 0.8, marginBottom: 20 }}>
                       You are importing data from <strong>{importingFileName}</strong>, which contains entries for {Object.keys(importData).length} set(s).
+                  </p>
+                  <p className="muted" style={{ marginTop: -12, marginBottom: 16 }}>
+                    {plural(importStats.recognized, 'recognized entry')} · {plural(importStats.skipped, 'skipped entry')}
                   </p>
                   {/* Overview of what will be imported per set */}
                   {importOverview.length > 0 ? (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,11 +17,13 @@ import {
 import {
   applyImportedInventories,
   canonicalizeInventory,
-  migrateLegacyInventories,
+  collectRawImportEntry,
+  loadInventoriesForPersistence,
   quotaForType,
   type CanonicalCatalog,
   type ImportResult,
 } from './core/inventory';
+import { createLoadCommitGate } from './core/loadGuard';
 import type { ActiveSelection, Card, Inventory, SetKey, SetMeta } from './core/types';
 
 /** Last entry in `manifest.json` is the newest set (release order). */
@@ -402,14 +404,20 @@ function FilterControls({ filters, setFilters }: FilterControlsProps) {
 /** Collect raw printing counts before all import formats use the same canonicalization path. */
 function addRawCount(
   aggregatedData: Record<SetKey, Inventory>,
-  setKey: string,
-  cardNumber: number,
-  count: number,
-) {
-  if (!setKey || !Number.isInteger(cardNumber) || cardNumber <= 0 || !Number.isFinite(count) || count <= 0) return;
+  setKey: unknown,
+  cardNumber: unknown,
+  count: unknown,
+): boolean {
+  return collectRawImportEntry(aggregatedData, setKey, cardNumber, count);
+}
 
-  const inv = aggregatedData[setKey as SetKey] ?? (aggregatedData[setKey as SetKey] = {});
-  inv[cardNumber] = (inv[cardNumber] ?? 0) + count;
+function normalizedImportResult(
+  raw: Record<SetKey, Inventory>,
+  catalog: CanonicalCatalog,
+  malformedSkipped: number,
+): ImportResult {
+  const result = applyImportedInventories({}, raw, 'replace', catalog);
+  return { ...result, skipped: result.skipped + malformedSkipped };
 }
 
 function parseCsvContent(fileContent: string): { headers: string[]; rows: string[][] } {
@@ -440,8 +448,9 @@ function parseCsvContent(fileContent: string): { headers: string[]; rows: string
     return { headers, rows };
 }
 
-async function parseXlsxData(file: File, catalog: CanonicalCatalog): Promise<ImportResult> {
+export async function parseXlsxData(file: File, catalog: CanonicalCatalog): Promise<ImportResult> {
   const aggregatedData: Record<SetKey, Inventory> = {};
+  let malformedSkipped = 0;
 
   const buf = await file.arrayBuffer();
   const wb = XLSX.read(buf, { type: 'array' });
@@ -450,7 +459,7 @@ async function parseXlsxData(file: File, catalog: CanonicalCatalog): Promise<Imp
 
   // Read as rows with header row
   const rows = XLSX.utils.sheet_to_json<Record<string, any>>(sheet, { defval: '' });
-  if (!rows.length) return applyImportedInventories({}, aggregatedData, 'replace', catalog);
+  if (!rows.length) return normalizedImportResult(aggregatedData, catalog, malformedSkipped);
 
   // Normalize header names once
   const norm = (s: string) => s.toLowerCase().replace(/[\s_]+/g, '');
@@ -470,8 +479,6 @@ async function parseXlsxData(file: File, catalog: CanonicalCatalog): Promise<Imp
   for (const r of rows) {
     const setKey = String(r[col('Set', r)] ?? '').trim().toUpperCase() as SetKey;
     const baseIdNum = Number(r[col('Base card id', r)]);
-    if (!setKey || !Number.isFinite(baseIdNum) || baseIdNum <= 0) continue;
-
     // Sum all variant columns starting at "Normal" through the end of the row.
     // We’ll include common known alt headers if present.
     const ALT_HEADERS = [
@@ -487,18 +494,19 @@ async function parseXlsxData(file: File, catalog: CanonicalCatalog): Promise<Imp
         if (Number.isFinite(n)) totalCount += n;
       }
     }
-    addRawCount(aggregatedData, setKey, baseIdNum, totalCount);
+    if (!addRawCount(aggregatedData, setKey, baseIdNum, totalCount)) malformedSkipped += 1;
   }
 
-  return applyImportedInventories({}, aggregatedData, 'replace', catalog);
+  return normalizedImportResult(aggregatedData, catalog, malformedSkipped);
 }
 
-function parseCsvData(
+export function parseCsvData(
   fileName: string, // kept for signature compatibility; not used for detection
   fileContent: string,
   catalog: CanonicalCatalog
 ): ImportResult {
   const aggregatedData: Record<SetKey, Inventory> = {};
+  let malformedSkipped = 0;
 
   // Parse CSV into headers + rows (rows are string[]; access via indices)
   const { headers, rows } = parseCsvContent(fileContent);
@@ -551,15 +559,13 @@ function parseCsvData(
       const setKey = rawSet.toUpperCase() as SetKey;
 
       const baseIdNum = Number(row[idCol]);
-      if (!setKey || !Number.isFinite(baseIdNum) || baseIdNum <= 0) continue;
-
       let totalCount = 0;
       for (let i = normalCol; i < row.length; i++) {
         const v = Number(row[i]);
         if (Number.isFinite(v)) totalCount += v;
       }
 
-      addRawCount(aggregatedData, setKey, baseIdNum, totalCount);
+      if (!addRawCount(aggregatedData, setKey, baseIdNum, totalCount)) malformedSkipped += 1;
     }
 
   } else if (format === "swudb") {
@@ -576,13 +582,12 @@ function parseCsvData(
       const setKey = (row[setCol] ?? "").toString().trim().toUpperCase() as SetKey;
 
       const cardNumRaw = (row[numCol] ?? "").toString().trim();
-      const count = Number(row[countCol]) || 0;
-      if (!setKey || cardNumRaw === "" || count <= 0) continue;
+      const count = Number(row[countCol]);
 
       // Strip leading zeros so keys match your index (e.g., "079" -> "79")
       const numericId = Number(cardNumRaw);
 
-      addRawCount(aggregatedData, setKey, numericId, count);
+      if (!addRawCount(aggregatedData, setKey, numericId, count)) malformedSkipped += 1;
     }
 
   } else {
@@ -593,10 +598,10 @@ function parseCsvData(
         const jsonSets = raw.sets as Record<SetKey, Record<string, number>>;
         for (const k of Object.keys(jsonSets) as SetKey[]) {
           for (const [numStr, count] of Object.entries(jsonSets[k])) {
-            addRawCount(aggregatedData, k, Number(numStr), Number(count));
+            if (!addRawCount(aggregatedData, k, numStr, count)) malformedSkipped += 1;
           }
         }
-        return applyImportedInventories({}, aggregatedData, 'replace', catalog);
+        return normalizedImportResult(aggregatedData, catalog, malformedSkipped);
       }
     } catch {
       // not JSON; fall through
@@ -605,7 +610,7 @@ function parseCsvData(
     throw new Error("File format not recognized. Expected a SWUDB or SW-Unlimited CSV (or a valid app JSON export).");
   }
 
-  return applyImportedInventories({}, aggregatedData, 'replace', catalog);
+  return normalizedImportResult(aggregatedData, catalog, malformedSkipped);
 }
 
 type ParsedSet = {
@@ -666,6 +671,7 @@ export default function App() {
 
   // cache parsed data for sets (so we don't refetch repeatedly)
   const parsedCacheRef = useRef<Map<string, ParsedSet>>(new Map());
+  const loadCommitGateRef = useRef(createLoadCommitGate());
   const [canonicalCatalog, setCanonicalCatalog] = useState<CanonicalCatalog>(new Map());
 
   useEffect(() => {
@@ -902,6 +908,7 @@ export default function App() {
 
   // Load set JSON
     useEffect(() => {
+      const loadToken = loadCommitGateRef.current.begin();
       // Helper function defined inside useEffect to access local scope functions (like baseOnly)
       const parseAndCache = async (meta: SetMeta): Promise<ParsedSet> => {
         // Check cache first
@@ -1004,36 +1011,35 @@ export default function App() {
             .filter(s => s.key !== setKey)
             .map(parseAndCache)
         );
+        if (!loadCommitGateRef.current.canCommit(loadToken)) return;
 
         const catalog = canonicalCatalogFromParsedSets(parsedCacheRef.current.values());
-        setCanonicalCatalog(catalog);
+        const loadedInventory = loadInventoriesForPersistence(localStorage, setKeys, catalog);
+        if (!loadCommitGateRef.current.canCommit(loadToken)) return;
 
-        let migratedInventories: Record<SetKey, Inventory>;
-        try {
-          migratedInventories = migrateLegacyInventories(localStorage, setKeys, catalog);
-        } catch {
-          migratedInventories = Object.fromEntries(setKeys.map(key => {
-            let parsedInventory: Inventory = {};
-            try {
-              parsedInventory = JSON.parse(localStorage.getItem(`inv:${key}`) || '{}') as Inventory;
-            } catch {
-              // Recover the valid sets even when one stored record is malformed.
-            }
-            return [key, canonicalizeInventory(key, parsedInventory, catalog)];
-          })) as Record<SetKey, Inventory>;
-          showToast('Inventory migration could not be saved. Your original backup was preserved.', 'warning');
+        if (!loadedInventory.migrationSucceeded) {
+          showToast(
+            loadedInventory.backupPreserved
+              ? 'Inventory migration could not finish. Your original backup remains preserved.'
+              : 'Inventory migration could not create a backup. Automatic saving is disabled to protect your original data.',
+            'warning',
+          );
         }
 
         // 3. Update the state for the current view
+        setCanonicalCatalog(catalog);
         setCardsAll(currentSetData.allCards);
         setCardsBase(currentSetData.baseCards);
         setBaseToAll(currentSetData.baseToAll);
-        setInventory(migratedInventories[setKey] ?? {});
-        setInventoryReadyForSet(setKey);
+        setInventory(loadedInventory.inventories[setKey] ?? {});
+        setInventoryReadyForSet(loadedInventory.persistenceAllowed ? setKey : null);
 
         // REMOVED: Deferred navigation logic (moved to a new hook below)
       }
-      load().catch(() => setError('Failed to load set data.'));
+      load().catch(() => {
+        if (loadCommitGateRef.current.canCommit(loadToken)) setError('Failed to load set data.');
+      });
+      return () => loadCommitGateRef.current.cancel(loadToken);
     // Dependencies only include set changes (NO pendingSelection)
     }, [setKey, sets, setKeys, showToast]);
 
@@ -1433,10 +1439,15 @@ export default function App() {
 
   const applyImport = (mode: 'merge' | 'replace') => {
       const current = Object.fromEntries(setKeys.map(key => [key, readSetInv(key)])) as Record<SetKey, Inventory>;
-      const result = applyImportedInventories(current, importData, mode, canonicalCatalog);
+      const knownSetKeys = new Set(setKeys);
+      const safeImportData = Object.fromEntries(
+        Object.entries(importData).filter(([key]) => knownSetKeys.has(key)),
+      ) as Record<SetKey, Inventory>;
+      const result = applyImportedInventories(current, safeImportData, mode, canonicalCatalog);
       let importedCount = 0;
 
-      for (const key of Object.keys(importData) as SetKey[]) {
+      for (const key of Object.keys(safeImportData) as SetKey[]) {
+          if (!knownSetKeys.has(key)) continue;
           const nextInventory = pruneZeros(result.inventories[key] ?? {});
           importedCount += Object.keys(nextInventory).length;
           writeSetInv(key, nextInventory);
@@ -1466,7 +1477,11 @@ export default function App() {
             ext === 'xlsx'
               ? await parseXlsxData(file, canonicalCatalog)
               : parseCsvData(file.name, await file.text(), canonicalCatalog);
-          setImportData(parsedImport.inventories);
+          const knownSetKeys = new Set(setKeys);
+          const safeInventories = Object.fromEntries(
+            Object.entries(parsedImport.inventories).filter(([key]) => knownSetKeys.has(key)),
+          ) as Record<SetKey, Inventory>;
+          setImportData(safeInventories);
           setImportStats({ recognized: parsedImport.recognized, skipped: parsedImport.skipped });
           setShowImportModal(true);
       } catch (e) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,12 @@ import {
   pageToSpread,
   spreadToPrimaryPage,
 } from './core/binder';
+import {
+  buildSearchSuggestions,
+  submittedSuggestion,
+  type SearchCatalog,
+  type SearchSuggestion,
+} from './core/search';
 import type { ActiveSelection, Card, Inventory, SetKey, SetMeta } from './core/types';
 
 /** Last entry in `manifest.json` is the newest set (release order). */
@@ -683,10 +689,6 @@ export default function App() {
   const [cardsBase, setCardsBase] = useState<Card[]>([]);   // base printing per Name (lowest Number)
   // alt maps for search: baseNumber -> all numbers (base first), altNumber -> baseNumber
   const [baseToAll, setBaseToAll] = useState<Map<number, number[]>>(new Map());
-  const [altToBase, setAltToBase] = useState<Map<number, number>>(new Map());
-
-  // Normalization function for search
-  const norm = (s: string) => s.toLowerCase().replace(/[^a-z0-9]/g, '');
 
   // Rarity normalization
   function normalizeRarity(r: any): string | undefined {
@@ -773,7 +775,6 @@ export default function App() {
 
   // Quick lookups
   const byNumber = useMemo(() => new Map(cardsBase.map(c => [c.Number, c])), [cardsBase]);
-  const baseByName = useMemo(() => new Map(cardsBase.map(c => [c.Name, c])), [cardsBase]);
 
   // Inventory
   const [inventory, setInventory] = useState<Inventory>({});
@@ -807,7 +808,10 @@ export default function App() {
   const [active, setActive] = useState<ActiveSelection | null>(null);
 
   // NEW: State to hold card details for selection after a set switch
-  const [pendingSelection, setPendingSelection] = useState<{ name: string; number: number } | null>(null);
+  const [pendingSelection, setPendingSelection] = useState<{
+    setKey: SetKey;
+    baseNumber: number;
+  } | null>(null);
 
   const [showHelpModal, setShowHelpModal] = useState(false); 
 
@@ -999,7 +1003,6 @@ export default function App() {
         setCardsAll(currentSetData.allCards);
         setCardsBase(currentSetData.baseCards);
         setBaseToAll(currentSetData.baseToAll);
-        setAltToBase(currentSetData.altToBase);
 
         // REMOVED: Deferred navigation logic (moved to a new hook below)
       }
@@ -1010,25 +1013,25 @@ export default function App() {
     // Deferred Navigation Hook: Runs after new set data is loaded
     useEffect(() => {
       // Only run if there is a pending card AND the current set data has loaded cards
-      if (pendingSelection && cardsBase.length > 0) {
+      if (
+        pendingSelection &&
+        pendingSelection.setKey === setKey &&
+        cardsBase.length > 0 &&
+        cardsBase.some(card => card.Set === setKey)
+      ) {
           // IMPORTANT: Clear any previous error before attempting the new lookup
           setError(''); 
 
           // Find the base card in the newly loaded set
-          const card = cardsBase.find(c => 
-              c.Number === pendingSelection.number && c.Name === pendingSelection.name
-          );
+          const card = cardsBase.find(c => c.Number === pendingSelection.baseNumber);
 
           if (card) {
-              const { page, row, column } = binderLayout(card.Number);
-              const { spreadCol, spreadRow } = getSpreadCoords(page, row, column);
-              setActive({ number: card.Number, card, page, row, column, spreadCol, spreadRow });
-              setViewSpread(pageToSpread(page));
+              selectCardByNumber(pendingSelection.baseNumber);
               // Clear query so search bar looks clean after selection
               setQuery('');
           } else {
               // Only set an error if the card truly cannot be found in the loaded set
-              setError(`Failed to find card #${pendingSelection.number} in set ${setKey}.`);
+              setError(`Failed to find card #${pendingSelection.baseNumber} in set ${setKey}.`);
           }
           
           // Always clear the pending state after attempting selection
@@ -1046,119 +1049,24 @@ export default function App() {
     return m;
   }, [cardsBase]);
 
-  // Suggestions (name or number)
-    type Suggestion = { 
-      kind: 'name' | 'number'; 
-      label: string; 
-      number: number; 
-      name: string; 
-      setKey: SetKey;
-      subtitle?: string;
-      type?: string;
-    };
-    const suggestions: Suggestion[] = useMemo(() => {
-      const raw = query.trim();
-      if (!raw) return [];
-      
-      const isDigits = /^[0-9]+$/.test(raw);
-      const qnorm = raw.replace(/^0+/, '') || '0';
-      const lower = norm(raw);
-      
-      // 1. Collect all Number Matches (Exact Base Number Match OR Alt-Art Match)
-      const qNum = Number(qnorm);
-      // Change to track uniqueness by "SetKey:Number"
-      const uniqueNumMatches = new Set<string>(); 
-      const numberMatches: Suggestion[] = [];
-      
-      if (isDigits) {
-          // Iterate over all sets to find exact Base Number or Alt-Art matches
-          for (const [key, parsed] of parsedCacheRef.current.entries()) {
-            
-            let targetBaseNum = 0;
-
-            // Check 1: Exact Base Number Match
-            if (parsed.byNumber.has(qNum)) {
-                targetBaseNum = qNum;
-            } 
-            // Check 2: Alt-Art Number Match
-            else if (parsed.altToBase.has(qNum)) {
-                targetBaseNum = parsed.altToBase.get(qNum)!;
-            }
-
-            if (targetBaseNum > 0) {
-                const baseCard = parsed.byNumber.get(targetBaseNum)!; // Card must exist if the number was found
-                const uniqueKey = `${key}:${baseCard.Number}`;
-                
-                // Ensure we haven't already added this base card from this set
-                if (!uniqueNumMatches.has(uniqueKey)) {
-                    uniqueNumMatches.add(uniqueKey);
-
-                    const suggestion: Suggestion = {
-                        kind: 'number' as const,
-                        name: baseCard.Name,
-                        number: baseCard.Number,
-                        type: baseCard.Type || '',
-                        setKey: key, 
-                        subtitle: baseCard.Subtitle,
-                        label: `${baseCard.Name}${baseCard.Subtitle ? ` - ${baseCard.Subtitle}` : ''} — #${baseCard.Number} (${key})`,
-                    };
-
-                    // Prioritize current set by putting its match at the front of the list
-                    if (key === setKey) {
-                        numberMatches.unshift(suggestion);
-                    } else {
-                        numberMatches.push(suggestion);
-                    }
-                }
-            }
-          }
-      }
-      
-      // 2. Collect all Name Matches (for both numeric and non-numeric queries)
-      // This handles "HK-47" and general name searches.
-      const nameMatches: Suggestion[] = [];
-      const nameMatchBaseNums = new Set<number>(numberMatches.map(s => s.number)); // Exclude cards already found by exact number match
-
-      // Search all sets for name matches
-      for (const [key, parsed] of parsedCacheRef.current.entries()) {
-        const hits = parsed.baseCards
-          .map(c => ({ 
-            c, 
-            // Check if name or subtitle contains the query (using normalized strings)
-            idx: norm(c.Name).indexOf(lower),
-            subIdx: c.Subtitle ? norm(c.Subtitle).indexOf(lower) : -1,
-          }))
-          // Filter: at least one name/subtitle match AND card number not already added by exact number match
-          .filter(o => (o.idx >= 0 || o.subIdx >= 0) && !nameMatchBaseNums.has(o.c.Number))
-          // Sort: by earliest match index (Name before Subtitle) then by Name
-          .sort((a,b) => {
-              const aIdx = a.idx >= 0 ? a.idx : a.subIdx;
-              const bIdx = b.idx >= 0 ? b.idx : b.subIdx;
-              return aIdx - bIdx || a.c.Name.localeCompare(b.c.Name);
-          })
-          .map(o => ({ 
-            kind: 'name' as const, 
-            name: o.c.Name, 
-            number: o.c.Number, 
-            type: o.c.Type,
-            setKey: key,
-            subtitle: o.c.Subtitle,
-            label: `${o.c.Name}${o.c.Subtitle ? ` - ${o.c.Subtitle}` : ''} — #${o.c.Number} (${key})`,
-          }));
-          
-          // Prioritize current set's name matches over others
-          if (key === setKey) {
-            nameMatches.unshift(...hits);
-          } else {
-            nameMatches.push(...hits);
-          }
-      }
-      
-      // 3. Merge: Exact Number matches first, then Name matches
-      return [...numberMatches, ...nameMatches].slice(0, 10);
-
-    }, [query, setKey, norm]);
-
+  // Suggestions retain the exact set and base-card identity selected by the user.
+  const searchCatalogs: SearchCatalog[] = useMemo(
+    () =>
+      Array.from(parsedCacheRef.current.entries()).map(([catalogSetKey, parsed]) => ({
+        setKey: catalogSetKey,
+        cards: parsed.baseCards,
+        printingNumbersByBase: parsed.baseToAll,
+        baseByPrintingNumber: new Map([
+          ...parsed.baseCards.map(card => [card.Number, card.Number] as const),
+          ...parsed.altToBase.entries(),
+        ]),
+      })),
+    [cardsBase, setKey],
+  );
+  const suggestions = useMemo(
+    () => buildSearchSuggestions(query, searchCatalogs, setKey),
+    [query, searchCatalogs, setKey],
+  );
   // Click outside to close dropdown
   useEffect(() => {
     const onDoc = (e: MouseEvent) => {
@@ -1168,65 +1076,31 @@ export default function App() {
     return () => document.removeEventListener('mousedown', onDoc);
   }, []);
 
-  // Resolve alt-art number -> base printing
-  function resolveToBase(n: number): Card | null {
-    const found = byNumber.get(n);
-    if (!found) return null;
-    const base = baseByName.get(found.Name);
-    return base || found;
-  }
-
-  // Search handlers (jump to spread immediately)
-  function goFromNumberString(nStr: string) {
-    const n = Number(nStr.replace(/^0+/, '') || '0');
-    if (!Number.isFinite(n) || n < 1) { setError('Invalid number.'); return; }
-    
-    // 1. Resolve to the base number (this defines baseNum)
-    const baseNum = altToBase.get(n) ?? n;          // alt → base
-    
-    // 2. Look up the card using the base number
-    const card = byNumber.get(baseNum);
-    if (!card) { setError('Number not found in this set.'); return; }
-    
-    // 3. Set the active state with all required properties
-    const { page, row, column } = binderLayout(baseNum);
-    const { spreadCol, spreadRow } = getSpreadCoords(page, row, column);
-    setActive({ number: card.Number, card, page, row, column, spreadCol, spreadRow });
-    setError('');
-    setViewSpread(pageToSpread(page));
-  }
-  function goFromName(name: string) {
-    const base = baseByName.get(name);
-    if (!base) { setError('Name not found in this set.'); return; }
-    const { page, row, column } = binderLayout(base.Number);
-    const { spreadCol, spreadRow } = getSpreadCoords(page, row, column);
-    setActive({ number: base.Number, card: base, page, row, column, spreadCol, spreadRow });
-    setError('');
-    setViewSpread(pageToSpread(page));
-  }
-  function onEnter() {
-    const q = query.trim();
-    if (!q) { setError('Enter a name or number.'); return; }
-    if (/^[0-9]+$/.test(q)) goFromNumberString(q);
-    else goFromName(q);
-    setOpenSug(false);
-  }
-  function onChoose(s: Suggestion) {
-    if (s.setKey !== setKey) {
-      // If the card is from a different set, store the target and switch sets.
-      setPendingSelection({ name: s.name, number: s.number });
-      setSetKey(s.setKey);
-      setQuery(''); setOpenSug(false);
+  function chooseSuggestion(suggestion: SearchSuggestion) {
+    if (suggestion.setKey !== setKey) {
+      setPendingSelection({
+        setKey: suggestion.setKey,
+        baseNumber: suggestion.baseNumber,
+      });
+      setSetKey(suggestion.setKey);
+      setQuery('');
+      setOpenSug(false);
       return;
     }
 
-    // If it's the current set, navigate as before.
-    if (s.kind === 'number') goFromNumberString(String(s.number));
-    else goFromName(s.name);
-    
-    setQuery(''); setOpenSug(false);
+    selectCardByNumber(suggestion.baseNumber);
+    setQuery('');
+    setOpenSug(false);
   }
 
+  function submitSearch() {
+    const suggestion = submittedSuggestion(suggestions, highlightIdx);
+    if (!suggestion) {
+      setError(query.trim() ? 'No matching card found.' : 'Enter a name or number.');
+      return;
+    }
+    chooseSuggestion(suggestion);
+  }
   function selectCardByNumber(baseNum: number) {
     const card = byNumber.get(baseNum);
     if (!card) { 
@@ -1607,13 +1481,6 @@ export default function App() {
       return tag === 'input' || tag === 'textarea' || node.isContentEditable;
     };
 
-    const callEnter = () => {
-      const q = (query || '').trim();
-      if (!q) return;
-      if (/^[0-9]+$/.test(q)) goFromNumberString(q);
-      else goFromName(q);
-    };
-
     const onKey = (e: KeyboardEvent) => {
       const typing = isTyping(e.target);
 
@@ -1629,7 +1496,7 @@ export default function App() {
       if (e.key === 'Enter' && !typing) {
         if ((query || '').trim()) {
           e.preventDefault();
-          callEnter();
+          submitSearch();
         }
         return;
       }
@@ -1987,12 +1854,7 @@ export default function App() {
                 }
                 if (e.key === 'Enter') {
                   e.preventDefault();
-                  if (openSug && suggestions.length) {
-                    const pick = suggestions[Math.min(highlightIdx, suggestions.length - 1)] || suggestions[0];
-                    onChoose(pick);
-                  } else {
-                    onEnter();
-                  }
+                  submitSearch();
                   setOpenSug(false);
                   setHighlightIdx(0);
                   (e.currentTarget as HTMLInputElement).blur();   // <-- defocus on Enter
@@ -2005,7 +1867,7 @@ export default function App() {
             <button
               type="button"
               className="search-icon"
-              onClick={() => onEnter()}
+              onClick={submitSearch}
               title="Search"
               aria-label="Search"
             >
@@ -2016,20 +1878,15 @@ export default function App() {
                 {suggestions.map((s, i) => {
                   const typeText = s.type ? s.type : ''; 
 
-                  // NEW LOGIC: Access the correct set's alt-art map from the cache
-                  const targetSetData = parsedCacheRef.current.get(s.setKey);
-                  
-                  // show base + alt numbers for BOTH kinds
-                  // Use the target set's baseToAll map, falling back to just the base number if data is missing
-                  const nums = targetSetData?.baseToAll.get(s.number) || [s.number];
+                  const nums = s.printingNumbers;
                   const numsLabel = nums.map((n) => `#${n}`).join(', ');
 
                   return (
                     <div
-                      key={`${s.setKey}:${s.number}`} // Ensure unique key across sets
+                      key={`${s.setKey}:${s.baseNumber}`} // Ensure unique key across sets
                       className={`sug-item ${i === highlightIdx ? 'active' : ''}`}
                       onMouseEnter={() => setHighlightIdx(i)}
-                      onMouseDown={(e) => { e.preventDefault(); onChoose(s); }}
+                      onMouseDown={(e) => { e.preventDefault(); chooseSuggestion(s); }}
                       role="option"
                       aria-selected={i === highlightIdx}
                       // Apply flex styling to arrange items horizontally

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -617,12 +617,11 @@ export function parseCsvData(
   } else {
     // Fallback: try your existing JSON format
     try {
-      const raw = JSON.parse(fileContent);
-      if (raw?.version === 1 && raw?.sets) {
-        const jsonSets = raw.sets as Record<SetKey, Record<string, number>>;
-        for (const k of Object.keys(jsonSets) as SetKey[]) {
-          for (const [numStr, count] of Object.entries(jsonSets[k])) {
-            if (!addRawCount(aggregatedData, k, numStr, count)) malformedSkipped += 1;
+      const raw: unknown = JSON.parse(fileContent);
+      if (isUnknownRecord(raw) && raw.version === 1 && isUnknownRecordMap(raw.sets)) {
+        for (const [setKey, inventory] of Object.entries(raw.sets)) {
+          for (const [numStr, count] of Object.entries(inventory)) {
+            if (!addRawCount(aggregatedData, setKey, numStr, count)) malformedSkipped += 1;
           }
         }
         return normalizedImportResult(aggregatedData, catalog, malformedSkipped);
@@ -650,6 +649,10 @@ type UnknownRecord = Record<string, unknown>;
 
 function isUnknownRecord(value: unknown): value is UnknownRecord {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isUnknownRecordMap(value: unknown): value is Record<string, UnknownRecord> {
+  return isUnknownRecord(value) && Object.values(value).every(isUnknownRecord);
 }
 
 function stringOrNamedValue(value: unknown): string | undefined {

--- a/src/components/BinderView.test.tsx
+++ b/src/components/BinderView.test.tsx
@@ -1,6 +1,10 @@
-import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
-import { Binder } from '../App';
+import React, { useState } from 'react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Binder, type BinderViewMode } from '../App';
+import { LocatorPanel } from './LocatorPanel';
+import { pageToSpread } from '../core/binder';
+import { focusedPageForSpread } from '../core/binderView';
 import type { Card } from '../core/types';
 
 const card25: Card = {
@@ -10,7 +14,13 @@ const card25: Card = {
   Type: 'Unit',
 };
 
-function renderBinder(viewMode: 'single' | 'spread') {
+afterEach(cleanup);
+
+function renderBinder(
+  viewMode: 'single' | 'spread',
+  focusedPage = 3,
+  totalPages = 5,
+) {
   const onActivateCard = vi.fn();
   const onFocusedPageChange = vi.fn();
   const onViewModeChange = vi.fn();
@@ -21,9 +31,9 @@ function renderBinder(viewMode: 'single' | 'spread') {
       viewSpread={1}
       setViewSpread={setViewSpread}
       totalSpreads={3}
-      totalPages={5}
+      totalPages={totalPages}
       viewMode={viewMode}
-      focusedPage={3}
+      focusedPage={focusedPage}
       onFocusedPageChange={onFocusedPageChange}
       onViewModeChange={onViewModeChange}
       onActivateCard={onActivateCard}
@@ -80,5 +90,86 @@ describe('Binder view modes', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /Previous spread/ }));
     expect(setViewSpread).toHaveBeenCalled();
+  });
+
+  it('disables physical-page navigation at the first and last page', () => {
+    const firstPage = renderBinder('single', 1, 5);
+    expect(screen.getByRole('button', { name: 'Previous page' })).toHaveProperty('disabled', true);
+    firstPage.unmount();
+
+    renderBinder('single', 5, 5);
+    expect(screen.getByRole('button', { name: 'Next page' })).toHaveProperty('disabled', true);
+  });
+
+  it('keeps one physical-page anchor across parent-controlled modes without changing selection', () => {
+    function BinderHarness() {
+      const [viewMode, setViewMode] = useState<BinderViewMode>('single');
+      const [focusedPage, setFocusedPage] = useState(3);
+      const totalPages = 9;
+      const viewSpread = pageToSpread(focusedPage);
+      const setViewSpread: React.Dispatch<React.SetStateAction<number>> = next => {
+        setFocusedPage(currentPage => {
+          const currentSpread = pageToSpread(currentPage);
+          const targetSpread = typeof next === 'function' ? next(currentSpread) : next;
+          return focusedPageForSpread(currentPage, targetSpread, totalPages);
+        });
+      };
+      const active = {
+        card: card25,
+        number: 25,
+        page: 3,
+        row: 1,
+        column: 1,
+        spreadCol: 5,
+        spreadRow: 1,
+      };
+
+      return (
+        <>
+          <LocatorPanel
+            selection={active}
+            quantity={0}
+            maximum={3}
+            onDecrease={vi.fn()}
+            onIncrease={vi.fn()}
+          />
+          <Binder
+            viewSpread={viewSpread}
+            setViewSpread={setViewSpread}
+            totalSpreads={5}
+            totalPages={totalPages}
+            viewMode={viewMode}
+            focusedPage={focusedPage}
+            onFocusedPageChange={setFocusedPage}
+            onViewModeChange={setViewMode}
+            onActivateCard={vi.fn()}
+            active={active}
+            presentNumbers={new Set([25])}
+            numToAspectSpec={new Map()}
+            byNumber={new Map([[25, card25]])}
+            inventory={{}}
+            inc={vi.fn()}
+            dec={vi.fn()}
+            setKey="SOR"
+            showHelpModal={false}
+            setShowHelpModal={vi.fn()}
+          />
+        </>
+      );
+    }
+
+    const { container } = render(<BinderHarness />);
+    fireEvent.click(screen.getByRole('button', { name: 'Next page' }));
+    expect(container.querySelector('.binder-subtitle')?.textContent).toContain('Page 4');
+    expect(container.querySelector('.locator-panel')?.textContent).toContain('Page3');
+    expect(container.querySelectorAll('rect[stroke="#ffffff"]')).toHaveLength(0);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Spread' }));
+    expect(container.querySelector('.binder-subtitle')?.textContent).toContain('Page 4 (left) | Page 5 (right)');
+
+    fireEvent.click(screen.getByRole('button', { name: /Next spread/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Single Page' }));
+    expect(container.querySelector('.binder-subtitle')?.textContent).toContain('Page 6');
+    expect(container.querySelector('.locator-panel')?.textContent).toContain('Page3');
   });
 });

--- a/src/components/BinderView.test.tsx
+++ b/src/components/BinderView.test.tsx
@@ -1,0 +1,84 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { Binder } from '../App';
+import type { Card } from '../core/types';
+
+const card25: Card = {
+  Name: 'Focused card',
+  Number: 25,
+  Set: 'SOR',
+  Type: 'Unit',
+};
+
+function renderBinder(viewMode: 'single' | 'spread') {
+  const onActivateCard = vi.fn();
+  const onFocusedPageChange = vi.fn();
+  const onViewModeChange = vi.fn();
+  const setViewSpread = vi.fn();
+
+  const result = render(
+    <Binder
+      viewSpread={1}
+      setViewSpread={setViewSpread}
+      totalSpreads={3}
+      totalPages={5}
+      viewMode={viewMode}
+      focusedPage={3}
+      onFocusedPageChange={onFocusedPageChange}
+      onViewModeChange={onViewModeChange}
+      onActivateCard={onActivateCard}
+      active={null}
+      presentNumbers={new Set([25])}
+      numToAspectSpec={new Map()}
+      byNumber={new Map([[25, card25]])}
+      inventory={{}}
+      inc={vi.fn()}
+      dec={vi.fn()}
+      setKey="SOR"
+      showHelpModal={false}
+      setShowHelpModal={vi.fn()}
+    />,
+  );
+
+  return {
+    ...result,
+    onActivateCard,
+    onFocusedPageChange,
+    onViewModeChange,
+    setViewSpread,
+  };
+}
+
+describe('Binder view modes', () => {
+  it('renders exactly one four-column physical page and navigates page by page', () => {
+    const { container, onActivateCard, onFocusedPageChange, onViewModeChange } =
+      renderBinder('single');
+
+    expect(container.querySelectorAll('.cell')).toHaveLength(12);
+    expect(container.querySelector('.binder-subtitle')?.textContent).toContain('Binder — Page 3');
+    expect(screen.queryByText(/Spread:/)).toBeNull();
+    expect(container.querySelector('.binder-divider')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Spread' }));
+    expect(onViewModeChange).toHaveBeenCalledWith('spread');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Previous page' }));
+    expect(onFocusedPageChange).toHaveBeenCalledWith(2);
+    fireEvent.click(screen.getByRole('button', { name: 'Next page' }));
+    expect(onFocusedPageChange).toHaveBeenCalledWith(4);
+
+    fireEvent.click(container.querySelector('.cell')!);
+    expect(onActivateCard).toHaveBeenCalledWith(card25);
+  });
+
+  it('preserves the eight-column spread geometry and spread navigation', () => {
+    const { container, setViewSpread } = renderBinder('spread');
+
+    expect(container.querySelectorAll('.cell')).toHaveLength(24);
+    expect(screen.getByText(/Spread: Page 2 \(left\) \| Page 3 \(right\)/)).toBeTruthy();
+    expect(container.querySelector('.binder-divider')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: /Previous spread/ }));
+    expect(setViewSpread).toHaveBeenCalled();
+  });
+});

--- a/src/components/LocatorPanel.test.tsx
+++ b/src/components/LocatorPanel.test.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { LocatorPanel } from './LocatorPanel';
+
+describe('LocatorPanel', () => {
+  it('shows the readable physical location and adjusts quantity', () => {
+    const onDecrease = vi.fn();
+    const onIncrease = vi.fn();
+
+    render(
+      <LocatorPanel
+        selection={{
+          card: {
+            Name: 'Darth Vader',
+            Subtitle: 'Dark Lord of the Sith',
+            Number: 10,
+            Type: 'Leader',
+            Set: 'SOR',
+          },
+          number: 10,
+          page: 1,
+          row: 3,
+          column: 2,
+          spreadCol: 6,
+          spreadRow: 3,
+        }}
+        quantity={0}
+        maximum={1}
+        onDecrease={onDecrease}
+        onIncrease={onIncrease}
+      />,
+    );
+
+    expect(screen.getByRole('heading', { name: 'Darth Vader' })).toBeTruthy();
+    expect(screen.getByText('Page')).toBeTruthy();
+    expect(screen.getByText('Column')).toBeTruthy();
+    expect(screen.getByText('2')).toBeTruthy();
+    expect(screen.queryByText('6')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Increase Darth Vader quantity' }));
+    expect(onIncrease).toHaveBeenCalledOnce();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Decrease Darth Vader quantity' }));
+    expect(onDecrease).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/LocatorPanel.tsx
+++ b/src/components/LocatorPanel.tsx
@@ -1,0 +1,71 @@
+import type { ActiveSelection } from '../core/types';
+
+type LocatorPanelProps = {
+  selection: ActiveSelection;
+  quantity: number;
+  maximum: number;
+  aspectBackground?: string;
+  onDecrease: () => void;
+  onIncrease: () => void;
+};
+
+export function LocatorPanel({
+  selection,
+  quantity,
+  maximum,
+  aspectBackground,
+  onDecrease,
+  onIncrease,
+}: LocatorPanelProps) {
+  const { card } = selection;
+
+  return (
+    <section className="locator-panel" aria-live="polite">
+      <div
+        className="locator-aspect"
+        style={aspectBackground ? { background: aspectBackground } : undefined}
+        aria-hidden="true"
+      />
+      <h2 className="locator-name">{card.Name}</h2>
+      {card.Subtitle && <p className="locator-subtitle">{card.Subtitle}</p>}
+      <p className="locator-number">Card #{card.Number}</p>
+
+      <dl className="locator-location">
+        <div>
+          <dt>Page</dt>
+          <dd className="locator-value">{selection.page}</dd>
+        </div>
+        <div>
+          <dt>Row</dt>
+          <dd className="locator-value">{selection.row}</dd>
+        </div>
+        <div>
+          <dt>Column</dt>
+          <dd className="locator-value">{selection.column}</dd>
+        </div>
+      </dl>
+
+      <div className="locator-qty" aria-label={`${card.Name} quantity`}>
+        <button
+          type="button"
+          aria-label={`Decrease ${card.Name} quantity`}
+          onClick={onDecrease}
+          disabled={quantity <= 0}
+        >
+          &minus;
+        </button>
+        <output aria-label="Quantity">
+          {quantity}/{maximum}
+        </output>
+        <button
+          type="button"
+          aria-label={`Increase ${card.Name} quantity`}
+          onClick={onIncrease}
+          disabled={quantity >= maximum}
+        >
+          +
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -1,0 +1,90 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createRef } from 'react'
+import { SettingsModal } from './SettingsModal'
+
+afterEach(cleanup)
+
+describe('SettingsModal', () => {
+  it('exposes settings accessibly and reports checkbox changes', () => {
+    const onChange = vi.fn()
+
+    render(
+      <SettingsModal
+        open
+        settings={{ autoOpenSinglePage: true }}
+        onChange={onChange}
+        onClose={vi.fn()}
+        returnFocusRef={createRef<HTMLButtonElement>()}
+      />,
+    )
+
+    const dialog = screen.getByRole('dialog', { name: 'Settings' })
+    const checkbox = screen.getByRole('checkbox', {
+      name: 'Automatically open enlarged page after selecting a card',
+    })
+    expect(document.activeElement).toBe(dialog)
+    expect((checkbox as HTMLInputElement).checked).toBe(true)
+
+    fireEvent.click(checkbox)
+
+    expect(onChange).toHaveBeenCalledWith({ autoOpenSinglePage: false })
+  })
+
+  it('closes on Escape without leaking the key to global handlers', () => {
+    const onClose = vi.fn()
+    const globalKeyHandler = vi.fn()
+    window.addEventListener('keydown', globalKeyHandler)
+
+    render(
+      <SettingsModal
+        open
+        settings={{ autoOpenSinglePage: true }}
+        onChange={vi.fn()}
+        onClose={onClose}
+        returnFocusRef={createRef<HTMLButtonElement>()}
+      />,
+    )
+
+    fireEvent.keyDown(screen.getByRole('dialog', { name: 'Settings' }), { key: 'Escape' })
+
+    expect(onClose).toHaveBeenCalledOnce()
+    expect(globalKeyHandler).not.toHaveBeenCalled()
+    window.removeEventListener('keydown', globalKeyHandler)
+  })
+
+  it('closes with the button and restores focus when dismissed', () => {
+    const triggerRef = createRef<HTMLButtonElement>()
+    const onClose = vi.fn()
+    const { rerender } = render(
+      <>
+        <button ref={triggerRef}>Settings trigger</button>
+        <SettingsModal
+          open
+          settings={{ autoOpenSinglePage: true }}
+          onChange={vi.fn()}
+          onClose={onClose}
+          returnFocusRef={triggerRef}
+        />
+      </>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    expect(onClose).toHaveBeenCalledOnce()
+
+    rerender(
+      <>
+        <button ref={triggerRef}>Settings trigger</button>
+        <SettingsModal
+          open={false}
+          settings={{ autoOpenSinglePage: true }}
+          onChange={vi.fn()}
+          onClose={onClose}
+          returnFocusRef={triggerRef}
+        />
+      </>,
+    )
+
+    expect(document.activeElement).toBe(triggerRef.current)
+  })
+})

--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -87,4 +87,47 @@ describe('SettingsModal', () => {
 
     expect(document.activeElement).toBe(triggerRef.current)
   })
+
+  it('traps forward and reverse Tab movement inside the dialog', () => {
+    render(
+      <SettingsModal
+        open
+        settings={{ autoOpenSinglePage: true }}
+        onChange={vi.fn()}
+        onClose={vi.fn()}
+        returnFocusRef={createRef<HTMLButtonElement>()}
+      />,
+    )
+
+    const checkbox = screen.getByRole('checkbox', {
+      name: 'Automatically open enlarged page after selecting a card',
+    })
+    const close = screen.getByRole('button', { name: 'Close' })
+
+    close.focus()
+    fireEvent.keyDown(close, { key: 'Tab' })
+    expect(document.activeElement).toBe(checkbox)
+
+    checkbox.focus()
+    fireEvent.keyDown(checkbox, { key: 'Tab', shiftKey: true })
+    expect(document.activeElement).toBe(close)
+  })
+
+  it('closes when the backdrop itself is pressed', () => {
+    const onClose = vi.fn()
+    const { container } = render(
+      <SettingsModal
+        open
+        settings={{ autoOpenSinglePage: true }}
+        onChange={vi.fn()}
+        onClose={onClose}
+        returnFocusRef={createRef<HTMLButtonElement>()}
+      />,
+    )
+
+    const backdrop = container.querySelector('.modal-backdrop')
+    expect(backdrop).toBeTruthy()
+    fireEvent.mouseDown(backdrop!)
+    expect(onClose).toHaveBeenCalledOnce()
+  })
 })

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useRef, type RefObject } from 'react'
+import type { AppSettings } from '../core/settings'
+
+type SettingsModalProps = {
+  open: boolean
+  settings: AppSettings
+  onChange: (settings: AppSettings) => void
+  onClose: () => void
+  returnFocusRef: RefObject<HTMLElement>
+}
+
+export function SettingsModal({
+  open,
+  settings,
+  onChange,
+  onClose,
+  returnFocusRef,
+}: SettingsModalProps) {
+  const dialogRef = useRef<HTMLElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+
+    dialogRef.current?.focus()
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return
+      event.preventDefault()
+      event.stopPropagation()
+      onClose()
+    }
+
+    document.addEventListener('keydown', handleKeyDown, true)
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown, true)
+      returnFocusRef.current?.focus()
+    }
+  }, [onClose, open, returnFocusRef])
+
+  if (!open) return null
+
+  return (
+    <div
+      className="modal-backdrop"
+      onMouseDown={event => event.target === event.currentTarget && onClose()}
+    >
+      <section
+        ref={dialogRef}
+        className="settings-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="settings-title"
+        tabIndex={-1}
+      >
+        <h2 id="settings-title">Settings</h2>
+        <label className="settings-toggle">
+          <input
+            type="checkbox"
+            checked={settings.autoOpenSinglePage}
+            onChange={event =>
+              onChange({ ...settings, autoOpenSinglePage: event.target.checked })
+            }
+          />
+          <span>Automatically open enlarged page after selecting a card</span>
+        </label>
+        <div className="settings-modal-actions">
+          <button type="button" className="tbtn" onClick={onClose}>
+            Close
+          </button>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -24,10 +24,39 @@ export function SettingsModal({
     dialogRef.current?.focus()
 
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== 'Escape') return
-      event.preventDefault()
-      event.stopPropagation()
-      onClose()
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        event.stopPropagation()
+        onClose()
+        return
+      }
+
+      if (event.key !== 'Tab' || !dialogRef.current) return
+
+      const dialog = dialogRef.current
+      const focusable = Array.from(
+        dialog.querySelectorAll<HTMLElement>(
+          'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        ),
+      ).filter(element => element.tabIndex >= 0 && !element.hidden)
+      const first = focusable[0]
+      const last = focusable[focusable.length - 1]
+
+      if (!first || !last) {
+        event.preventDefault()
+        dialog.focus()
+        return
+      }
+
+      const activeElement = document.activeElement
+      const focusIsOutside = !activeElement || !dialog.contains(activeElement)
+      if (event.shiftKey && (activeElement === first || activeElement === dialog || focusIsOutside)) {
+        event.preventDefault()
+        last.focus()
+      } else if (!event.shiftKey && (activeElement === last || activeElement === dialog || focusIsOutside)) {
+        event.preventDefault()
+        first.focus()
+      }
     }
 
     document.addEventListener('keydown', handleKeyDown, true)

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -22,6 +22,7 @@ export function SettingsModal({
     if (!open) return
 
     dialogRef.current?.focus()
+    const returnFocusElement = returnFocusRef.current
 
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
@@ -62,7 +63,7 @@ export function SettingsModal({
     document.addEventListener('keydown', handleKeyDown, true)
     return () => {
       document.removeEventListener('keydown', handleKeyDown, true)
-      returnFocusRef.current?.focus()
+      returnFocusElement?.focus()
     }
   }, [onClose, open, returnFocusRef])
 

--- a/src/core/binder.test.ts
+++ b/src/core/binder.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import {
+  binderLayout,
+  getSpreadCoords,
+  moveBinderSelection,
+  pageToSpread,
+} from './binder'
+
+describe('binder geometry', () => {
+  it.each([
+    [1, { page: 1, row: 1, column: 1 }],
+    [4, { page: 1, row: 1, column: 4 }],
+    [5, { page: 1, row: 2, column: 1 }],
+    [12, { page: 1, row: 3, column: 4 }],
+    [13, { page: 2, row: 1, column: 1 }],
+  ])('maps card %i to its physical position', (number, expected) => {
+    expect(binderLayout(number)).toEqual(expected)
+  })
+
+  it('keeps physical and spread columns distinct', () => {
+    expect(getSpreadCoords(1, 1, 1)).toEqual({ spreadCol: 5, spreadRow: 1 })
+    expect(binderLayout(1).column).toBe(1)
+  })
+
+  it('moves right from the final column to the adjacent physical page', () => {
+    const selection = { ...binderLayout(16), number: 16 }
+    expect(moveBinderSelection(selection, 'right', 10)).toMatchObject({
+      number: 25,
+      page: 3,
+      row: 1,
+      column: 1,
+    })
+  })
+
+  it('preserves vertical spread wrapping', () => {
+    const selection = { ...binderLayout(24), number: 24 }
+    expect(moveBinderSelection(selection, 'down', 10)).toMatchObject({
+      page: 4,
+      row: 1,
+      column: 4,
+    })
+  })
+
+  it('does not move beyond the first or last spread', () => {
+    const first = { ...binderLayout(1), number: 1 }
+    expect(moveBinderSelection(first, 'left', 1)).toEqual(first)
+    expect(pageToSpread(1)).toBe(0)
+  })
+})

--- a/src/core/binder.ts
+++ b/src/core/binder.ts
@@ -1,0 +1,95 @@
+import type { BinderPosition } from './types'
+
+export type MoveDirection = 'left' | 'right' | 'up' | 'down'
+
+export function binderLayout(number: number): Omit<BinderPosition, 'number'> {
+  const page = Math.floor((number - 1) / 12) + 1
+  const row = Math.floor(((number - 1) % 12) / 4) + 1
+  const column = ((number - 1) % 4) + 1
+  return { page, row, column }
+}
+
+export function getSpreadCoords(page: number, row: number, column: number) {
+  const isOddPage = page % 2 !== 0
+  return {
+    spreadCol: isOddPage ? column + 4 : column,
+    spreadRow: row,
+  }
+}
+
+export function numberFromPagePosition(
+  page: number,
+  row: number,
+  column: number,
+): number {
+  return (page - 1) * 12 + (row - 1) * 4 + column
+}
+
+export function pageToSpread(page: number): number {
+  return page <= 1 ? 0 : Math.floor((page - 2) / 2) + 1
+}
+
+export function spreadToPrimaryPage(spread: number): number {
+  return spread <= 0 ? 1 : 2 + (spread - 1) * 2
+}
+
+export function moveBinderSelection(
+  selection: BinderPosition,
+  direction: MoveDirection,
+  totalPages: number,
+): BinderPosition {
+  const { spreadCol, spreadRow } = getSpreadCoords(
+    selection.page,
+    selection.row,
+    selection.column,
+  )
+  let nextSpreadCol = spreadCol
+  let nextSpreadRow = spreadRow
+  let targetSpread = pageToSpread(selection.page)
+
+  if (direction === 'left') nextSpreadCol -= 1
+  if (direction === 'right') nextSpreadCol += 1
+  if (direction === 'up') nextSpreadRow -= 1
+  if (direction === 'down') nextSpreadRow += 1
+
+  if (nextSpreadCol > 8) {
+    nextSpreadCol = 1
+    targetSpread += 1
+  } else if (nextSpreadCol < 1) {
+    nextSpreadCol = 8
+    targetSpread -= 1
+  }
+
+  if (nextSpreadRow > 3) {
+    nextSpreadRow = 1
+    targetSpread += 1
+  } else if (nextSpreadRow < 1) {
+    nextSpreadRow = 3
+    targetSpread -= 1
+  }
+
+  const finalSpread = pageToSpread(totalPages)
+  if (targetSpread < 0 || targetSpread > finalSpread) return selection
+
+  let targetPage = spreadToPrimaryPage(targetSpread)
+  let targetColumn: number
+
+  if (nextSpreadCol <= 4) {
+    targetColumn = nextSpreadCol
+    if (targetPage % 2 !== 0 && targetPage > 1) targetPage -= 1
+    if (targetPage === 1) return selection
+  } else {
+    targetColumn = nextSpreadCol - 4
+    if (targetPage % 2 === 0) targetPage += 1
+  }
+
+  const number = numberFromPagePosition(targetPage, nextSpreadRow, targetColumn)
+  if (number > totalPages * 12) return selection
+
+  return {
+    number,
+    page: targetPage,
+    row: nextSpreadRow,
+    column: targetColumn,
+  }
+}

--- a/src/core/binderView.test.ts
+++ b/src/core/binderView.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import {
+  focusedPageForSpread,
+  viewModeAfterSelection,
+} from './binderView';
+
+describe('binder view continuity', () => {
+  it('preserves the browsed physical-page side when changing spreads', () => {
+    expect(focusedPageForSpread(4, 2, 9)).toBe(4);
+    expect(focusedPageForSpread(4, 3, 9)).toBe(6);
+    expect(focusedPageForSpread(5, 3, 9)).toBe(7);
+  });
+
+  it('handles page one and clamps an incomplete final spread', () => {
+    expect(focusedPageForSpread(1, 1, 9)).toBe(3);
+    expect(focusedPageForSpread(9, 0, 9)).toBe(1);
+    expect(focusedPageForSpread(7, 4, 8)).toBe(8);
+  });
+
+  it('uses the setting only for card activation mode changes', () => {
+    expect(viewModeAfterSelection({ autoOpenSinglePage: true }, 'spread')).toBe('single');
+    expect(viewModeAfterSelection({ autoOpenSinglePage: false }, 'spread')).toBe('spread');
+    expect(viewModeAfterSelection({ autoOpenSinglePage: false }, 'single')).toBe('single');
+  });
+});

--- a/src/core/binderView.test.ts
+++ b/src/core/binderView.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import {
-  focusedPageForSpread,
-  viewModeAfterSelection,
-} from './binderView';
+import { focusedPageForSpread } from './binderView';
 
 describe('binder view continuity', () => {
   it('preserves the browsed physical-page side when changing spreads', () => {
@@ -15,11 +12,5 @@ describe('binder view continuity', () => {
     expect(focusedPageForSpread(1, 1, 9)).toBe(3);
     expect(focusedPageForSpread(9, 0, 9)).toBe(1);
     expect(focusedPageForSpread(7, 4, 8)).toBe(8);
-  });
-
-  it('uses the setting only for card activation mode changes', () => {
-    expect(viewModeAfterSelection({ autoOpenSinglePage: true }, 'spread')).toBe('single');
-    expect(viewModeAfterSelection({ autoOpenSinglePage: false }, 'spread')).toBe('spread');
-    expect(viewModeAfterSelection({ autoOpenSinglePage: false }, 'single')).toBe('single');
   });
 });

--- a/src/core/binderView.ts
+++ b/src/core/binderView.ts
@@ -1,14 +1,4 @@
 import { pageToSpread, spreadToPrimaryPage } from './binder';
-import type { AppSettings } from './settings';
-
-export type BinderViewMode = 'single' | 'spread';
-
-export function viewModeAfterSelection(
-  settings: AppSettings,
-  currentMode: BinderViewMode,
-): BinderViewMode {
-  return settings.autoOpenSinglePage ? 'single' : currentMode;
-}
 
 export function focusedPageForSpread(
   currentPage: number,

--- a/src/core/binderView.ts
+++ b/src/core/binderView.ts
@@ -1,0 +1,27 @@
+import { pageToSpread, spreadToPrimaryPage } from './binder';
+import type { AppSettings } from './settings';
+
+export type BinderViewMode = 'single' | 'spread';
+
+export function viewModeAfterSelection(
+  settings: AppSettings,
+  currentMode: BinderViewMode,
+): BinderViewMode {
+  return settings.autoOpenSinglePage ? 'single' : currentMode;
+}
+
+export function focusedPageForSpread(
+  currentPage: number,
+  requestedSpread: number,
+  totalPages: number,
+): number {
+  const lastPage = Math.max(1, totalPages);
+  const lastSpread = pageToSpread(lastPage);
+  const targetSpread = Math.max(0, Math.min(lastSpread, requestedSpread));
+  if (targetSpread === 0) return 1;
+
+  const leftPage = spreadToPrimaryPage(targetSpread);
+  const rightPage = leftPage + 1;
+  const preserveRightSide = currentPage === 1 || currentPage % 2 === 1;
+  return Math.min(lastPage, preserveRightSide ? rightPage : leftPage);
+}

--- a/src/core/inventory-imports.test.ts
+++ b/src/core/inventory-imports.test.ts
@@ -45,6 +45,21 @@ describe('inventory import parser statistics', () => {
     expect(parsed.skipped).toBe(3)
   })
 
+  it.each([
+    ['null root', null],
+    ['array root', []],
+    ['boolean sets', { version: 1, sets: true }],
+    ['null sets', { version: 1, sets: null }],
+    ['array sets', { version: 1, sets: [] }],
+    ['boolean set inventory', { version: 1, sets: { SOR: true } }],
+    ['null set inventory', { version: 1, sets: { SOR: null } }],
+    ['array set inventory', { version: 1, sets: { SOR: [] } }],
+  ])('rejects malformed JSON structure: %s', (_label, payload) => {
+    expect(() =>
+      parseCsvData('inventory.json', JSON.stringify(payload), catalog),
+    ).toThrow('File format not recognized')
+  })
+
   it('counts malformed and reserved XLSX rows as skipped', async () => {
     const sheet = XLSX.utils.json_to_sheet([
       { Set: 'SOR', 'Base card id': 87, Normal: 1 },

--- a/src/core/inventory-imports.test.ts
+++ b/src/core/inventory-imports.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import * as XLSX from 'xlsx'
+import { parseCsvData, parseXlsxData } from '../App'
+import type { CanonicalCatalog } from './inventory'
+
+const catalog: CanonicalCatalog = new Map([
+  ['SOR:87', { setKey: 'SOR', printingNumber: 87, baseNumber: 87, type: 'Unit' }],
+  ['SOR:351', { setKey: 'SOR', printingNumber: 351, baseNumber: 87, type: 'Unit' }],
+])
+
+describe('inventory import parser statistics', () => {
+  it('counts malformed and reserved CSV entries as skipped', () => {
+    const parsed = parseCsvData(
+      'inventory.csv',
+      [
+        'Set,CardNumber,Count',
+        'SOR,87,1',
+        'SOR,not-a-number,2',
+        'SOR,351,not-a-quantity',
+        'schema-version,87,1',
+      ].join('\n'),
+      catalog,
+    )
+
+    expect(parsed.inventories).toEqual({ SOR: { 87: 1 } })
+    expect(parsed.recognized).toBe(1)
+    expect(parsed.skipped).toBe(3)
+  })
+
+  it('counts malformed and reserved JSON entries as skipped', () => {
+    const parsed = parseCsvData(
+      'inventory.json',
+      JSON.stringify({
+        version: 1,
+        sets: {
+          SOR: { 87: 1, invalid: 2, 351: 'not-a-quantity' },
+          'migration:v2:backup': { 87: 1 },
+        },
+      }),
+      catalog,
+    )
+
+    expect(parsed.inventories).toEqual({ SOR: { 87: 1 } })
+    expect(parsed.recognized).toBe(1)
+    expect(parsed.skipped).toBe(3)
+  })
+
+  it('counts malformed and reserved XLSX rows as skipped', async () => {
+    const sheet = XLSX.utils.json_to_sheet([
+      { Set: 'SOR', 'Base card id': 87, Normal: 1 },
+      { Set: 'SOR', 'Base card id': 'invalid', Normal: 2 },
+      { Set: 'schema-version', 'Base card id': 87, Normal: 1 },
+    ])
+    const workbook = XLSX.utils.book_new()
+    XLSX.utils.book_append_sheet(workbook, sheet, 'Inventory')
+    const bytes = XLSX.write(workbook, { type: 'array', bookType: 'xlsx' })
+    const file = new File([bytes], 'inventory.xlsx')
+
+    const parsed = await parseXlsxData(file, catalog)
+
+    expect(parsed.inventories).toEqual({ SOR: { 87: 1 } })
+    expect(parsed.recognized).toBe(1)
+    expect(parsed.skipped).toBe(2)
+  })
+})

--- a/src/core/inventory.test.ts
+++ b/src/core/inventory.test.ts
@@ -4,6 +4,8 @@ import {
   INVENTORY_SCHEMA_KEY,
   applyImportedInventories,
   canonicalizeInventory,
+  collectRawImportEntry,
+  loadInventoriesForPersistence,
   migrateLegacyInventories,
   type CanonicalCatalog,
 } from './inventory'
@@ -93,6 +95,36 @@ describe('canonical inventory', () => {
     expect(result.skipped).toBe(1)
   })
 
+  it('rejects reserved and unrecognized imported set keys', () => {
+    const result = applyImportedInventories(
+      { 'schema-version': { 1: 1 }, SOR: { 87: 1 } },
+      {
+        'migration:v2:backup': { 87: 1 },
+        'schema-version': { 87: 1 },
+        ARBITRARY: { 87: 1 },
+      },
+      'replace',
+      catalog,
+    )
+
+    expect(result.inventories).toEqual({ SOR: { 87: 1 } })
+    expect(result.skipped).toBe(3)
+  })
+
+  it('counts malformed raw import entries as skipped', () => {
+    const raw: Record<string, Record<number, number>> = {}
+    let skipped = 0
+
+    skipped += collectRawImportEntry(raw, 'SOR', 'not-a-number', 2) ? 0 : 1
+    skipped += collectRawImportEntry(raw, 'SOR', 87, 'not-a-quantity') ? 0 : 1
+    skipped += collectRawImportEntry(raw, 'SOR', 87, 2) ? 0 : 1
+    const normalized = applyImportedInventories({}, raw, 'replace', catalog)
+
+    expect(raw).toEqual({ SOR: { 87: 2 } })
+    expect(normalized.recognized).toBe(1)
+    expect(normalized.skipped + skipped).toBe(2)
+  })
+
   it('backs up and migrates legacy data only once', () => {
     const storage = new MemoryStorage({
       'inv:SOR': JSON.stringify({ 87: 2, 351: 2 }),
@@ -132,5 +164,25 @@ describe('canonical inventory', () => {
     expect(() => migrateLegacyInventories(storage, ['SOR'], catalog)).toThrow('quota exceeded')
     expect(storage.getItem(INVENTORY_BACKUP_KEY)).toContain('351')
     expect(storage.getItem(INVENTORY_SCHEMA_KEY)).toBeNull()
+  })
+
+  it('does not allow persistence to overwrite legacy data when the backup write fails', () => {
+    const legacy = JSON.stringify({ 351: 2 })
+    const storage = new MemoryStorage({ 'inv:SOR': legacy })
+    const originalSetItem = storage.setItem.bind(storage)
+    storage.setItem = (key, value) => {
+      if (key === INVENTORY_BACKUP_KEY) throw new Error('storage unavailable')
+      originalSetItem(key, value)
+    }
+
+    const loaded = loadInventoriesForPersistence(storage, ['SOR'], catalog)
+    if (loaded.persistenceAllowed) {
+      storage.setItem('inv:SOR', JSON.stringify(loaded.inventories.SOR))
+    }
+
+    expect(loaded.migrationSucceeded).toBe(false)
+    expect(loaded.backupPreserved).toBe(false)
+    expect(loaded.persistenceAllowed).toBe(false)
+    expect(storage.getItem('inv:SOR')).toBe(legacy)
   })
 })

--- a/src/core/inventory.test.ts
+++ b/src/core/inventory.test.ts
@@ -5,6 +5,7 @@ import {
   applyImportedInventories,
   canonicalizeInventory,
   collectRawImportEntry,
+  createInventoryExportSnapshot,
   loadInventoriesForPersistence,
   migrateLegacyInventories,
   persistCanonicalInventory,
@@ -220,5 +221,30 @@ describe('canonical inventory', () => {
     expect(storage.getItem('inv:SOR')).toBe(JSON.stringify({ 87: 2 }))
     expect(removePersistedInventory(storage, 'SOR', catalog)).toBe(true)
     expect(storage.getItem('inv:SOR')).toBeNull()
+  })
+
+  it('exports the current set from memory even when its saved record is stale', () => {
+    const storage = new MemoryStorage({
+      'inv:SOR': JSON.stringify({ 87: 1 }),
+      'inv:SHD': JSON.stringify({ 1: 1 }),
+    })
+
+    expect(
+      createInventoryExportSnapshot(storage, ['SOR', 'SHD'], 'SOR', { 87: 3 }, catalog),
+    ).toEqual({
+      SOR: { 87: 3 },
+      SHD: { 1: 1 },
+    })
+  })
+
+  it('aborts export when another set record cannot be parsed', () => {
+    const storage = new MemoryStorage({
+      'inv:SOR': JSON.stringify({ 87: 1 }),
+      'inv:SHD': '{not json',
+    })
+
+    expect(() =>
+      createInventoryExportSnapshot(storage, ['SOR', 'SHD'], 'SOR', { 87: 2 }, catalog),
+    ).toThrow('SHD')
   })
 })

--- a/src/core/inventory.test.ts
+++ b/src/core/inventory.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest'
+import {
+  INVENTORY_BACKUP_KEY,
+  INVENTORY_SCHEMA_KEY,
+  applyImportedInventories,
+  canonicalizeInventory,
+  migrateLegacyInventories,
+  type CanonicalCatalog,
+} from './inventory'
+
+class MemoryStorage implements Storage {
+  private readonly values = new Map<string, string>()
+
+  constructor(initial: Record<string, string> = {}) {
+    for (const [key, value] of Object.entries(initial)) this.values.set(key, value)
+  }
+
+  get length() {
+    return this.values.size
+  }
+
+  clear() {
+    this.values.clear()
+  }
+
+  getItem(key: string) {
+    return this.values.get(key) ?? null
+  }
+
+  key(index: number) {
+    return [...this.values.keys()][index] ?? null
+  }
+
+  removeItem(key: string) {
+    this.values.delete(key)
+  }
+
+  setItem(key: string, value: string) {
+    this.values.set(key, value)
+  }
+}
+
+const catalog: CanonicalCatalog = new Map([
+  ['SOR:10', { setKey: 'SOR', printingNumber: 10, baseNumber: 10, type: 'Leader' }],
+  ['SOR:87', { setKey: 'SOR', printingNumber: 87, baseNumber: 87, type: 'Unit' }],
+  ['SOR:351', { setKey: 'SOR', printingNumber: 351, baseNumber: 87, type: 'Unit' }],
+  ['SHD:1', { setKey: 'SHD', printingNumber: 1, baseNumber: 1, type: 'Base' }],
+])
+
+describe('canonical inventory', () => {
+  it('combines printings at the base card and caps after aggregation', () => {
+    expect(canonicalizeInventory('SOR', { 87: 2, 351: 2 }, catalog)).toEqual({ 87: 3 })
+  })
+
+  it('uses the destination set quota during cross-set merge', () => {
+    const result = applyImportedInventories(
+      { SHD: { 1: 1 } },
+      { SHD: { 1: 2 } },
+      'merge',
+      catalog,
+    )
+
+    expect(result.inventories.SHD).toEqual({ 1: 1 })
+  })
+
+  it('canonicalizes retained current sets even when another set is imported', () => {
+    const result = applyImportedInventories(
+      { SOR: { 351: 2 } },
+      { SHD: { 1: 1 } },
+      'replace',
+      catalog,
+    )
+
+    expect(result.inventories.SOR).toEqual({ 87: 2 })
+  })
+
+  it('skips unknown and malformed entries', () => {
+    expect(canonicalizeInventory('SOR', { 87: 1, 9999: 3, [-1]: 2 }, catalog)).toEqual({
+      87: 1,
+    })
+  })
+
+  it('reports recognized and skipped import entries through the shared normalization path', () => {
+    const result = applyImportedInventories(
+      {},
+      { SOR: { 87: 1, 351: 1, 9999: 4 } },
+      'replace',
+      catalog,
+    )
+
+    expect(result.inventories.SOR).toEqual({ 87: 2 })
+    expect(result.recognized).toBe(2)
+    expect(result.skipped).toBe(1)
+  })
+
+  it('backs up and migrates legacy data only once', () => {
+    const storage = new MemoryStorage({
+      'inv:SOR': JSON.stringify({ 87: 2, 351: 2 }),
+    })
+
+    const first = migrateLegacyInventories(storage, ['SOR'], catalog)
+    expect(first.SOR).toEqual({ 87: 3 })
+    expect(storage.getItem(INVENTORY_BACKUP_KEY)).toContain('351')
+    expect(storage.getItem(INVENTORY_SCHEMA_KEY)).toBe('2')
+
+    storage.setItem('inv:SOR', JSON.stringify({ 87: 1 }))
+    expect(migrateLegacyInventories(storage, ['SOR'], catalog).SOR).toEqual({ 87: 1 })
+  })
+
+  it('writes the backup before normalized inventories and marks the schema last', () => {
+    const storage = new MemoryStorage({ 'inv:SOR': JSON.stringify({ 351: 2 }) })
+    const writes: string[] = []
+    const originalSetItem = storage.setItem.bind(storage)
+    storage.setItem = (key, value) => {
+      writes.push(key)
+      originalSetItem(key, value)
+    }
+
+    migrateLegacyInventories(storage, ['SOR'], catalog)
+
+    expect(writes).toEqual([INVENTORY_BACKUP_KEY, 'inv:SOR', INVENTORY_SCHEMA_KEY])
+  })
+
+  it('does not advance the schema marker when an inventory write fails', () => {
+    const storage = new MemoryStorage({ 'inv:SOR': JSON.stringify({ 351: 2 }) })
+    const originalSetItem = storage.setItem.bind(storage)
+    storage.setItem = (key, value) => {
+      if (key === 'inv:SOR') throw new Error('quota exceeded')
+      originalSetItem(key, value)
+    }
+
+    expect(() => migrateLegacyInventories(storage, ['SOR'], catalog)).toThrow('quota exceeded')
+    expect(storage.getItem(INVENTORY_BACKUP_KEY)).toContain('351')
+    expect(storage.getItem(INVENTORY_SCHEMA_KEY)).toBeNull()
+  })
+})

--- a/src/core/inventory.test.ts
+++ b/src/core/inventory.test.ts
@@ -7,6 +7,8 @@ import {
   collectRawImportEntry,
   loadInventoriesForPersistence,
   migrateLegacyInventories,
+  persistCanonicalInventory,
+  removePersistedInventory,
   type CanonicalCatalog,
 } from './inventory'
 
@@ -184,5 +186,39 @@ describe('canonical inventory', () => {
     expect(loaded.backupPreserved).toBe(false)
     expect(loaded.persistenceAllowed).toBe(false)
     expect(storage.getItem('inv:SOR')).toBe(legacy)
+  })
+
+  it('keeps legacy inventory byte-for-byte unchanged when merge and replace imports are persistence-locked', () => {
+    const legacy = '{"351":2}'
+    const storage = new MemoryStorage({ 'inv:SOR': legacy })
+    const originalSetItem = storage.setItem.bind(storage)
+    storage.setItem = (key, value) => {
+      if (key === INVENTORY_BACKUP_KEY) throw new Error('storage unavailable')
+      originalSetItem(key, value)
+    }
+    const loaded = loadInventoriesForPersistence(storage, ['SOR'], catalog)
+
+    for (const mode of ['merge', 'replace'] as const) {
+      const applied = applyImportedInventories(
+        loaded.inventories,
+        { SOR: { 87: 1 } },
+        mode,
+        catalog,
+      )
+      expect(persistCanonicalInventory(storage, 'SOR', applied.inventories.SOR, catalog)).toBe(false)
+      expect(storage.getItem('inv:SOR')).toBe(legacy)
+    }
+  })
+
+  it('persists successful imports and authorized removals after schema migration', () => {
+    const storage = new MemoryStorage({
+      'inv:SOR': JSON.stringify({ 87: 1 }),
+      [INVENTORY_SCHEMA_KEY]: '2',
+    })
+
+    expect(persistCanonicalInventory(storage, 'SOR', { 351: 2 }, catalog)).toBe(true)
+    expect(storage.getItem('inv:SOR')).toBe(JSON.stringify({ 87: 2 }))
+    expect(removePersistedInventory(storage, 'SOR', catalog)).toBe(true)
+    expect(storage.getItem('inv:SOR')).toBeNull()
   })
 })

--- a/src/core/inventory.ts
+++ b/src/core/inventory.ts
@@ -247,3 +247,43 @@ export function loadInventoriesForPersistence(
     }
   }
 }
+
+export function inventoryPersistenceAuthorized(storage: Storage): boolean {
+  try {
+    return (
+      storage.getItem(INVENTORY_SCHEMA_KEY) === INVENTORY_SCHEMA_VERSION ||
+      storage.getItem(INVENTORY_BACKUP_KEY) !== null
+    )
+  } catch {
+    return false
+  }
+}
+
+export function persistCanonicalInventory(
+  storage: Storage,
+  setKey: SetKey,
+  inventory: Inventory,
+  catalog: CanonicalCatalog,
+): boolean {
+  if (!inventoryPersistenceAuthorized(storage) || !knownSetKeys(catalog).has(setKey)) return false
+  try {
+    storage.setItem(`inv:${setKey}`, JSON.stringify(canonicalizeInventory(setKey, inventory, catalog)))
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function removePersistedInventory(
+  storage: Storage,
+  setKey: SetKey,
+  catalog: CanonicalCatalog,
+): boolean {
+  if (!inventoryPersistenceAuthorized(storage) || !knownSetKeys(catalog).has(setKey)) return false
+  try {
+    storage.removeItem(`inv:${setKey}`)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/src/core/inventory.ts
+++ b/src/core/inventory.ts
@@ -126,6 +126,56 @@ export function canonicalizeInventory(
   return canonical
 }
 
+function parseTrustedStoredInventory(
+  raw: string | null,
+  setKey: SetKey,
+  catalog: CanonicalCatalog,
+): Inventory {
+  if (raw === null) return {}
+
+  const parsed: unknown = JSON.parse(raw)
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`Inventory for ${setKey} is not an object.`)
+  }
+
+  for (const [rawNumber, rawQuantity] of Object.entries(parsed)) {
+    const printingNumber = Number(rawNumber)
+    const quantity = Number(rawQuantity)
+    if (
+      !Number.isInteger(printingNumber) ||
+      printingNumber <= 0 ||
+      !Number.isFinite(quantity) ||
+      quantity <= 0 ||
+      !canonicalRef(catalog, setKey, printingNumber)
+    ) {
+      throw new Error(`Inventory for ${setKey} contains an invalid entry.`)
+    }
+  }
+
+  return parsed as Inventory
+}
+
+export function createInventoryExportSnapshot(
+  storage: Pick<Storage, 'getItem'>,
+  setKeys: SetKey[],
+  currentSetKey: SetKey,
+  currentInventory: Inventory,
+  catalog: CanonicalCatalog,
+): Record<SetKey, Inventory> {
+  return Object.fromEntries(setKeys.map(key => {
+    if (key === currentSetKey) {
+      return [key, canonicalizeInventory(key, currentInventory, catalog)]
+    }
+
+    try {
+      const stored = parseTrustedStoredInventory(storage.getItem(`inv:${key}`), key, catalog)
+      return [key, canonicalizeInventory(key, stored, catalog)]
+    } catch {
+      throw new Error(`Inventory for ${key} could not be read for export.`)
+    }
+  })) as Record<SetKey, Inventory>
+}
+
 export function applyImportedInventories(
   current: Record<SetKey, Inventory>,
   imported: Record<SetKey, Inventory>,

--- a/src/core/inventory.ts
+++ b/src/core/inventory.ts
@@ -1,0 +1,166 @@
+import type { Inventory, SetKey } from './types'
+
+export type CanonicalCardRef = {
+  setKey: SetKey
+  printingNumber: number
+  baseNumber: number
+  type?: string
+}
+
+export type CanonicalCatalog = Map<string, CanonicalCardRef>
+export type ImportMode = 'merge' | 'replace'
+export type ImportResult = {
+  inventories: Record<SetKey, Inventory>
+  recognized: number
+  skipped: number
+}
+
+export const INVENTORY_SCHEMA_VERSION = '2'
+export const INVENTORY_SCHEMA_KEY = 'inv:schema-version'
+export const INVENTORY_BACKUP_KEY = 'inv:migration:v2:backup'
+
+export function quotaForType(type?: string): number {
+  const normalized = (type ?? '').trim().toLowerCase()
+  return normalized === 'leader' || normalized === 'base' ? 1 : 3
+}
+
+function asInventory(value: unknown): Inventory {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  return value as Inventory
+}
+
+function parseInventory(raw: string | null): Inventory {
+  if (!raw) return {}
+  try {
+    return asInventory(JSON.parse(raw))
+  } catch {
+    return {}
+  }
+}
+
+function canonicalRef(
+  catalog: CanonicalCatalog,
+  setKey: SetKey,
+  printingNumber: number,
+): CanonicalCardRef | undefined {
+  const printing = catalog.get(`${setKey}:${printingNumber}`)
+  if (!printing || printing.setKey !== setKey) return undefined
+  return catalog.get(`${setKey}:${printing.baseNumber}`) ?? printing
+}
+
+function normalizedEntries(
+  setKey: SetKey,
+  inventory: Inventory,
+  catalog: CanonicalCatalog,
+): Array<{ ref: CanonicalCardRef; quantity: number }> {
+  const result: Array<{ ref: CanonicalCardRef; quantity: number }> = []
+
+  for (const [rawNumber, rawQuantity] of Object.entries(inventory)) {
+    const printingNumber = Number(rawNumber)
+    const quantity = Number(rawQuantity)
+    if (
+      !Number.isInteger(printingNumber) ||
+      printingNumber <= 0 ||
+      !Number.isFinite(quantity) ||
+      quantity <= 0
+    ) {
+      continue
+    }
+
+    const ref = canonicalRef(catalog, setKey, printingNumber)
+    if (ref) result.push({ ref, quantity })
+  }
+
+  return result
+}
+
+export function canonicalizeInventory(
+  setKey: SetKey,
+  inventory: Inventory,
+  catalog: CanonicalCatalog,
+): Inventory {
+  const canonical: Inventory = {}
+
+  for (const { ref, quantity } of normalizedEntries(setKey, inventory, catalog)) {
+    canonical[ref.baseNumber] = Math.min(
+      (canonical[ref.baseNumber] ?? 0) + quantity,
+      quotaForType(ref.type),
+    )
+  }
+
+  return canonical
+}
+
+export function applyImportedInventories(
+  current: Record<SetKey, Inventory>,
+  imported: Record<SetKey, Inventory>,
+  mode: ImportMode,
+  catalog: CanonicalCatalog,
+): ImportResult {
+  const inventories = Object.fromEntries(
+    Object.entries(current).map(([setKey, inventory]) => [
+      setKey,
+      canonicalizeInventory(setKey, inventory, catalog),
+    ]),
+  ) as Record<SetKey, Inventory>
+  let recognized = 0
+  let skipped = 0
+
+  for (const [setKey, rawImported] of Object.entries(imported)) {
+    const currentCanonical = canonicalizeInventory(setKey, current[setKey] ?? {}, catalog)
+    const destination: Inventory = mode === 'merge' ? { ...currentCanonical } : {}
+
+    for (const [rawNumber, rawQuantity] of Object.entries(asInventory(rawImported))) {
+      const printingNumber = Number(rawNumber)
+      const quantity = Number(rawQuantity)
+      const validNumber = Number.isInteger(printingNumber) && printingNumber > 0
+      const validQuantity = Number.isFinite(quantity) && quantity > 0
+      const ref = validNumber ? canonicalRef(catalog, setKey, printingNumber) : undefined
+
+      if (!validNumber || !validQuantity || !ref) {
+        skipped += 1
+        continue
+      }
+
+      recognized += 1
+      destination[ref.baseNumber] = Math.min(
+        (destination[ref.baseNumber] ?? 0) + quantity,
+        quotaForType(ref.type),
+      )
+    }
+
+    inventories[setKey] = destination
+  }
+
+  return { inventories, recognized, skipped }
+}
+
+export function migrateLegacyInventories(
+  storage: Storage,
+  setKeys: SetKey[],
+  catalog: CanonicalCatalog,
+): Record<SetKey, Inventory> {
+  const rawInventories = Object.fromEntries(
+    setKeys.map(setKey => [setKey, storage.getItem(`inv:${setKey}`)]),
+  ) as Record<SetKey, string | null>
+
+  const canonical = Object.fromEntries(
+    setKeys.map(setKey => [
+      setKey,
+      canonicalizeInventory(setKey, parseInventory(rawInventories[setKey]), catalog),
+    ]),
+  ) as Record<SetKey, Inventory>
+
+  if (storage.getItem(INVENTORY_SCHEMA_KEY) === INVENTORY_SCHEMA_VERSION) return canonical
+
+  if (storage.getItem(INVENTORY_BACKUP_KEY) === null) {
+    storage.setItem(INVENTORY_BACKUP_KEY, JSON.stringify(rawInventories))
+  }
+
+  for (const setKey of setKeys) {
+    storage.setItem(`inv:${setKey}`, JSON.stringify(canonical[setKey]))
+  }
+
+  storage.setItem(INVENTORY_SCHEMA_KEY, INVENTORY_SCHEMA_VERSION)
+  return canonical
+}

--- a/src/core/inventory.ts
+++ b/src/core/inventory.ts
@@ -15,6 +15,13 @@ export type ImportResult = {
   skipped: number
 }
 
+export type InventoryLoadResult = {
+  inventories: Record<SetKey, Inventory>
+  migrationSucceeded: boolean
+  backupPreserved: boolean
+  persistenceAllowed: boolean
+}
+
 export const INVENTORY_SCHEMA_VERSION = '2'
 export const INVENTORY_SCHEMA_KEY = 'inv:schema-version'
 export const INVENTORY_BACKUP_KEY = 'inv:migration:v2:backup'
@@ -46,6 +53,34 @@ function canonicalRef(
   const printing = catalog.get(`${setKey}:${printingNumber}`)
   if (!printing || printing.setKey !== setKey) return undefined
   return catalog.get(`${setKey}:${printing.baseNumber}`) ?? printing
+}
+
+function knownSetKeys(catalog: CanonicalCatalog): Set<SetKey> {
+  return new Set([...catalog.values()].map(ref => ref.setKey))
+}
+
+export function collectRawImportEntry(
+  imported: Record<SetKey, Inventory>,
+  rawSetKey: unknown,
+  rawPrintingNumber: unknown,
+  rawQuantity: unknown,
+): boolean {
+  const setKey = typeof rawSetKey === 'string' ? rawSetKey.trim().toUpperCase() : ''
+  const printingNumber = Number(rawPrintingNumber)
+  const quantity = Number(rawQuantity)
+  if (
+    !setKey ||
+    !Number.isInteger(printingNumber) ||
+    printingNumber <= 0 ||
+    !Number.isFinite(quantity) ||
+    quantity <= 0
+  ) {
+    return false
+  }
+
+  const inventory = imported[setKey] ?? (imported[setKey] = {})
+  inventory[printingNumber] = (inventory[printingNumber] ?? 0) + quantity
+  return true
 }
 
 function normalizedEntries(
@@ -97,16 +132,23 @@ export function applyImportedInventories(
   mode: ImportMode,
   catalog: CanonicalCatalog,
 ): ImportResult {
+  const allowedSets = knownSetKeys(catalog)
   const inventories = Object.fromEntries(
-    Object.entries(current).map(([setKey, inventory]) => [
-      setKey,
-      canonicalizeInventory(setKey, inventory, catalog),
-    ]),
+    Object.entries(current)
+      .filter(([setKey]) => allowedSets.has(setKey))
+      .map(([setKey, inventory]) => [
+        setKey,
+        canonicalizeInventory(setKey, inventory, catalog),
+      ]),
   ) as Record<SetKey, Inventory>
   let recognized = 0
   let skipped = 0
 
   for (const [setKey, rawImported] of Object.entries(imported)) {
+    if (!allowedSets.has(setKey)) {
+      skipped += Object.keys(asInventory(rawImported)).length
+      continue
+    }
     const currentCanonical = canonicalizeInventory(setKey, current[setKey] ?? {}, catalog)
     const destination: Inventory = mode === 'merge' ? { ...currentCanonical } : {}
 
@@ -163,4 +205,45 @@ export function migrateLegacyInventories(
 
   storage.setItem(INVENTORY_SCHEMA_KEY, INVENTORY_SCHEMA_VERSION)
   return canonical
+}
+
+export function loadInventoriesForPersistence(
+  storage: Storage,
+  setKeys: SetKey[],
+  catalog: CanonicalCatalog,
+): InventoryLoadResult {
+  try {
+    const inventories = migrateLegacyInventories(storage, setKeys, catalog)
+    let backupPreserved = false
+    try {
+      backupPreserved = storage.getItem(INVENTORY_BACKUP_KEY) !== null
+    } catch {
+      // Migration success is sufficient to permit canonical persistence.
+    }
+    return { inventories, migrationSucceeded: true, backupPreserved, persistenceAllowed: true }
+  } catch {
+    const inventories = Object.fromEntries(setKeys.map(setKey => {
+      let inventory: Inventory = {}
+      try {
+        inventory = parseInventory(storage.getItem(`inv:${setKey}`))
+      } catch {
+        // Recover other valid set records even if one storage read fails.
+      }
+      return [setKey, canonicalizeInventory(setKey, inventory, catalog)]
+    })) as Record<SetKey, Inventory>
+
+    let backupPreserved = false
+    try {
+      backupPreserved = storage.getItem(INVENTORY_BACKUP_KEY) !== null
+    } catch {
+      // If preservation cannot be demonstrated, persistence must stay disabled.
+    }
+
+    return {
+      inventories,
+      migrationSucceeded: false,
+      backupPreserved,
+      persistenceAllowed: backupPreserved,
+    }
+  }
 }

--- a/src/core/loadGuard.test.ts
+++ b/src/core/loadGuard.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { createLoadCommitGate } from './loadGuard'
+
+describe('load commit gate', () => {
+  it('allows only the latest async load to commit', () => {
+    const gate = createLoadCommitGate()
+    const first = gate.begin()
+    const second = gate.begin()
+
+    expect(gate.canCommit(first)).toBe(false)
+    expect(gate.canCommit(second)).toBe(true)
+  })
+
+  it('invalidates a load when its effect is cancelled', () => {
+    const gate = createLoadCommitGate()
+    const request = gate.begin()
+    gate.cancel(request)
+
+    expect(gate.canCommit(request)).toBe(false)
+  })
+})

--- a/src/core/loadGuard.ts
+++ b/src/core/loadGuard.ts
@@ -1,0 +1,24 @@
+export type LoadToken = number
+
+export type LoadCommitGate = {
+  begin: () => LoadToken
+  canCommit: (token: LoadToken) => boolean
+  cancel: (token: LoadToken) => void
+}
+
+export function createLoadCommitGate(): LoadCommitGate {
+  let latest = 0
+
+  return {
+    begin() {
+      latest += 1
+      return latest
+    },
+    canCommit(token) {
+      return token === latest
+    },
+    cancel(token) {
+      if (token === latest) latest += 1
+    },
+  }
+}

--- a/src/core/search.test.ts
+++ b/src/core/search.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { buildSearchSuggestions, submittedSuggestion } from './search'
+
+const catalogs = [
+  {
+    setKey: 'SOR',
+    cards: [
+      {
+        Name: 'Darth Vader',
+        Subtitle: 'Dark Lord of the Sith',
+        Number: 10,
+        Type: 'Leader',
+        Set: 'SOR',
+      },
+      {
+        Name: 'Darth Vader',
+        Subtitle: 'Commanding the First Legion',
+        Number: 87,
+        Type: 'Unit',
+        Set: 'SOR',
+      },
+    ],
+    printingNumbersByBase: new Map([
+      [10, [10]],
+      [87, [87, 351]],
+    ]),
+    baseByPrintingNumber: new Map([
+      [10, 10],
+      [87, 87],
+      [351, 87],
+    ]),
+  },
+  {
+    setKey: 'TWI',
+    cards: [{ Name: 'Brain Invaders', Number: 255, Type: 'Unit', Set: 'TWI' }],
+    printingNumbersByBase: new Map([[255, [255]]]),
+    baseByPrintingNumber: new Map([[255, 255]]),
+  },
+]
+
+describe('search suggestions', () => {
+  it('keeps duplicate names as distinct stable card identities', () => {
+    const results = buildSearchSuggestions('Darth Vader', catalogs, 'SOR')
+    expect(results.map(result => result.baseNumber)).toEqual([10, 87])
+  })
+
+  it('ranks intentional word starts before incidental normalized substrings', () => {
+    const results = buildSearchSuggestions('Vader', catalogs, 'SOR')
+    expect(results[0]).toMatchObject({ setKey: 'SOR', baseNumber: 10 })
+    expect(results[results.length - 1]?.name).toBe('Brain Invaders')
+  })
+
+  it('resolves an alternate printing number to its base card', () => {
+    expect(buildSearchSuggestions('351', catalogs, 'SOR')[0]).toMatchObject({
+      setKey: 'SOR',
+      baseNumber: 87,
+    })
+  })
+
+  it('submits the highlighted result and falls back to the first', () => {
+    const results = buildSearchSuggestions('Darth Vader', catalogs, 'SOR')
+    expect(submittedSuggestion(results, 1)?.baseNumber).toBe(87)
+    expect(submittedSuggestion(results, 99)?.baseNumber).toBe(10)
+  })
+})

--- a/src/core/search.test.ts
+++ b/src/core/search.test.ts
@@ -41,12 +41,12 @@ const catalogs = [
 describe('search suggestions', () => {
   it('keeps duplicate names as distinct stable card identities', () => {
     const results = buildSearchSuggestions('Darth Vader', catalogs, 'SOR')
-    expect(results.map(result => result.baseNumber)).toEqual([10, 87])
+    expect(results.map(result => result.baseNumber)).toEqual([87, 10])
   })
 
   it('ranks intentional word starts before incidental normalized substrings', () => {
     const results = buildSearchSuggestions('Vader', catalogs, 'SOR')
-    expect(results[0]).toMatchObject({ setKey: 'SOR', baseNumber: 10 })
+    expect(results[0]).toMatchObject({ setKey: 'SOR', name: 'Darth Vader' })
     expect(results[results.length - 1]?.name).toBe('Brain Invaders')
   })
 
@@ -59,7 +59,7 @@ describe('search suggestions', () => {
 
   it('submits the highlighted result and falls back to the first', () => {
     const results = buildSearchSuggestions('Darth Vader', catalogs, 'SOR')
-    expect(submittedSuggestion(results, 1)?.baseNumber).toBe(87)
-    expect(submittedSuggestion(results, 99)?.baseNumber).toBe(10)
+    expect(submittedSuggestion(results, 1)?.baseNumber).toBe(10)
+    expect(submittedSuggestion(results, 99)?.baseNumber).toBe(87)
   })
 })

--- a/src/core/search.ts
+++ b/src/core/search.ts
@@ -1,0 +1,105 @@
+import type { Card, SetKey } from './types'
+
+export type SearchCatalog = {
+  setKey: SetKey
+  cards: Card[]
+  printingNumbersByBase: Map<number, number[]>
+  baseByPrintingNumber: Map<number, number>
+}
+
+export type SearchSuggestion = {
+  kind: 'name' | 'number'
+  setKey: SetKey
+  baseNumber: number
+  name: string
+  subtitle?: string
+  type?: string
+  printingNumbers: number[]
+  label: string
+}
+
+type RankedSuggestion = SearchSuggestion & { score: number }
+
+function normalize(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]/g, '')
+}
+
+function nameMatchScore(card: Card, rawQuery: string, normalizedQuery: string): number | null {
+  const normalizedName = normalize(card.Name)
+  const normalizedSubtitle = normalize(card.Subtitle ?? '')
+  const lowerQuery = rawQuery.toLowerCase()
+  const lowerName = card.Name.toLowerCase()
+  const words = lowerName.split(/[^a-z0-9]+/).filter(Boolean)
+
+  if (normalizedName === normalizedQuery) return 0
+  if (words.some(word => word.startsWith(lowerQuery))) return 10
+  if (lowerName.includes(lowerQuery)) return 20
+  if (normalizedSubtitle.includes(normalizedQuery)) return 30
+  if (normalizedName.includes(normalizedQuery)) return 40
+  return null
+}
+
+export function buildSearchSuggestions(
+  query: string,
+  catalogs: SearchCatalog[],
+  currentSetKey: SetKey,
+  limit = 10,
+): SearchSuggestion[] {
+  const rawQuery = query.trim()
+  if (!rawQuery || limit <= 0) return []
+
+  const normalizedQuery = normalize(rawQuery)
+  const numericQuery = /^\d+$/.test(rawQuery)
+    ? Number(rawQuery.replace(/^0+/, '') || '0')
+    : null
+  const byIdentity = new Map<string, RankedSuggestion>()
+
+  for (const catalog of catalogs) {
+    for (const card of catalog.cards) {
+      const printingNumbers = catalog.printingNumbersByBase.get(card.Number) ?? [card.Number]
+      const exactPrinting = numericQuery !== null
+        && catalog.baseByPrintingNumber.get(numericQuery) === card.Number
+      const matchScore = exactPrinting
+        ? 0
+        : nameMatchScore(card, rawQuery, normalizedQuery)
+
+      if (matchScore === null) continue
+
+      const kind = exactPrinting ? 'number' : 'name'
+      const setScore = catalog.setKey === currentSetKey ? 0 : 50
+      const score = exactPrinting ? setScore : 100 + setScore + matchScore
+      const suggestion: RankedSuggestion = {
+        kind,
+        setKey: catalog.setKey,
+        baseNumber: card.Number,
+        name: card.Name,
+        subtitle: card.Subtitle,
+        type: card.Type,
+        printingNumbers,
+        label: `${card.Name}${card.Subtitle ? ` - ${card.Subtitle}` : ''} — #${card.Number} (${catalog.setKey})`,
+        score,
+      }
+      const identity = `${catalog.setKey}:${card.Number}`
+      const existing = byIdentity.get(identity)
+      if (!existing || suggestion.score < existing.score) byIdentity.set(identity, suggestion)
+    }
+  }
+
+  return [...byIdentity.values()]
+    .sort((a, b) =>
+      a.score - b.score
+      || a.name.localeCompare(b.name)
+      || a.baseNumber - b.baseNumber
+      || (a.subtitle ?? '').localeCompare(b.subtitle ?? ''),
+    )
+    .slice(0, limit)
+    .map(({ score: _score, ...suggestion }) => suggestion)
+}
+
+export function submittedSuggestion(
+  suggestions: SearchSuggestion[],
+  highlightIndex: number,
+): SearchSuggestion | null {
+  if (!suggestions.length) return null
+  return suggestions[highlightIndex] ?? suggestions[0]
+}

--- a/src/core/search.ts
+++ b/src/core/search.ts
@@ -89,8 +89,8 @@ export function buildSearchSuggestions(
     .sort((a, b) =>
       a.score - b.score
       || a.name.localeCompare(b.name)
-      || a.baseNumber - b.baseNumber
-      || (a.subtitle ?? '').localeCompare(b.subtitle ?? ''),
+      || (a.subtitle ?? '').localeCompare(b.subtitle ?? '')
+      || a.baseNumber - b.baseNumber,
     )
     .slice(0, limit)
     .map(({ score: _score, ...suggestion }) => suggestion)

--- a/src/core/selection.test.ts
+++ b/src/core/selection.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import type { ActiveSelection, Card } from './types';
+import { selectionAfterMove, viewModeAfterSelection } from './selection';
+
+const active: ActiveSelection = {
+  card: {
+    Name: 'Page Two Card',
+    Number: 16,
+    Set: 'SOR',
+  },
+  number: 16,
+  page: 2,
+  row: 1,
+  column: 4,
+  spreadCol: 4,
+  spreadRow: 1,
+};
+
+describe('selection state', () => {
+  it('uses automatic single-page mode only when enabled', () => {
+    expect(viewModeAfterSelection({ autoOpenSinglePage: true }, 'spread')).toBe('single');
+    expect(viewModeAfterSelection({ autoOpenSinglePage: false }, 'spread')).toBe('spread');
+    expect(viewModeAfterSelection({ autoOpenSinglePage: false }, 'single')).toBe('single');
+  });
+
+  it('moves right across the page boundary and follows the exact card', () => {
+    const destination: Card = {
+      Name: 'Page Three Card',
+      Number: 25,
+      Set: 'SOR',
+    };
+    const byNumber = new Map([[destination.Number, destination]]);
+
+    expect(selectionAfterMove(active, 'right', 3, byNumber)).toEqual({
+      card: destination,
+      number: 25,
+      page: 3,
+      row: 1,
+      column: 1,
+      spreadCol: 5,
+      spreadRow: 1,
+    });
+  });
+
+  it('keeps the current selection when the target slot has no card', () => {
+    expect(selectionAfterMove(active, 'right', 3, new Map())).toBe(active);
+  });
+});

--- a/src/core/selection.ts
+++ b/src/core/selection.ts
@@ -1,0 +1,31 @@
+import { getSpreadCoords, moveBinderSelection, type MoveDirection } from './binder';
+import type { AppSettings } from './settings';
+import type { ActiveSelection, Card } from './types';
+
+export type BinderViewMode = 'single' | 'spread';
+
+export function viewModeAfterSelection(
+  settings: AppSettings,
+  currentMode: BinderViewMode,
+): BinderViewMode {
+  return settings.autoOpenSinglePage ? 'single' : currentMode;
+}
+
+export function selectionAfterMove(
+  active: ActiveSelection,
+  direction: MoveDirection,
+  totalPages: number,
+  byNumber: ReadonlyMap<number, Card>,
+): ActiveSelection {
+  const next = moveBinderSelection(active, direction, totalPages);
+  if (next === active) return active;
+
+  const card = byNumber.get(next.number);
+  if (!card) return active;
+
+  return {
+    ...next,
+    card,
+    ...getSpreadCoords(next.page, next.row, next.column),
+  };
+}

--- a/src/core/setData.test.ts
+++ b/src/core/setData.test.ts
@@ -1,27 +1,27 @@
-import { describe, expect, it, vi } from 'vitest'
-import { fetchSetPayload, parseSetPayload } from './setData'
+import { describe, expect, it, vi } from 'vitest';
+import { fetchSetPayload, parseSetPayload } from './setData';
 
 function response(body: unknown, ok = true): Response {
-  return { ok, json: async () => body } as Response
+  return { ok, json: async () => body } as Response;
 }
 
 describe('set data loading', () => {
   it('rejects a non-success response even when it contains JSON', async () => {
-    const fetcher = vi.fn(async () => response([{ Name: 'Wrong' }], false))
+    const fetcher = vi.fn(async () => response([{ Name: 'Wrong' }], false));
 
     await expect(fetchSetPayload(fetcher, '/sets/missing.json')).rejects.toThrow(
       'Failed to fetch set data',
-    )
-  })
+    );
+  });
 
   it('rejects malformed primary payload objects', () => {
-    expect(() => parseSetPayload({ cards: [] })).toThrow('Invalid set data')
-  })
+    expect(() => parseSetPayload({ cards: [] })).toThrow('Invalid set data');
+  });
 
   it('accepts array payloads and data-array wrappers', () => {
-    const cards = [{ Name: 'Alpha', Number: 1 }]
+    const cards = [{ Name: 'Alpha', Number: 1 }];
 
-    expect(parseSetPayload(cards)).toBe(cards)
-    expect(parseSetPayload({ data: cards })).toBe(cards)
-  })
-})
+    expect(parseSetPayload(cards)).toBe(cards);
+    expect(parseSetPayload({ data: cards })).toBe(cards);
+  });
+});

--- a/src/core/setData.test.ts
+++ b/src/core/setData.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from 'vitest'
+import { fetchSetPayload, parseSetPayload } from './setData'
+
+function response(body: unknown, ok = true): Response {
+  return { ok, json: async () => body } as Response
+}
+
+describe('set data loading', () => {
+  it('rejects a non-success response even when it contains JSON', async () => {
+    const fetcher = vi.fn(async () => response([{ Name: 'Wrong' }], false))
+
+    await expect(fetchSetPayload(fetcher, '/sets/missing.json')).rejects.toThrow(
+      'Failed to fetch set data',
+    )
+  })
+
+  it('rejects malformed primary payload objects', () => {
+    expect(() => parseSetPayload({ cards: [] })).toThrow('Invalid set data')
+  })
+
+  it('accepts array payloads and data-array wrappers', () => {
+    const cards = [{ Name: 'Alpha', Number: 1 }]
+
+    expect(parseSetPayload(cards)).toBe(cards)
+    expect(parseSetPayload({ data: cards })).toBe(cards)
+  })
+})

--- a/src/core/setData.ts
+++ b/src/core/setData.ts
@@ -1,17 +1,17 @@
-type Fetcher = (input: RequestInfo | URL) => Promise<Response>
+type Fetcher = (input: RequestInfo | URL) => Promise<Response>;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return !!value && typeof value === 'object' && !Array.isArray(value)
+  return !!value && typeof value === 'object' && !Array.isArray(value);
 }
 
 export function parseSetPayload(payload: unknown): unknown[] {
-  if (Array.isArray(payload)) return payload
-  if (isRecord(payload) && Array.isArray(payload.data)) return payload.data
-  throw new Error('Invalid set data payload.')
+  if (Array.isArray(payload)) return payload;
+  if (isRecord(payload) && Array.isArray(payload.data)) return payload.data;
+  throw new Error('Invalid set data payload.');
 }
 
 export async function fetchSetPayload(fetcher: Fetcher, url: string): Promise<unknown[]> {
-  const response = await fetcher(url)
-  if (!response.ok) throw new Error(`Failed to fetch set data from ${url}.`)
-  return parseSetPayload(await response.json())
+  const response = await fetcher(url);
+  if (!response.ok) throw new Error(`Failed to fetch set data from ${url}.`);
+  return parseSetPayload(await response.json());
 }

--- a/src/core/setData.ts
+++ b/src/core/setData.ts
@@ -1,0 +1,17 @@
+type Fetcher = (input: RequestInfo | URL) => Promise<Response>
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+export function parseSetPayload(payload: unknown): unknown[] {
+  if (Array.isArray(payload)) return payload
+  if (isRecord(payload) && Array.isArray(payload.data)) return payload.data
+  throw new Error('Invalid set data payload.')
+}
+
+export async function fetchSetPayload(fetcher: Fetcher, url: string): Promise<unknown[]> {
+  const response = await fetcher(url)
+  if (!response.ok) throw new Error(`Failed to fetch set data from ${url}.`)
+  return parseSetPayload(await response.json())
+}

--- a/src/core/settings.test.ts
+++ b/src/core/settings.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { DEFAULT_SETTINGS, readSettings, SETTINGS_STORAGE_KEY, writeSettings } from './settings'
+
+describe('settings persistence', () => {
+  it('enables automatic enlarged-page mode by default', () => {
+    expect(DEFAULT_SETTINGS.autoOpenSinglePage).toBe(true)
+  })
+
+  it('falls back to defaults for missing or malformed storage', () => {
+    expect(readSettings({ getItem: () => null })).toEqual(DEFAULT_SETTINGS)
+    expect(readSettings({ getItem: () => '{bad json' })).toEqual(DEFAULT_SETTINGS)
+  })
+
+  it('round-trips supported settings and ignores unknown values', () => {
+    let stored = ''
+    const storage = {
+      getItem: (key: string) => (key === SETTINGS_STORAGE_KEY ? stored : null),
+      setItem: (_key: string, value: string) => {
+        stored = value
+      },
+    }
+
+    writeSettings(storage, { autoOpenSinglePage: false })
+
+    expect(readSettings(storage)).toEqual({ autoOpenSinglePage: false })
+    stored = JSON.stringify({ autoOpenSinglePage: 'no', futureSetting: true })
+    expect(readSettings(storage)).toEqual(DEFAULT_SETTINGS)
+  })
+})

--- a/src/core/settings.ts
+++ b/src/core/settings.ts
@@ -1,0 +1,30 @@
+export type AppSettings = {
+  autoOpenSinglePage: boolean
+}
+
+export const DEFAULT_SETTINGS: AppSettings = {
+  autoOpenSinglePage: true,
+}
+
+export const SETTINGS_STORAGE_KEY = 'swu:settings:v1'
+
+type ReadStorage = Pick<Storage, 'getItem'>
+type WriteStorage = Pick<Storage, 'setItem'>
+
+export function readSettings(storage: ReadStorage): AppSettings {
+  try {
+    const parsed = JSON.parse(storage.getItem(SETTINGS_STORAGE_KEY) ?? '{}') as Partial<AppSettings>
+    return {
+      autoOpenSinglePage:
+        typeof parsed.autoOpenSinglePage === 'boolean'
+          ? parsed.autoOpenSinglePage
+          : DEFAULT_SETTINGS.autoOpenSinglePage,
+    }
+  } catch {
+    return DEFAULT_SETTINGS
+  }
+}
+
+export function writeSettings(storage: WriteStorage, settings: AppSettings): void {
+  storage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(settings))
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,0 +1,20 @@
+export type Card = {
+  Name: string
+  Subtitle?: string
+  Number: number
+  Aspects?: string[]
+  Type?: string
+  Rarity?: string
+  MarketPrice?: number
+  Set: string
+}
+
+export type Inventory = Record<number, number>
+export type SetKey = string
+export type SetMeta = { key: string; label: string; file: string }
+export type BinderPosition = { number: number; page: number; row: number; column: number }
+export type ActiveSelection = BinderPosition & {
+  card: Card
+  spreadCol: number
+  spreadRow: number
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,10 @@
+/// <reference types="vitest/config" />
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: 'jsdom',
+  },
 })


### PR DESCRIPTION
## Summary

- add a large centered card locator with physical page, row, and column coordinates
- add persisted Settings for automatic Single Page filing view, while preserving manual Spread mode
- preserve and test keyboard grid navigation, wrapping, quantity controls, search focus, and spread shortcuts
- make search selection exact for duplicate names, alternate printings, and cross-set results
- canonicalize inventory by base card across supported JSON, CSV, and XLSX imports
- add a silent, backup-first local inventory migration with centralized write protection
- surface local persistence, export, and set-data loading failures instead of silently losing or hiding data
- document the personal, local-first filing workflow and accepted import schemas

## Why

This project is a personal filing aid. The primary goal is to make physical SWU card organization easier when card numbers are difficult to read, while keeping the fast keyboard workflow intact.

The iteration also fixes ambiguity around duplicate card names and alternate printings, and protects existing locally stored inventory during schema normalization.

## User impact

Selecting a card now opens a high-readability locator and, by default, a centered four-column physical page. The behavior can be disabled in Settings. Existing arrow, quantity, search, and spread shortcuts remain available.

Inventory stays local to the browser. Cloud sync and accounts are intentionally out of scope for this PR.

## Validation

- 70 Vitest tests passing across 14 files
- TypeScript typecheck passing
- ESLint passing
- production Vite build passing
- desktop and 800px manual browser checks completed without console errors
- full branch code review approved

## Known baseline

Repository-wide `npm run format:check` still reports 34 pre-existing committed files. New set-data helpers and README changes pass focused Prettier checks; this PR avoids a broad unrelated formatting rewrite.
