### PR TITLE
feat: cloud-sync inventory via Google OAuth + SQLite API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,8 @@ coverage/
 
 # ---- Docker (local overrides) ----
 docker-compose.override.yml
+
+# ---- Runtime data (local-dev SQLite; prod bind mount is /var/config/swu-organizer) ----
+data/
+server/.env
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,34 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.swu-organizer.entrypoints=websecure"
       - "traefik.http.routers.swu-organizer.rule=Host(`swu.mattyflix.com`)"
+      - "traefik.http.routers.swu-organizer.priority=1"
       - "traefik.http.services.swu-organizer.loadbalancer.server.port=8080"
+    networks:
+      - proxy
+
+  swu-api:
+    build: ./server
+    container_name: swu-api
+    restart: unless-stopped
+    environment:
+      - DB_PATH=/config/swu.db
+      - PORT=3001
+      - SESSION_SECRET=${SESSION_SECRET}
+      - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}
+      - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET}
+      - OAUTH_REDIRECT=${OAUTH_REDIRECT}
+      - POST_LOGIN_REDIRECT=${POST_LOGIN_REDIRECT}
+      - ALLOWED_EMAILS=${ALLOWED_EMAILS}
+      - COOKIE_SECURE=true
+      - TRUST_PROXY=true
+    volumes:
+      - /var/config/swu-organizer:/config
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.swu-api.entrypoints=websecure"
+      - "traefik.http.routers.swu-api.rule=Host(`swu.mattyflix.com`) && PathPrefix(`/api`)"
+      - "traefik.http.routers.swu-api.priority=100"
+      - "traefik.http.services.swu-api.loadbalancer.server.port=3001"
     networks:
       - proxy
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -24,7 +24,7 @@ export default tseslint.config(
         'warn',
         {
           allowConstantExport: true,
-          allowExportNames: ['parseCsvData', 'parseXlsxData'],
+          allowExportNames: ['parseCsvData', 'parseXlsxData', 'summarize'],
         },
       ],
       '@typescript-eslint/no-unused-vars': [

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,38 @@
+# Portainer / docker-compose environment variables for the swu-api service.
+#
+# In production, set these in your Portainer stack's Environment variables UI
+# so they interpolate into the ${VAR} slots in docker-compose.yml.
+#
+# For local development (`npm run dev` inside ./server), copy this file to
+# `.env` in ./server/ and adjust as needed — the dev script also reads from
+# process.env, and a local dotenv loader can be added if you want.
+
+# --- Session signing key ---
+# Generate a strong random value once and keep it stable:
+#   openssl rand -base64 32
+SESSION_SECRET=change-me-to-a-long-random-string
+
+# --- Google OAuth 2.0 web-client credentials ---
+GOOGLE_CLIENT_ID=xxxxxxxxxxxx.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=xxxxxxxxxxxxxxxxx
+
+# Must exactly match an Authorized redirect URI on your Google OAuth client.
+OAUTH_REDIRECT=https://swu.mattyflix.com/api/auth/callback
+
+# Browser destination after a successful sign-in (usually the SPA root).
+POST_LOGIN_REDIRECT=https://swu.mattyflix.com/
+
+# Comma-separated list of Google emails allowed to sign in. Anyone else gets 403.
+ALLOWED_EMAILS=matt.grochocinski@gmail.com
+
+# --- Local-dev-only overrides (uncomment when running the API on http:// locally) ---
+# When true, session cookies require HTTPS (correct for production behind Traefik).
+# For local dev over http://localhost, set to false so the browser accepts the cookie.
+# COOKIE_SECURE=false
+
+# When behind a reverse proxy that sets X-Forwarded-* headers (Traefik in prod).
+# TRUST_PROXY=true
+
+# Where the SQLite file lives. In the container this is on the mounted volume.
+# In local dev outside Docker you probably want something like ./data/swu.db.
+# DB_PATH=/config/swu.db

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.env

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,23 @@
+# ---------- build stage ----------
+FROM node:20-alpine AS build
+WORKDIR /app
+RUN apk add --no-cache python3 make g++
+COPY package*.json ./
+RUN npm ci
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build
+
+# ---------- runtime ----------
+FROM node:20-alpine
+WORKDIR /app
+RUN apk add --no-cache wget
+ENV NODE_ENV=production
+COPY package*.json ./
+RUN npm ci --omit=dev
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/src/schema.sql ./dist/schema.sql
+
+EXPOSE 3001
+HEALTHCHECK CMD wget -qO- http://localhost:3001/api/health >/dev/null 2>&1 || exit 1
+CMD ["node", "dist/index.js"]

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "swu-organizer-api",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "license": "PolyForm-Noncommercial-1.0.0",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "better-sqlite3": "^11.5.0",
+    "cookie-parser": "^1.4.7",
+    "express": "^4.21.2",
+    "express-rate-limit": "^7.4.1",
+    "google-auth-library": "^9.15.0",
+    "pino": "^9.5.0",
+    "pino-http": "^10.3.0",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.11",
+    "@types/cookie-parser": "^1.4.7",
+    "@types/express": "^4.17.21",
+    "@types/node": "^22.9.0",
+    "@types/supertest": "^6.0.2",
+    "supertest": "^7.0.0",
+    "tsx": "^4.19.2",
+    "typescript": "^5.6.3",
+    "vitest": "^2.1.4"
+  }
+}

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,0 +1,54 @@
+import express, { type Express } from 'express'
+import cookieParser from 'cookie-parser'
+import pinoHttp from 'pino-http'
+import { pino, type Logger } from 'pino'
+import type { Db } from './db.js'
+import type { Config } from './config.js'
+import { attachSession } from './auth/session.js'
+import { makeAuthRouter } from './auth/routes.js'
+import { makeInventoryRouter } from './inventories/routes.js'
+import { makeGoogleClient } from './auth/google.js'
+
+export type AppDeps = {
+  db: Db
+  config: Config
+  logger?: Logger
+}
+
+export function makeApp({ db, config, logger }: AppDeps): Express {
+  const app = express()
+
+  if (config.TRUST_PROXY) app.set('trust proxy', 1)
+
+  const log: Logger = logger ?? pino({ level: process.env.LOG_LEVEL ?? 'info' })
+  app.use(pinoHttp({ logger: log }))
+  app.use(express.json({ limit: '2mb' }))
+  app.use(cookieParser())
+  app.use(attachSession({ db, secret: config.SESSION_SECRET }))
+
+  app.get('/api/health', (_req, res) => {
+    res.json({ ok: true })
+  })
+
+  const googleClient = makeGoogleClient({
+    clientId: config.GOOGLE_CLIENT_ID,
+    clientSecret: config.GOOGLE_CLIENT_SECRET,
+    redirectUri: config.OAUTH_REDIRECT,
+  })
+
+  app.use(
+    '/api/auth',
+    makeAuthRouter({
+      db,
+      googleClient,
+      googleClientId: config.GOOGLE_CLIENT_ID,
+      allowedEmails: new Set(config.ALLOWED_EMAILS),
+      sessionSecret: config.SESSION_SECRET,
+      cookieSecure: config.COOKIE_SECURE,
+      postLoginRedirect: config.POST_LOGIN_REDIRECT,
+    }),
+  )
+  app.use('/api/inventories', makeInventoryRouter({ db }))
+
+  return app
+}

--- a/server/src/auth/google.ts
+++ b/server/src/auth/google.ts
@@ -1,0 +1,50 @@
+import { OAuth2Client } from 'google-auth-library'
+
+export type GoogleIdentity = {
+  sub: string
+  email: string
+  emailVerified: boolean
+}
+
+export type GoogleConfig = {
+  clientId: string
+  clientSecret: string
+  redirectUri: string
+}
+
+export function makeGoogleClient(cfg: GoogleConfig): OAuth2Client {
+  return new OAuth2Client({
+    clientId: cfg.clientId,
+    clientSecret: cfg.clientSecret,
+    redirectUri: cfg.redirectUri,
+  })
+}
+
+export function buildAuthUrl(client: OAuth2Client, state: string): string {
+  return client.generateAuthUrl({
+    access_type: 'online',
+    prompt: 'select_account',
+    scope: ['openid', 'email'],
+    state,
+    include_granted_scopes: false,
+  })
+}
+
+export async function exchangeCodeForIdentity(
+  client: OAuth2Client,
+  code: string,
+  clientId: string,
+): Promise<GoogleIdentity> {
+  const { tokens } = await client.getToken(code)
+  if (!tokens.id_token) throw new Error('Google response missing id_token')
+  const ticket = await client.verifyIdToken({ idToken: tokens.id_token, audience: clientId })
+  const payload = ticket.getPayload()
+  if (!payload || !payload.sub || !payload.email) {
+    throw new Error('Google id_token payload missing sub/email')
+  }
+  return {
+    sub: payload.sub,
+    email: payload.email.toLowerCase(),
+    emailVerified: payload.email_verified === true,
+  }
+}

--- a/server/src/auth/routes.ts
+++ b/server/src/auth/routes.ts
@@ -1,0 +1,125 @@
+import { Router, type RequestHandler } from 'express'
+import rateLimit from 'express-rate-limit'
+import { randomBytes } from 'node:crypto'
+import type { OAuth2Client } from 'google-auth-library'
+import type { Db } from '../db.js'
+import { buildAuthUrl, exchangeCodeForIdentity } from './google.js'
+import {
+  clearSessionCookie,
+  createSession,
+  destroySession,
+  requireAuth,
+  setSessionCookie,
+} from './session.js'
+
+type Deps = {
+  db: Db
+  googleClient: OAuth2Client
+  googleClientId: string
+  allowedEmails: Set<string>
+  sessionSecret: string
+  cookieSecure: boolean
+  postLoginRedirect: string
+}
+
+const STATE_COOKIE = 'oauth_state'
+const STATE_TTL_MS = 10 * 60 * 1000
+
+export function makeAuthRouter(deps: Deps): Router {
+  const router = Router()
+
+  const callbackLimiter = rateLimit({
+    windowMs: 60 * 1000,
+    max: 20,
+    standardHeaders: true,
+    legacyHeaders: false,
+  })
+
+  const loginLimiter = rateLimit({
+    windowMs: 60 * 1000,
+    max: 30,
+    standardHeaders: true,
+    legacyHeaders: false,
+  })
+
+  router.get('/login', loginLimiter, (_req, res) => {
+    const state = randomBytes(24).toString('base64url')
+    res.cookie(STATE_COOKIE, state, {
+      httpOnly: true,
+      secure: deps.cookieSecure,
+      sameSite: 'lax',
+      path: '/api/auth',
+      maxAge: STATE_TTL_MS,
+    })
+    res.redirect(buildAuthUrl(deps.googleClient, state))
+  })
+
+  router.get('/callback', callbackLimiter, (async (req, res) => {
+    const code = typeof req.query.code === 'string' ? req.query.code : ''
+    const state = typeof req.query.state === 'string' ? req.query.state : ''
+    const cookieState = req.cookies?.[STATE_COOKIE] as string | undefined
+    res.clearCookie(STATE_COOKIE, { path: '/api/auth' })
+
+    if (!code || !state || !cookieState || state !== cookieState) {
+      res.status(400).json({ error: 'invalid_state' })
+      return
+    }
+
+    let identity
+    try {
+      identity = await exchangeCodeForIdentity(deps.googleClient, code, deps.googleClientId)
+    } catch {
+      res.status(400).json({ error: 'code_exchange_failed' })
+      return
+    }
+
+    if (!identity.emailVerified) {
+      res.status(403).json({ error: 'email_not_verified' })
+      return
+    }
+    if (!deps.allowedEmails.has(identity.email)) {
+      res.status(403).json({ error: 'email_not_allowed' })
+      return
+    }
+
+    const now = Date.now()
+    const existing = deps.db
+      .prepare('SELECT id FROM users WHERE google_sub = ?')
+      .get(identity.sub) as { id: number } | undefined
+
+    let userId: number
+    if (existing) {
+      userId = existing.id
+      deps.db.prepare('UPDATE users SET email = ? WHERE id = ?').run(identity.email, userId)
+    } else {
+      const result = deps.db
+        .prepare('INSERT INTO users (google_sub, email, created_at) VALUES (?, ?, ?)')
+        .run(identity.sub, identity.email, now)
+      userId = Number(result.lastInsertRowid)
+    }
+
+    const session = createSession(deps.db, userId, now)
+    setSessionCookie(res, session.id, { secret: deps.sessionSecret, secure: deps.cookieSecure })
+    res.redirect(deps.postLoginRedirect)
+  }) as RequestHandler)
+
+  router.post('/logout', (req, res) => {
+    const sid = req.session?.sessionId
+    if (sid) destroySession(deps.db, sid)
+    clearSessionCookie(res, { secret: deps.sessionSecret, secure: deps.cookieSecure })
+    res.status(204).end()
+  })
+
+  router.get('/me', requireAuth(), (req, res) => {
+    const row = deps.db
+      .prepare('SELECT email FROM users WHERE id = ?')
+      .get(req.session!.userId) as { email: string } | undefined
+    if (!row) {
+      res.status(401).json({ error: 'unauthenticated' })
+      return
+    }
+    res.json({ email: row.email })
+  })
+
+  return router
+}

--- a/server/src/auth/session.ts
+++ b/server/src/auth/session.ts
@@ -1,0 +1,137 @@
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto'
+import type { Request, Response, NextFunction, RequestHandler } from 'express'
+import type { Db } from '../db.js'
+
+const COOKIE_NAME = 'sid'
+const SESSION_TTL_MS = 30 * 24 * 60 * 60 * 1000
+const REFRESH_WINDOW_MS = 24 * 60 * 60 * 1000
+
+export type SessionRow = {
+  id: string
+  user_id: number
+  expires_at: number
+}
+
+export type SessionUser = {
+  userId: number
+  sessionId: string
+}
+
+declare module 'express-serve-static-core' {
+  interface Request {
+    session?: SessionUser
+  }
+}
+
+function sign(value: string, secret: string): string {
+  return createHmac('sha256', secret).update(value).digest('base64url')
+}
+
+function safeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a)
+  const bb = Buffer.from(b)
+  if (ab.length !== bb.length) return false
+  return timingSafeEqual(ab, bb)
+}
+
+export function encodeSid(id: string, secret: string): string {
+  return `${id}.${sign(id, secret)}`
+}
+
+export function decodeSid(cookie: string | undefined, secret: string): string | null {
+  if (!cookie) return null
+  const dot = cookie.indexOf('.')
+  if (dot < 0) return null
+  const id = cookie.slice(0, dot)
+  const mac = cookie.slice(dot + 1)
+  if (!id || !mac) return null
+  if (!safeEqual(mac, sign(id, secret))) return null
+  return id
+}
+
+export function createSession(db: Db, userId: number, now = Date.now()): SessionRow {
+  const id = randomBytes(32).toString('base64url')
+  const expiresAt = now + SESSION_TTL_MS
+  db.prepare(
+    'INSERT INTO sessions (id, user_id, expires_at, created_at) VALUES (?, ?, ?, ?)',
+  ).run(id, userId, expiresAt, now)
+  return { id, user_id: userId, expires_at: expiresAt }
+}
+
+export function readSession(db: Db, id: string, now = Date.now()): SessionRow | null {
+  const row = db
+    .prepare('SELECT id, user_id, expires_at FROM sessions WHERE id = ?')
+    .get(id) as SessionRow | undefined
+  if (!row) return null
+  if (row.expires_at <= now) {
+    destroySession(db, id)
+    return null
+  }
+  if (row.expires_at - now < SESSION_TTL_MS - REFRESH_WINDOW_MS) {
+    const newExpires = now + SESSION_TTL_MS
+    db.prepare('UPDATE sessions SET expires_at = ? WHERE id = ?').run(newExpires, id)
+    row.expires_at = newExpires
+  }
+  return row
+}
+
+export function destroySession(db: Db, id: string): void {
+  db.prepare('DELETE FROM sessions WHERE id = ?').run(id)
+}
+
+type SessionCookieOptions = {
+  secret: string
+  secure: boolean
+}
+
+export function setSessionCookie(res: Response, sessionId: string, opts: SessionCookieOptions): void {
+  const value = encodeSid(sessionId, opts.secret)
+  res.cookie(COOKIE_NAME, value, {
+    httpOnly: true,
+    secure: opts.secure,
+    sameSite: 'lax',
+    path: '/',
+    maxAge: SESSION_TTL_MS,
+  })
+}
+
+export function clearSessionCookie(res: Response, opts: SessionCookieOptions): void {
+  res.clearCookie(COOKIE_NAME, {
+    httpOnly: true,
+    secure: opts.secure,
+    sameSite: 'lax',
+    path: '/',
+  })
+}
+
+export function readSessionCookie(req: Request, secret: string): string | null {
+  const raw = req.cookies?.[COOKIE_NAME] as string | undefined
+  return decodeSid(raw, secret)
+}
+
+type AuthDeps = {
+  db: Db
+  secret: string
+}
+
+export function attachSession(deps: AuthDeps): RequestHandler {
+  return (req, _res, next) => {
+    const id = readSessionCookie(req, deps.secret)
+    if (!id) return next()
+    const row = readSession(deps.db, id)
+    if (row) req.session = { userId: row.user_id, sessionId: row.id }
+    next()
+  }
+}
+
+export function requireAuth(): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (!req.session) {
+      res.status(401).json({ error: 'unauthenticated' })
+      return
+    }
+    next()
+  }
+}
+
+export const SESSION_COOKIE_NAME = COOKIE_NAME

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod'
+
+const bool = z
+  .union([z.boolean(), z.string()])
+  .transform(v => (typeof v === 'boolean' ? v : /^(1|true|yes|on)$/i.test(v)))
+
+const Env = z.object({
+  PORT: z.coerce.number().int().positive().default(3001),
+  DB_PATH: z.string().min(1).default('/data/swu.db'),
+  SESSION_SECRET: z.string().min(16, 'SESSION_SECRET must be at least 16 chars'),
+  GOOGLE_CLIENT_ID: z.string().min(1),
+  GOOGLE_CLIENT_SECRET: z.string().min(1),
+  OAUTH_REDIRECT: z.string().url(),
+  POST_LOGIN_REDIRECT: z.string().url().default('http://localhost:5173/'),
+  ALLOWED_EMAILS: z
+    .string()
+    .transform(v =>
+      v
+        .split(',')
+        .map(s => s.trim().toLowerCase())
+        .filter(Boolean),
+    )
+    .pipe(z.array(z.string().email()).min(1, 'ALLOWED_EMAILS must include at least one email')),
+  COOKIE_SECURE: bool.default(true),
+  TRUST_PROXY: bool.default(true),
+})
+
+export type Config = z.infer<typeof Env>
+
+export function loadConfig(source: NodeJS.ProcessEnv = process.env): Config {
+  const parsed = Env.safeParse(source)
+  if (!parsed.success) {
+    const issues = parsed.error.issues.map(i => `  ${i.path.join('.') || '(root)'}: ${i.message}`).join('\n')
+    throw new Error(`Invalid server configuration:\n${issues}`)
+  }
+  return parsed.data
+}

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -1,0 +1,31 @@
+import Database, { type Database as DatabaseInstance } from 'better-sqlite3'
+import { readFileSync } from 'node:fs'
+import { dirname } from 'node:path'
+import { mkdirSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const SCHEMA_PATH = join(here, 'schema.sql')
+
+export type Db = DatabaseInstance
+
+export function openDb(dbPath: string): Db {
+  if (dbPath !== ':memory:') {
+    mkdirSync(dirname(dbPath), { recursive: true })
+  }
+  const db = new Database(dbPath)
+  db.pragma('journal_mode = WAL')
+  db.pragma('foreign_keys = ON')
+  bootstrap(db)
+  return db
+}
+
+function bootstrap(db: Db): void {
+  const currentVersion = Number(
+    (db.pragma('user_version', { simple: true }) as number | bigint) ?? 0,
+  )
+  if (currentVersion >= 1) return
+  const schema = readFileSync(SCHEMA_PATH, 'utf8')
+  db.exec(schema)
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,0 +1,14 @@
+import { pino } from 'pino'
+import { loadConfig } from './config.js'
+import { openDb } from './db.js'
+import { makeApp } from './app.js'
+
+const logger = pino({ level: process.env.LOG_LEVEL ?? 'info' })
+
+const config = loadConfig()
+const db = openDb(config.DB_PATH)
+const app = makeApp({ db, config, logger })
+
+app.listen(config.PORT, () => {
+  logger.info({ port: config.PORT }, 'swu-api listening')
+})

--- a/server/src/inventories/repo.ts
+++ b/server/src/inventories/repo.ts
@@ -1,0 +1,105 @@
+import type { Db } from '../db.js'
+
+export type Inventory = Record<string, number>
+
+export type InventoryRow = {
+  setKey: string
+  data: Inventory
+  version: number
+  updatedAt: number
+}
+
+export type PutOutcome =
+  | { ok: true; version: number }
+  | { ok: false; current: InventoryRow }
+
+function parseData(json: string): Inventory {
+  try {
+    const parsed = JSON.parse(json)
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? (parsed as Inventory) : {}
+  } catch {
+    return {}
+  }
+}
+
+export function getAll(db: Db, userId: number): InventoryRow[] {
+  const rows = db
+    .prepare(
+      'SELECT set_key AS setKey, data_json AS dataJson, version, updated_at AS updatedAt FROM inventories WHERE user_id = ?',
+    )
+    .all(userId) as Array<{ setKey: string; dataJson: string; version: number; updatedAt: number }>
+  return rows.map(r => ({
+    setKey: r.setKey,
+    data: parseData(r.dataJson),
+    version: r.version,
+    updatedAt: r.updatedAt,
+  }))
+}
+
+export function getOne(db: Db, userId: number, setKey: string): InventoryRow | null {
+  const row = db
+    .prepare(
+      'SELECT set_key AS setKey, data_json AS dataJson, version, updated_at AS updatedAt FROM inventories WHERE user_id = ? AND set_key = ?',
+    )
+    .get(userId, setKey) as
+    | { setKey: string; dataJson: string; version: number; updatedAt: number }
+    | undefined
+  if (!row) return null
+  return {
+    setKey: row.setKey,
+    data: parseData(row.dataJson),
+    version: row.version,
+    updatedAt: row.updatedAt,
+  }
+}
+
+export function upsertOne(
+  db: Db,
+  userId: number,
+  setKey: string,
+  data: Inventory,
+  expectedVersion: number,
+  now = Date.now(),
+): PutOutcome {
+  const json = JSON.stringify(data)
+  const tx = db.transaction((): PutOutcome => {
+    const current = getOne(db, userId, setKey)
+    if (!current) {
+      if (expectedVersion !== 0) {
+        return { ok: false, current: { setKey, data: {}, version: 0, updatedAt: 0 } }
+      }
+      db.prepare(
+        'INSERT INTO inventories (user_id, set_key, data_json, version, updated_at) VALUES (?, ?, ?, ?, ?)',
+      ).run(userId, setKey, json, 1, now)
+      return { ok: true, version: 1 }
+    }
+    if (current.version !== expectedVersion) {
+      return { ok: false, current }
+    }
+    const nextVersion = current.version + 1
+    db.prepare(
+      'UPDATE inventories SET data_json = ?, version = ?, updated_at = ? WHERE user_id = ? AND set_key = ?',
+    ).run(json, nextVersion, now, userId, setKey)
+    return { ok: true, version: nextVersion }
+  })
+  return tx()
+}
+
+export function replaceAll(
+  db: Db,
+  userId: number,
+  sets: Record<string, Inventory>,
+  now = Date.now(),
+): InventoryRow[] {
+  const tx = db.transaction(() => {
+    db.prepare('DELETE FROM inventories WHERE user_id = ?').run(userId)
+    const insert = db.prepare(
+      'INSERT INTO inventories (user_id, set_key, data_json, version, updated_at) VALUES (?, ?, ?, ?, ?)',
+    )
+    for (const [setKey, data] of Object.entries(sets)) {
+      insert.run(userId, setKey, JSON.stringify(data ?? {}), 1, now)
+    }
+  })
+  tx()
+  return getAll(db, userId)
+}

--- a/server/src/inventories/routes.ts
+++ b/server/src/inventories/routes.ts
@@ -1,0 +1,77 @@
+import { Router } from 'express'
+import { z } from 'zod'
+import type { Db } from '../db.js'
+import { requireAuth } from '../auth/session.js'
+import { getAll, replaceAll, upsertOne, type InventoryRow } from './repo.js'
+
+const SET_KEY_RE = /^[A-Z0-9]{1,16}$/
+const InventorySchema = z.record(z.string(), z.number().int().nonnegative())
+const PutBody = z.object({ data: InventorySchema })
+const BulkBody = z.object({
+  sets: z.record(z.string().regex(SET_KEY_RE), InventorySchema),
+})
+
+type Deps = { db: Db }
+
+function toResponseSets(rows: InventoryRow[]): Record<string, { data: Record<string, number>; version: number; updatedAt: number }> {
+  const out: Record<string, { data: Record<string, number>; version: number; updatedAt: number }> = {}
+  for (const r of rows) {
+    out[r.setKey] = { data: r.data, version: r.version, updatedAt: r.updatedAt }
+  }
+  return out
+}
+
+export function makeInventoryRouter(deps: Deps): Router {
+  const router = Router()
+  router.use(requireAuth())
+
+  router.get('/', (req, res) => {
+    const rows = getAll(deps.db, req.session!.userId)
+    res.json({ sets: toResponseSets(rows) })
+  })
+
+  router.put('/', (req, res) => {
+    const parsed = BulkBody.safeParse(req.body)
+    if (!parsed.success) {
+      res.status(400).json({ error: 'invalid_body', issues: parsed.error.issues })
+      return
+    }
+    const rows = replaceAll(deps.db, req.session!.userId, parsed.data.sets)
+    res.json({ sets: toResponseSets(rows) })
+  })
+
+  router.put('/:setKey', (req, res) => {
+    const setKey = req.params.setKey ?? ''
+    if (!SET_KEY_RE.test(setKey)) {
+      res.status(400).json({ error: 'invalid_set_key' })
+      return
+    }
+    const parsedBody = PutBody.safeParse(req.body)
+    if (!parsedBody.success) {
+      res.status(400).json({ error: 'invalid_body', issues: parsedBody.error.issues })
+      return
+    }
+    const ifMatch = req.header('if-match')
+    const expected = ifMatch === undefined ? NaN : Number(ifMatch)
+    if (!Number.isInteger(expected) || expected < 0) {
+      res.status(428).json({ error: 'if_match_required' })
+      return
+    }
+
+    const outcome = upsertOne(deps.db, req.session!.userId, setKey, parsedBody.data.data, expected)
+    if (outcome.ok) {
+      res.json({ version: outcome.version })
+      return
+    }
+    res.status(409).json({
+      error: 'version_conflict',
+      current: {
+        data: outcome.current.data,
+        version: outcome.current.version,
+        updatedAt: outcome.current.updatedAt,
+      },
+    })
+  })
+
+  return router
+}

--- a/server/src/schema.sql
+++ b/server/src/schema.sql
@@ -1,0 +1,28 @@
+-- Applied once at boot when PRAGMA user_version < 1.
+
+CREATE TABLE IF NOT EXISTS users (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  google_sub TEXT UNIQUE NOT NULL,
+  email TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS sessions (
+  id TEXT PRIMARY KEY,
+  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  expires_at INTEGER NOT NULL,
+  created_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_user ON sessions(user_id);
+
+CREATE TABLE IF NOT EXISTS inventories (
+  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  set_key TEXT NOT NULL,
+  data_json TEXT NOT NULL,
+  version INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  PRIMARY KEY (user_id, set_key)
+);
+
+PRAGMA user_version = 1;

--- a/server/test/auth.test.ts
+++ b/server/test/auth.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import request from 'supertest'
+import { makeTestApp, memoryDb, seedUserWithSession } from './helpers.js'
+import { decodeSid, encodeSid } from '../src/auth/session.js'
+
+describe('auth', () => {
+  it('GET /api/health responds without auth', async () => {
+    const db = memoryDb()
+    const app = makeTestApp(db)
+    const res = await request(app).get('/api/health')
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ ok: true })
+  })
+
+  it('GET /api/auth/me returns 401 without a session cookie', async () => {
+    const db = memoryDb()
+    const app = makeTestApp(db)
+    const res = await request(app).get('/api/auth/me')
+    expect(res.status).toBe(401)
+  })
+
+  it('GET /api/auth/me returns email for a valid session', async () => {
+    const db = memoryDb()
+    const app = makeTestApp(db)
+    const { cookie } = seedUserWithSession(db, 'allowed@example.com')
+    const res = await request(app).get('/api/auth/me').set('Cookie', cookie)
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ email: 'allowed@example.com' })
+  })
+
+  it('POST /api/auth/logout clears the session and cookie', async () => {
+    const db = memoryDb()
+    const app = makeTestApp(db)
+    const { cookie, sessionId } = seedUserWithSession(db)
+    const res = await request(app).post('/api/auth/logout').set('Cookie', cookie)
+    expect(res.status).toBe(204)
+    const row = db.prepare('SELECT id FROM sessions WHERE id = ?').get(sessionId)
+    expect(row).toBeUndefined()
+  })
+
+  it('GET /api/auth/login sets an oauth_state cookie and redirects to Google', async () => {
+    const db = memoryDb()
+    const app = makeTestApp(db)
+    const res = await request(app).get('/api/auth/login')
+    expect(res.status).toBe(302)
+    expect(res.headers.location).toContain('accounts.google.com')
+    expect(res.headers['set-cookie']?.join(';')).toContain('oauth_state=')
+  })
+
+  it('GET /api/auth/callback rejects mismatched state', async () => {
+    const db = memoryDb()
+    const app = makeTestApp(db)
+    const res = await request(app)
+      .get('/api/auth/callback?code=abc&state=notmatching')
+      .set('Cookie', 'oauth_state=different')
+    expect(res.status).toBe(400)
+  })
+
+  it('signed session cookies round-trip', () => {
+    const secret = 'testing-secret-1234567890'
+    const encoded = encodeSid('abc123', secret)
+    expect(decodeSid(encoded, secret)).toBe('abc123')
+    expect(decodeSid(encoded, 'wrong-secret')).toBeNull()
+    expect(decodeSid('abc123.tampered', secret)).toBeNull()
+  })
+})

--- a/server/test/helpers.ts
+++ b/server/test/helpers.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import Database from 'better-sqlite3'
+import { pino } from 'pino'
+import type { Db } from '../src/db.js'
+import type { Config } from '../src/config.js'
+import { makeApp } from '../src/app.js'
+import { createSession, encodeSid } from '../src/auth/session.js'
+
+const silentLogger = pino({ level: 'silent' })
+
+const here = dirname(fileURLToPath(import.meta.url))
+const SCHEMA_PATH = join(here, '..', 'src', 'schema.sql')
+
+export function memoryDb(): Db {
+  const db = new Database(':memory:')
+  db.pragma('foreign_keys = ON')
+  db.exec(readFileSync(SCHEMA_PATH, 'utf8'))
+  return db
+}
+
+export const TEST_CONFIG: Config = {
+  PORT: 0,
+  DB_PATH: ':memory:',
+  SESSION_SECRET: 'test-secret-test-secret-test-secret',
+  GOOGLE_CLIENT_ID: 'test-client-id',
+  GOOGLE_CLIENT_SECRET: 'test-client-secret',
+  OAUTH_REDIRECT: 'http://localhost/api/auth/callback',
+  POST_LOGIN_REDIRECT: 'http://localhost/',
+  ALLOWED_EMAILS: ['allowed@example.com'],
+  COOKIE_SECURE: false,
+  TRUST_PROXY: false,
+}
+
+export function makeTestApp(db: Db) {
+  return makeApp({ db, config: TEST_CONFIG, logger: silentLogger })
+}
+
+export function seedUserWithSession(db: Db, email = 'allowed@example.com') {
+  const result = db
+    .prepare('INSERT INTO users (google_sub, email, created_at) VALUES (?, ?, ?)')
+    .run(`sub-${email}`, email, Date.now())
+  const userId = Number(result.lastInsertRowid)
+  const session = createSession(db, userId)
+  const cookie = `sid=${encodeSid(session.id, TEST_CONFIG.SESSION_SECRET)}`
+  return { userId, sessionId: session.id, cookie }
+}

--- a/server/test/inventories.test.ts
+++ b/server/test/inventories.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest'
+import request from 'supertest'
+import { makeTestApp, memoryDb, seedUserWithSession } from './helpers.js'
+
+describe('inventories API', () => {
+  it('rejects unauthenticated requests', async () => {
+    const db = memoryDb()
+    const app = makeTestApp(db)
+    const res = await request(app).get('/api/inventories')
+    expect(res.status).toBe(401)
+  })
+
+  it('returns empty sets for a fresh user', async () => {
+    const db = memoryDb()
+    const app = makeTestApp(db)
+    const { cookie } = seedUserWithSession(db)
+    const res = await request(app).get('/api/inventories').set('Cookie', cookie)
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ sets: {} })
+  })
+
+  it('creates a new inventory when If-Match: 0', async () => {
+    const db = memoryDb()
+    const app = makeTestApp(db)
+    const { cookie } = seedUserWithSession(db)
+    const res = await request(app)
+      .put('/api/inventories/SOR')
+      .set('Cookie', cookie)
+      .set('If-Match', '0')
+      .send({ data: { 42: 2 } })
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ version: 1 })
+
+    const list = await request(app).get('/api/inventories').set('Cookie', cookie)
+    expect(list.body.sets.SOR).toMatchObject({ data: { '42': 2 }, version: 1 })
+  })
+
+  it('bumps version on subsequent writes with matching If-Match', async () => {
+    const db = memoryDb()
+    const app = makeTestApp(db)
+    const { cookie } = seedUserWithSession(db)
+    await request(app)
+      .put('/api/inventories/SOR')
+      .set('Cookie', cookie)
+      .set('If-Match', '0')
+      .send({ data: { 1: 1 } })
+    const res = await request(app)
+      .put('/api/inventories/SOR')
+      .set('Cookie', cookie)
+      .set('If-Match', '1')
+      .send({ data: { 1: 2 } })
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ version: 2 })
+  })
+
+  it('returns 409 with the current state when If-Match is stale', async () => {
+    const db = memoryDb()
+    const app = makeTestApp(db)
+    const { cookie } = seedUserWithSession(db)
+    await request(app)
+      .put('/api/inventories/SOR')
+      .set('Cookie', cookie)
+      .set('If-Match', '0')
+      .send({ data: { 1: 1 } })
+    const res = await request(app)
+      .put('/api/inventories/SOR')
+      .set('Cookie', cookie)
+      .set('If-Match', '0')
+      .send({ data: { 1: 9 } })
+    expect(res.status).toBe(409)
+    expect(res.body.error).toBe('version_conflict')
+    expect(res.body.current).toMatchObject({ data: { '1': 1 }, version: 1 })
+  })
+
+  it('requires If-Match header on PUT :setKey', async () => {
+    const db = memoryDb()
+    const app = makeTestApp(db)
+    const { cookie } = seedUserWithSession(db)
+    const res = await request(app)
+      .put('/api/inventories/SOR')
+      .set('Cookie', cookie)
+      .send({ data: { 1: 1 } })
+    expect(res.status).toBe(428)
+  })
+
+  it('bulk PUT replaces all sets atomically and resets versions to 1', async () => {
+    const db = memoryDb()
+    const app = makeTestApp(db)
+    const { cookie } = seedUserWithSession(db)
+    await request(app)
+      .put('/api/inventories/SOR')
+      .set('Cookie', cookie)
+      .set('If-Match', '0')
+      .send({ data: { 1: 3 } })
+
+    const res = await request(app)
+      .put('/api/inventories')
+      .set('Cookie', cookie)
+      .send({ sets: { SOR: { 2: 1 }, SHD: { 7: 3 } } })
+    expect(res.status).toBe(200)
+    expect(res.body.sets.SOR).toMatchObject({ data: { '2': 1 }, version: 1 })
+    expect(res.body.sets.SHD).toMatchObject({ data: { '7': 3 }, version: 1 })
+  })
+
+  it('rejects invalid set keys', async () => {
+    const db = memoryDb()
+    const app = makeTestApp(db)
+    const { cookie } = seedUserWithSession(db)
+    const res = await request(app)
+      .put('/api/inventories/bad-key')
+      .set('Cookie', cookie)
+      .set('If-Match', '0')
+      .send({ data: {} })
+    expect(res.status).toBe(400)
+  })
+})

--- a/server/test/repo.test.ts
+++ b/server/test/repo.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { memoryDb } from './helpers.js'
+import { getAll, getOne, replaceAll, upsertOne } from '../src/inventories/repo.js'
+
+function seedUser(db: ReturnType<typeof memoryDb>): number {
+  const result = db
+    .prepare('INSERT INTO users (google_sub, email, created_at) VALUES (?, ?, ?)')
+    .run('sub', 'a@b.c', Date.now())
+  return Number(result.lastInsertRowid)
+}
+
+describe('inventory repo', () => {
+  it('upserts with optimistic concurrency', () => {
+    const db = memoryDb()
+    const userId = seedUser(db)
+
+    const create = upsertOne(db, userId, 'SOR', { 1: 1 }, 0)
+    expect(create).toEqual({ ok: true, version: 1 })
+
+    const stale = upsertOne(db, userId, 'SOR', { 1: 9 }, 0)
+    expect(stale.ok).toBe(false)
+    if (!stale.ok) expect(stale.current.version).toBe(1)
+
+    const next = upsertOne(db, userId, 'SOR', { 1: 2 }, 1)
+    expect(next).toEqual({ ok: true, version: 2 })
+
+    const row = getOne(db, userId, 'SOR')
+    expect(row).toMatchObject({ setKey: 'SOR', data: { '1': 2 }, version: 2 })
+  })
+
+  it('replaceAll wipes and inserts atomically', () => {
+    const db = memoryDb()
+    const userId = seedUser(db)
+    upsertOne(db, userId, 'SOR', { 1: 1 }, 0)
+    upsertOne(db, userId, 'SHD', { 2: 2 }, 0)
+    const rows = replaceAll(db, userId, { SOR: { 3: 3 } })
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.setKey).toBe('SOR')
+    expect(getAll(db, userId)).toHaveLength(1)
+  })
+
+  it('rejects a first-write with a non-zero If-Match', () => {
+    const db = memoryDb()
+    const userId = seedUser(db)
+    const outcome = upsertOne(db, userId, 'SOR', { 1: 1 }, 5)
+    expect(outcome.ok).toBe(false)
+    if (!outcome.ok) expect(outcome.current.version).toBe(0)
+  })
+})

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": false,
+    "sourceMap": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "test"]
+}

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['test/**/*.test.ts'],
+  },
+})

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,20 @@ import { createLoadCommitGate } from './core/loadGuard';
 import { fetchSetPayload } from './core/setData';
 import { selectionAfterMove } from './core/selection';
 import type { ActiveSelection, Card, Inventory, SetKey, SetMeta } from './core/types';
+import {
+  createCloudSync,
+  makeBrowserBroadcast,
+  type CloudSync,
+  type SyncEvent,
+  type SyncStatus,
+} from './core/cloudSync';
+import { useAuth } from './hooks/useAuth';
+import { AuthMenu } from './components/AuthMenu';
+import {
+  CloudMigrationModal,
+  summarize,
+  type MigrationChoice,
+} from './components/CloudMigrationModal';
 
 /** Last entry in `manifest.json` is the newest set (release order). */
 function newestSetKeyFromManifest(list: SetMeta[]): SetKey {
@@ -705,6 +719,24 @@ export default function App() {
   const loadCommitGateRef = useRef(createLoadCommitGate());
   const [canonicalCatalog, setCanonicalCatalog] = useState<CanonicalCatalog>(new Map());
 
+  // Cloud sync (local writes remain synchronous; server pushes are debounced).
+  const auth = useAuth();
+  const cloudSyncRef = useRef<CloudSync | null>(null);
+  const applyRemoteInventoryRef = useRef<(setKey: SetKey, data: Inventory) => void>(() => {});
+  const [syncStatus, setSyncStatus] = useState<SyncStatus>('off');
+  const [migrationPrompt, setMigrationPrompt] = useState<null | {
+    local: Record<SetKey, Inventory>;
+    cloud: Record<SetKey, { data: Inventory; version: number }>;
+  }>(null);
+  if (cloudSyncRef.current == null) {
+    cloudSyncRef.current = createCloudSync({
+      storage: localStorage,
+      fetch: (input, init) => fetch(input, init),
+      broadcast: makeBrowserBroadcast(),
+      onLocalApply: (incomingKey, data) => applyRemoteInventoryRef.current(incomingKey, data),
+    });
+  }
+
   useEffect(() => {
     fetch('/sets/manifest.json')
       .then(r => r.ok ? r.json() : Promise.reject(new Error('no manifest')))
@@ -815,9 +847,121 @@ export default function App() {
     if (inventoryReadyForSet === setKey) {
       if (!persistCanonicalInventory(localStorage, setKey, inventory, canonicalCatalog)) {
         showToast('Inventory could not be saved on this device.', 'error');
+        return;
       }
+      cloudSyncRef.current?.scheduleSync(setKey, inventory);
     }
   }, [canonicalCatalog, inventory, inventoryReadyForSet, setKey, showToast]);
+
+  useEffect(() => {
+    applyRemoteInventoryRef.current = (incomingKey, data) => {
+      try {
+        persistCanonicalInventory(localStorage, incomingKey, data, canonicalCatalog);
+      } catch {
+        // Best-effort; ignore write failures on cross-tab replay.
+      }
+      if (incomingKey === setKey) setInventory(data);
+    };
+  }, [canonicalCatalog, setKey]);
+
+  useEffect(() => {
+    const sync = cloudSyncRef.current;
+    if (!sync) return;
+    const unsub = sync.subscribe((event: SyncEvent) => {
+      if (event.type === 'status') {
+        setSyncStatus(event.status);
+        return;
+      }
+      if (event.type === 'signout') {
+        window.dispatchEvent(new Event('swu:auth-signout'));
+        showToast('Signed out — cloud sync paused. Sign in again to resume.', 'warning');
+        return;
+      }
+      if (event.type === 'error' && event.consecutive >= 3) {
+        showToast(
+          `Cloud sync retrying for ${event.setKey} (${event.consecutive} failed attempts).`,
+          'warning',
+        );
+      }
+    });
+    const onOnline = () => {
+      void sync.flushDirty().catch(() => {});
+    };
+    window.addEventListener('online', onOnline);
+    return () => {
+      unsub();
+      window.removeEventListener('online', onOnline);
+    };
+  }, [showToast]);
+
+  useEffect(() => () => cloudSyncRef.current?.dispose(), []);
+
+  const bootstrappedRef = useRef(false);
+  useEffect(() => {
+    const sync = cloudSyncRef.current;
+    if (!sync) return;
+    if (auth.status === 'loading') return;
+    if (auth.status === 'signedOut') {
+      sync.setSignedIn(false);
+      bootstrappedRef.current = false;
+      setMigrationPrompt(null);
+      return;
+    }
+    if (!setKeys.length || canonicalCatalog.size === 0) return;
+    if (bootstrappedRef.current) return;
+    bootstrappedRef.current = true;
+
+    let cancelled = false;
+    sync.setSignedIn(true);
+    (async () => {
+      let cloud: Record<SetKey, { data: Inventory; version: number }> = {};
+      try {
+        cloud = await sync.pullAll();
+      } catch {
+        return;
+      }
+      if (cancelled) return;
+      const local: Record<SetKey, Inventory> = {};
+      for (const key of setKeys) {
+        try {
+          const raw = localStorage.getItem(`inv:${key}`);
+          local[key] = raw ? (JSON.parse(raw) as Inventory) : {};
+        } catch {
+          local[key] = {};
+        }
+      }
+      const state = sync.getState();
+      const anyLocal = Object.values(local).some(inv => Object.keys(inv).length > 0);
+      const anyCloud = Object.values(cloud).some(v => Object.keys(v.data).length > 0);
+
+      if (!state.migrationChoiceMade) {
+        if (!anyLocal && !anyCloud) {
+          sync.markMigrationDone();
+        } else if (!anyLocal && anyCloud) {
+          for (const [k, v] of Object.entries(cloud)) {
+            if (persistCanonicalInventory(localStorage, k, v.data, canonicalCatalog)) {
+              if (k === setKey) setInventory(v.data);
+            }
+          }
+          sync.markMigrationDone();
+        } else {
+          setMigrationPrompt({ local, cloud });
+          return;
+        }
+      } else {
+        for (const [k, v] of Object.entries(cloud)) {
+          if (persistCanonicalInventory(localStorage, k, v.data, canonicalCatalog)) {
+            if (k === setKey) setInventory(v.data);
+          }
+        }
+      }
+      if (cancelled) return;
+      await sync.flushDirty();
+    })().catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [auth.status, canonicalCatalog, setKey, setKeys]);
   const pruneZeros = (inv: Inventory) =>
     Object.fromEntries(Object.entries(inv).filter(([,q]) => (q as number) > 0)) as Inventory;
   useEffect(() => {
@@ -1438,27 +1582,37 @@ export default function App() {
       if (scope === 'current') {
           if (removePersistedInventory(localStorage, setKey, canonicalCatalog)) {
               setInventory({});
+              cloudSyncRef.current?.scheduleSync(setKey, {});
               showToast(`Inventory for the current set (${setKey}) has been cleared.`);
           } else {
               showToast('Inventory could not be cleared while protected persistence is locked.', 'warning');
           }
       } else if (scope === 'all') {
           let allRemoved = true;
+          const clearedKeys: SetKey[] = [];
           // Clear set inventories without deleting the migration backup or schema marker.
           if (!sets.length) {
               for (const key of Object.keys(localStorage)) {
                   if (/^inv:[A-Z0-9]+$/.test(key)) {
-                      allRemoved = removePersistedInventory(localStorage, key.slice(4), canonicalCatalog) && allRemoved;
+                      const setKeyToClear = key.slice(4);
+                      const ok = removePersistedInventory(localStorage, setKeyToClear, canonicalCatalog);
+                      allRemoved = ok && allRemoved;
+                      if (ok) clearedKeys.push(setKeyToClear);
                   }
               }
           } else {
               // Clear based on loaded set keys
               for (const set of sets) {
-                  allRemoved = removePersistedInventory(localStorage, set.key, canonicalCatalog) && allRemoved;
+                  const ok = removePersistedInventory(localStorage, set.key, canonicalCatalog);
+                  allRemoved = ok && allRemoved;
+                  if (ok) clearedKeys.push(set.key);
               }
           }
           if (allRemoved) {
               setInventory({}); // Reset current view as well
+              for (const key of clearedKeys) {
+                  cloudSyncRef.current?.scheduleSync(key, {});
+              }
               showToast('Inventory for ALL sets has been cleared.');
           } else {
               showToast('Inventories could not be cleared while protected persistence is locked.', 'warning');
@@ -1470,6 +1624,54 @@ export default function App() {
   function resetInv() {
       setShowResetModal(true);
   }
+
+  const handleMigrationDecision = useCallback(async (choice: MigrationChoice) => {
+    const sync = cloudSyncRef.current;
+    if (!sync || !migrationPrompt) return;
+    const { local, cloud } = migrationPrompt;
+    const cloudAsInv: Record<SetKey, Inventory> = Object.fromEntries(
+      Object.entries(cloud).map(([k, v]) => [k, v.data]),
+    );
+    try {
+      if (choice === 'upload') {
+        await sync.pushAll(local);
+      } else if (choice === 'startFresh') {
+        await sync.pushAll({});
+        for (const key of setKeys) {
+          if (removePersistedInventory(localStorage, key, canonicalCatalog) && key === setKey) {
+            setInventory({});
+          }
+        }
+      } else if (choice === 'useCloud') {
+        for (const [k, inv] of Object.entries(cloudAsInv)) {
+          if (persistCanonicalInventory(localStorage, k, inv, canonicalCatalog) && k === setKey) {
+            setInventory(inv);
+          }
+        }
+        for (const key of setKeys) {
+          if (!(key in cloudAsInv)) {
+            if (removePersistedInventory(localStorage, key, canonicalCatalog) && key === setKey) {
+              setInventory({});
+            }
+          }
+        }
+      } else if (choice === 'merge') {
+        const merged = applyImportedInventories(local, cloudAsInv, 'merge', canonicalCatalog);
+        await sync.pushAll(merged.inventories);
+        for (const [k, inv] of Object.entries(merged.inventories)) {
+          if (persistCanonicalInventory(localStorage, k, inv, canonicalCatalog) && k === setKey) {
+            setInventory(inv);
+          }
+        }
+      }
+      sync.markMigrationDone();
+      showToast('Cloud sync is now active on this device.', 'success');
+    } catch {
+      showToast('Cloud setup could not complete. Your local data is unchanged.', 'error');
+    } finally {
+      setMigrationPrompt(null);
+    }
+  }, [canonicalCatalog, migrationPrompt, setKey, setKeys, showToast]);
 
   const applyImport = (mode: 'merge' | 'replace') => {
       const current = Object.fromEntries(setKeys.map(key => [key, readSetInv(key)])) as Record<SetKey, Inventory>;
@@ -1487,6 +1689,7 @@ export default function App() {
           if (writeSetInv(key, nextInventory)) {
               importedCount += Object.keys(nextInventory).length;
               if (key === setKey) setInventory(nextInventory);
+              cloudSyncRef.current?.scheduleSync(key, nextInventory);
           } else {
               persistenceBlocked = true;
           }
@@ -1944,6 +2147,12 @@ export default function App() {
           </div>
 
           {/* Right side controls */}
+          <AuthMenu
+            authStatus={auth.status}
+            email={auth.email}
+            syncStatus={syncStatus}
+            onSignOut={auth.signOut}
+          />
           <div className="toolbar-block">
             <div className="toolbar-label">Inventory Controls</div>
             <div className="toolbar-group">
@@ -2355,6 +2564,22 @@ export default function App() {
           )
         )}
       </div>
+
+      {migrationPrompt && (
+        <CloudMigrationModal
+          localSummary={summarize(migrationPrompt.local)}
+          cloudSummary={summarize(
+            Object.fromEntries(
+              Object.entries(migrationPrompt.cloud).map(([k, v]) => [k, v.data]),
+            ),
+          )}
+          onDecision={handleMigrationDecision}
+          onDismiss={() => {
+            cloudSyncRef.current?.markMigrationDone();
+            setMigrationPrompt(null);
+          }}
+        />
+      )}
 
       {/* NEW: Reset Confirmation Modal JSX */}
       {showResetModal && (

--- a/src/components/AuthMenu.tsx
+++ b/src/components/AuthMenu.tsx
@@ -1,0 +1,140 @@
+import React from 'react'
+import type { SyncStatus } from '../core/cloudSync'
+import { beginSignIn } from '../core/auth'
+
+type Props = {
+  authStatus: 'loading' | 'signedIn' | 'signedOut'
+  email: string | null
+  syncStatus: SyncStatus
+  onSignOut: () => void | Promise<void>
+}
+
+function statusLabel(status: SyncStatus): string {
+  switch (status) {
+    case 'off':
+      return 'Cloud sync off'
+    case 'idle':
+      return 'Cloud sync on'
+    case 'pushing':
+      return 'Syncing…'
+    case 'error':
+      return 'Sync retrying'
+    case 'offline':
+      return 'Offline — queued'
+  }
+}
+
+export function AuthMenu({ authStatus, email, syncStatus, onSignOut }: Props) {
+  const [menuOpen, setMenuOpen] = React.useState(false)
+
+  if (authStatus === 'loading') {
+    return (
+      <div className="toolbar-block">
+        <div className="toolbar-label">Cloud</div>
+        <div className="toolbar-group">
+          <span className="muted" style={{ fontSize: 12 }}>
+            Checking sign-in…
+          </span>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="toolbar-block">
+      <div className="toolbar-label">Cloud</div>
+      <div className="toolbar-group" style={{ position: 'relative' }}>
+        {authStatus === 'signedOut' ? (
+          <button
+            type="button"
+            className="tbtn"
+            onClick={() => beginSignIn()}
+            title="Sign in with Google to enable cloud sync"
+            aria-label="Sign in with Google"
+          >
+            <span className="icon" aria-hidden="true">login</span>
+            <span>Sign in with Google</span>
+          </button>
+        ) : (
+          <>
+            <button
+              type="button"
+              className="tbtn"
+              onClick={() => setMenuOpen(v => !v)}
+              aria-haspopup="menu"
+              aria-expanded={menuOpen}
+              title={email ?? undefined}
+              style={{ maxWidth: 220, overflow: 'hidden', textOverflow: 'ellipsis' }}
+            >
+              <span className="icon" aria-hidden="true">account_circle</span>
+              <span
+                style={{
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  maxWidth: 160,
+                }}
+              >
+                {email ?? 'Signed in'}
+              </span>
+              <span aria-hidden="true">▾</span>
+            </button>
+            {menuOpen && (
+              <div
+                role="menu"
+                style={{
+                  position: 'absolute',
+                  top: '100%',
+                  right: 0,
+                  marginTop: 4,
+                  background: '#1a1c25',
+                  border: '1px solid #333',
+                  borderRadius: 6,
+                  padding: 6,
+                  zIndex: 20,
+                  minWidth: 180,
+                }}
+              >
+                <button
+                  type="button"
+                  role="menuitem"
+                  className="tbtn"
+                  style={{ width: '100%', justifyContent: 'flex-start' }}
+                  onClick={() => {
+                    setMenuOpen(false)
+                    void onSignOut()
+                  }}
+                >
+                  <span className="icon" aria-hidden="true">logout</span>
+                  <span>Sign out</span>
+                </button>
+              </div>
+            )}
+          </>
+        )}
+        <span
+          aria-label={statusLabel(syncStatus)}
+          title={statusLabel(syncStatus)}
+          style={{
+            fontSize: 11,
+            padding: '2px 8px',
+            borderRadius: 999,
+            border: '1px solid currentColor',
+            opacity: 0.75,
+            color:
+              syncStatus === 'error'
+                ? '#f87171'
+                : syncStatus === 'off'
+                  ? '#9aa0b4'
+                  : syncStatus === 'pushing'
+                    ? '#facc15'
+                    : '#22c55e',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {statusLabel(syncStatus)}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/CloudMigrationModal.tsx
+++ b/src/components/CloudMigrationModal.tsx
@@ -1,0 +1,172 @@
+import React from 'react'
+import type { Inventory, SetKey } from '../core/types'
+
+export type CloudSummary = { setKey: SetKey; entries: number }
+
+export type MigrationChoice = 'upload' | 'startFresh' | 'useCloud' | 'merge'
+
+type Props = {
+  localSummary: CloudSummary[]
+  cloudSummary: CloudSummary[]
+  onDecision: (choice: MigrationChoice) => void | Promise<void>
+  onDismiss: () => void
+}
+
+function totalEntries(summary: CloudSummary[]): number {
+  return summary.reduce((a, s) => a + s.entries, 0)
+}
+
+export function summarize(sets: Record<SetKey, Inventory>): CloudSummary[] {
+  return Object.entries(sets)
+    .map(([setKey, inv]) => ({ setKey, entries: Object.keys(inv ?? {}).length }))
+    .filter(s => s.entries > 0)
+    .sort((a, b) => a.setKey.localeCompare(b.setKey))
+}
+
+export function CloudMigrationModal({
+  localSummary,
+  cloudSummary,
+  onDecision,
+  onDismiss,
+}: Props) {
+  const localCount = totalEntries(localSummary)
+  const cloudCount = totalEntries(cloudSummary)
+  const [busy, setBusy] = React.useState(false)
+
+  async function pick(choice: MigrationChoice) {
+    setBusy(true)
+    try {
+      await onDecision(choice)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  let body: React.ReactNode
+  let actions: React.ReactNode
+
+  if (localCount === 0 && cloudCount === 0) {
+    // Should be auto-dismissed by the caller before rendering.
+    body = <p>No inventory data found locally or in the cloud.</p>
+    actions = (
+      <button type="button" className="tbtn" onClick={onDismiss}>
+        <span>Got it</span>
+      </button>
+    )
+  } else if (cloudCount === 0 && localCount > 0) {
+    body = (
+      <>
+        <p>
+          You have <strong>{localCount}</strong> local inventory entries and the cloud
+          copy is empty.
+        </p>
+        <p>Do you want to upload your local inventory to the cloud?</p>
+      </>
+    )
+    actions = (
+      <>
+        <button
+          type="button"
+          className="tbtn"
+          disabled={busy}
+          onClick={() => void pick('upload')}
+        >
+          <span className="icon" aria-hidden="true">cloud_upload</span>
+          <span>Upload local to cloud</span>
+        </button>
+        <button
+          type="button"
+          className="tbtn tbtn-danger"
+          disabled={busy}
+          onClick={() => void pick('startFresh')}
+        >
+          <span className="icon" aria-hidden="true">delete</span>
+          <span>Start fresh (discard local)</span>
+        </button>
+      </>
+    )
+  } else if (localCount === 0 && cloudCount > 0) {
+    body = (
+      <p>
+        Restoring <strong>{cloudCount}</strong> inventory entries from the cloud.
+      </p>
+    )
+    actions = (
+      <button
+        type="button"
+        className="tbtn"
+        disabled={busy}
+        onClick={() => void pick('useCloud')}
+      >
+        <span className="icon" aria-hidden="true">cloud_download</span>
+        <span>Use cloud copy</span>
+      </button>
+    )
+  } else {
+    body = (
+      <>
+        <p>
+          Cloud has <strong>{cloudCount}</strong> inventory entries and this device has{' '}
+          <strong>{localCount}</strong>. Choose how to reconcile.
+        </p>
+        <ul style={{ margin: '8px 0 0 16px', padding: 0 }}>
+          <li><strong>Use cloud:</strong> discard local changes and mirror the cloud copy.</li>
+          <li><strong>Merge:</strong> combine both (higher quantity per card wins).</li>
+        </ul>
+      </>
+    )
+    actions = (
+      <>
+        <button
+          type="button"
+          className="tbtn"
+          disabled={busy}
+          onClick={() => void pick('useCloud')}
+        >
+          <span className="icon" aria-hidden="true">cloud_download</span>
+          <span>Use cloud (discard local)</span>
+        </button>
+        <button
+          type="button"
+          className="tbtn"
+          disabled={busy}
+          onClick={() => void pick('merge')}
+        >
+          <span className="icon" aria-hidden="true">merge</span>
+          <span>Merge local into cloud</span>
+        </button>
+      </>
+    )
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Cloud sync setup"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0,0,0,0.5)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 100,
+      }}
+    >
+      <div
+        className="card"
+        style={{ maxWidth: 520, width: '90%', padding: 20, background: '#141821' }}
+      >
+        <h2 style={{ marginTop: 0 }}>Set up cloud sync</h2>
+        <div style={{ fontSize: 14, lineHeight: 1.4 }}>{body}</div>
+        <div
+          className="toolbar-group"
+          style={{ marginTop: 16, gap: 8, flexWrap: 'wrap' }}
+        >
+          {actions}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/core/auth.ts
+++ b/src/core/auth.ts
@@ -1,0 +1,23 @@
+export type AuthMe = { email: string }
+
+export async function fetchMe(fetchFn: typeof fetch = fetch): Promise<AuthMe | null> {
+  try {
+    const res = await fetchFn('/api/auth/me', { credentials: 'include' })
+    if (!res.ok) return null
+    return (await res.json()) as AuthMe
+  } catch {
+    return null
+  }
+}
+
+export function beginSignIn(): void {
+  window.location.assign('/api/auth/login')
+}
+
+export async function signOut(fetchFn: typeof fetch = fetch): Promise<void> {
+  try {
+    await fetchFn('/api/auth/logout', { method: 'POST', credentials: 'include' })
+  } catch {
+    // best-effort; the cookie is cleared server-side.
+  }
+}

--- a/src/core/cloudSync.test.ts
+++ b/src/core/cloudSync.test.ts
@@ -1,0 +1,252 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  createCloudSync,
+  type BroadcastPayload,
+  type CloudSync,
+  type SyncEvent,
+} from './cloudSync'
+
+function memoryStorage(): Storage {
+  const map = new Map<string, string>()
+  return {
+    get length() {
+      return map.size
+    },
+    clear: () => map.clear(),
+    getItem: (k: string) => (map.has(k) ? map.get(k)! : null),
+    key: (i: number) => Array.from(map.keys())[i] ?? null,
+    removeItem: (k: string) => {
+      map.delete(k)
+    },
+    setItem: (k: string, v: string) => {
+      map.set(k, String(v))
+    },
+  }
+}
+
+type FetchStep = {
+  status: number
+  json?: unknown
+}
+
+function makeFetch(steps: FetchStep[]) {
+  const calls: Array<{ url: string; init?: RequestInit }> = []
+  let i = 0
+  const fetchFn = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    calls.push({ url, init })
+    const step = steps[i++]
+    if (!step) throw new Error(`unexpected fetch: ${url}`)
+    return {
+      ok: step.status >= 200 && step.status < 300,
+      status: step.status,
+      json: async () => step.json ?? {},
+    } as unknown as Response
+  })
+  return { fetchFn, calls }
+}
+
+function fakeBroadcast() {
+  let handler: ((payload: BroadcastPayload) => void) | null = null
+  const posted: BroadcastPayload[] = []
+  return {
+    posted,
+    api: {
+      postMessage: (event: BroadcastPayload) => {
+        posted.push(event)
+      },
+      onMessage: (fn: (payload: BroadcastPayload) => void) => {
+        handler = fn
+        return () => {
+          handler = null
+        }
+      },
+    },
+    deliver: (payload: BroadcastPayload) => handler?.(payload),
+  }
+}
+
+let sync: CloudSync | null = null
+
+afterEach(() => {
+  sync?.dispose()
+  sync = null
+})
+
+describe('cloudSync', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('debounces push per set and clears pending on success', async () => {
+    const storage = memoryStorage()
+    const { fetchFn, calls } = makeFetch([{ status: 200, json: { version: 1 } }])
+    sync = createCloudSync({ storage, fetch: fetchFn })
+    sync.setSignedIn(true)
+
+    sync.scheduleSync('SOR', { 1: 1 })
+    sync.scheduleSync('SOR', { 1: 2 })
+    sync.scheduleSync('SOR', { 1: 3 })
+
+    await vi.advanceTimersByTimeAsync(1000)
+    await vi.runOnlyPendingTimersAsync()
+
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+    const body = JSON.parse((calls[0]!.init!.body as string) || '{}')
+    expect(body).toEqual({ data: { 1: 3 } })
+
+    const state = sync.getState()
+    expect(state.pending).toEqual({})
+    expect(state.versions.SOR).toBe(1)
+  })
+
+  it('persists pending edit when offline and flushes after signIn', async () => {
+    const storage = memoryStorage()
+    const { fetchFn } = makeFetch([{ status: 200, json: { version: 1 } }])
+    sync = createCloudSync({ storage, fetch: fetchFn })
+
+    // Not signed in yet — should still record pending.
+    sync.scheduleSync('SOR', { 5: 3 })
+    expect(sync.getState().pending.SOR).toEqual({ 5: 3 })
+    expect(fetchFn).not.toHaveBeenCalled()
+
+    sync.setSignedIn(true)
+    await vi.runOnlyPendingTimersAsync()
+    await Promise.resolve()
+
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+    expect(sync.getState().pending).toEqual({})
+  })
+
+  it('emits signout event and stops pushing on 401', async () => {
+    const storage = memoryStorage()
+    const { fetchFn } = makeFetch([{ status: 401 }])
+    sync = createCloudSync({ storage, fetch: fetchFn })
+    const events: SyncEvent[] = []
+    sync.subscribe(e => events.push(e))
+    sync.setSignedIn(true)
+
+    sync.scheduleSync('SOR', { 1: 1 })
+    await vi.advanceTimersByTimeAsync(1000)
+    await vi.runOnlyPendingTimersAsync()
+
+    expect(events.some(e => e.type === 'signout')).toBe(true)
+    expect(sync.getState().pending.SOR).toEqual({ 1: 1 })
+  })
+
+  it('applies server version on 409 and calls onLocalApply', async () => {
+    const storage = memoryStorage()
+    const { fetchFn } = makeFetch([
+      { status: 409, json: { current: { data: { 3: 3 }, version: 7 } } },
+    ])
+    const onLocalApply = vi.fn()
+    sync = createCloudSync({ storage, fetch: fetchFn, onLocalApply })
+    const events: SyncEvent[] = []
+    sync.subscribe(e => events.push(e))
+    sync.setSignedIn(true)
+
+    sync.scheduleSync('SOR', { 3: 1 })
+    await vi.advanceTimersByTimeAsync(1000)
+    await vi.runOnlyPendingTimersAsync()
+
+    expect(onLocalApply).toHaveBeenCalledWith('SOR', { 3: 3 })
+    expect(sync.getState().versions.SOR).toBe(7)
+    expect(sync.getState().pending).toEqual({})
+    expect(events.some(e => e.type === 'pulled')).toBe(true)
+  })
+
+  it('retries with backoff on 5xx and reports error after 3 attempts', async () => {
+    const storage = memoryStorage()
+    const { fetchFn } = makeFetch([
+      { status: 500 },
+      { status: 500 },
+      { status: 500 },
+    ])
+    sync = createCloudSync({ storage, fetch: fetchFn })
+    const errors: SyncEvent[] = []
+    sync.subscribe(e => {
+      if (e.type === 'error') errors.push(e)
+    })
+    sync.setSignedIn(true)
+
+    sync.scheduleSync('SOR', { 1: 1 })
+    // Debounce
+    await vi.advanceTimersByTimeAsync(1000)
+    await vi.runOnlyPendingTimersAsync()
+    // First backoff: 1s
+    await vi.advanceTimersByTimeAsync(1000)
+    await vi.runOnlyPendingTimersAsync()
+    // Second backoff: 2s
+    await vi.advanceTimersByTimeAsync(2000)
+    await vi.runOnlyPendingTimersAsync()
+
+    expect(fetchFn).toHaveBeenCalledTimes(3)
+    expect(errors.length).toBeGreaterThanOrEqual(1)
+    const last = errors[errors.length - 1]!
+    if (last.type === 'error') expect(last.consecutive).toBeGreaterThanOrEqual(3)
+  })
+
+  it('applies broadcast messages from other tabs', () => {
+    const storage = memoryStorage()
+    const { fetchFn } = makeFetch([])
+    const bc = fakeBroadcast()
+    const onLocalApply = vi.fn()
+    sync = createCloudSync({
+      storage,
+      fetch: fetchFn,
+      broadcast: bc.api,
+      onLocalApply,
+    })
+    sync.setSignedIn(true)
+
+    bc.deliver({ type: 'pushed', setKey: 'SOR', data: { 7: 3 }, version: 4 })
+    expect(onLocalApply).toHaveBeenCalledWith('SOR', { 7: 3 })
+    expect(sync.getState().versions.SOR).toBe(4)
+  })
+
+  it('pullAll updates versions and returns server state', async () => {
+    const storage = memoryStorage()
+    const { fetchFn } = makeFetch([
+      {
+        status: 200,
+        json: {
+          sets: {
+            SOR: { data: { 1: 1 }, version: 2, updatedAt: 100 },
+            SHD: { data: { 5: 3 }, version: 1, updatedAt: 100 },
+          },
+        },
+      },
+    ])
+    sync = createCloudSync({ storage, fetch: fetchFn })
+    sync.setSignedIn(true)
+
+    const result = await sync.pullAll()
+    expect(result.SOR).toEqual({ data: { 1: 1 }, version: 2 })
+    expect(sync.getState().versions).toEqual({ SOR: 2, SHD: 1 })
+  })
+
+  it('pushAll (bulk migration) resets pending and versions', async () => {
+    const storage = memoryStorage()
+    const { fetchFn } = makeFetch([
+      {
+        status: 200,
+        json: {
+          sets: {
+            SOR: { data: { 1: 1 }, version: 1, updatedAt: 100 },
+          },
+        },
+      },
+    ])
+    sync = createCloudSync({ storage, fetch: fetchFn })
+    sync.setSignedIn(true)
+    sync.scheduleSync('SOR', { 1: 1 })
+
+    await sync.pushAll({ SOR: { 1: 1 } })
+    expect(sync.getState().pending).toEqual({})
+    expect(sync.getState().versions.SOR).toBe(1)
+  })
+})

--- a/src/core/cloudSync.ts
+++ b/src/core/cloudSync.ts
@@ -1,0 +1,369 @@
+import type { Inventory, SetKey } from './types'
+
+export type SyncStatus = 'off' | 'idle' | 'pushing' | 'error' | 'offline'
+
+export type SyncEvent =
+  | { type: 'pulled'; setKey: SetKey; data: Inventory; version: number }
+  | { type: 'pushed'; setKey: SetKey; version: number }
+  | { type: 'signout' }
+  | { type: 'status'; status: SyncStatus }
+  | { type: 'error'; setKey: SetKey; consecutive: number; message: string }
+
+export type SyncListener = (event: SyncEvent) => void
+
+export type SyncState = {
+  versions: Record<SetKey, number>
+  pending: Record<SetKey, Inventory>
+  lastPulledAt: number
+  migrationChoiceMade: boolean
+}
+
+const STATE_KEY = 'sync:state'
+const RETRY_MS = [1000, 2000, 5000, 15000, 60000] as const
+const DEBOUNCE_MS = 1000
+
+const emptyState: SyncState = {
+  versions: {},
+  pending: {},
+  lastPulledAt: 0,
+  migrationChoiceMade: false,
+}
+
+function readState(storage: Pick<Storage, 'getItem'>): SyncState {
+  try {
+    const raw = storage.getItem(STATE_KEY)
+    if (!raw) return { ...emptyState }
+    const parsed = JSON.parse(raw) as Partial<SyncState>
+    return {
+      versions: parsed.versions ?? {},
+      pending: parsed.pending ?? {},
+      lastPulledAt: parsed.lastPulledAt ?? 0,
+      migrationChoiceMade: parsed.migrationChoiceMade ?? false,
+    }
+  } catch {
+    return { ...emptyState }
+  }
+}
+
+function writeState(storage: Pick<Storage, 'setItem'>, state: SyncState): void {
+  try {
+    storage.setItem(STATE_KEY, JSON.stringify(state))
+  } catch {
+    // If storage is full or blocked, we lose the sync intent — nothing to do.
+  }
+}
+
+export type CloudSyncDeps = {
+  storage: Storage
+  fetch: typeof fetch
+  now?: () => number
+  setTimeoutFn?: (fn: () => void, ms: number) => number
+  clearTimeoutFn?: (id: number) => void
+  broadcast?: {
+    postMessage: (event: BroadcastPayload) => void
+    onMessage: (handler: (event: BroadcastPayload) => void) => () => void
+  } | null
+  onLocalApply?: (setKey: SetKey, data: Inventory) => void
+}
+
+export type BroadcastPayload =
+  | { type: 'pushed'; setKey: SetKey; data: Inventory; version: number }
+  | { type: 'pulled'; setKey: SetKey; data: Inventory; version: number }
+
+type PendingTimer = { id: number; data: Inventory }
+
+export type CloudSync = ReturnType<typeof createCloudSync>
+
+export function createCloudSync(deps: CloudSyncDeps) {
+  const now = deps.now ?? (() => Date.now())
+  const schedule = deps.setTimeoutFn ?? ((fn: () => void, ms: number) =>
+    (setTimeout(fn, ms) as unknown) as number)
+  const cancel = deps.clearTimeoutFn ?? ((id: number) => clearTimeout(id))
+
+  const listeners = new Set<SyncListener>()
+  const debounces = new Map<SetKey, PendingTimer>()
+  const retryTimers = new Map<SetKey, number>()
+  const retryAttempt = new Map<SetKey, number>()
+  const inFlight = new Set<SetKey>()
+
+  let signedIn = false
+  let currentStatus: SyncStatus = 'off'
+
+  const bcUnsub = deps.broadcast?.onMessage(handleBroadcast)
+
+  function emit(event: SyncEvent) {
+    for (const listener of listeners) listener(event)
+  }
+
+  function setStatus(next: SyncStatus) {
+    if (next === currentStatus) return
+    currentStatus = next
+    emit({ type: 'status', status: next })
+  }
+
+  function subscribe(listener: SyncListener): () => void {
+    listeners.add(listener)
+    return () => {
+      listeners.delete(listener)
+    }
+  }
+
+  function getState(): SyncState {
+    return readState(deps.storage)
+  }
+
+  function mutate(patch: (s: SyncState) => SyncState): SyncState {
+    const next = patch(readState(deps.storage))
+    writeState(deps.storage, next)
+    return next
+  }
+
+  function setSignedIn(value: boolean): void {
+    signedIn = value
+    if (!value) {
+      setStatus('off')
+      return
+    }
+    setStatus('idle')
+    flushDirty().catch(() => {
+      /* errors surface via events */
+    })
+  }
+
+  function markMigrationDone(): void {
+    mutate(s => ({ ...s, migrationChoiceMade: true }))
+  }
+
+  function scheduleSync(setKey: SetKey, data: Inventory): void {
+    const snapshot = { ...data }
+    mutate(s => ({
+      ...s,
+      pending: { ...s.pending, [setKey]: snapshot },
+    }))
+    const existing = debounces.get(setKey)
+    if (existing) cancel(existing.id)
+    if (!signedIn) return
+    const id = schedule(() => {
+      debounces.delete(setKey)
+      void pushSet(setKey).catch(() => {})
+    }, DEBOUNCE_MS)
+    debounces.set(setKey, { id, data: snapshot })
+  }
+
+  async function pushSet(setKey: SetKey): Promise<void> {
+    if (!signedIn) return
+    if (inFlight.has(setKey)) return
+    const state = readState(deps.storage)
+    const data = state.pending[setKey]
+    if (!data) return
+    inFlight.add(setKey)
+    setStatus('pushing')
+    const version = state.versions[setKey] ?? 0
+    try {
+      const res = await deps.fetch(`/api/inventories/${encodeURIComponent(setKey)}`, {
+        method: 'PUT',
+        credentials: 'include',
+        headers: {
+          'content-type': 'application/json',
+          'if-match': String(version),
+        },
+        body: JSON.stringify({ data }),
+      })
+      if (res.status === 401) {
+        signedIn = false
+        setStatus('off')
+        emit({ type: 'signout' })
+        return
+      }
+      if (res.status === 409) {
+        const body = await res.json().catch(() => ({}))
+        const current = body?.current as { data?: Inventory; version?: number } | undefined
+        if (current && typeof current.version === 'number') {
+          applyServerVersion(setKey, current.data ?? {}, current.version)
+        }
+        retryAttempt.delete(setKey)
+        setStatus('idle')
+        return
+      }
+      if (res.status >= 500) {
+        throw new Error(`sync_5xx_${res.status}`)
+      }
+      if (!res.ok) {
+        throw new Error(`sync_failed_${res.status}`)
+      }
+      const body = (await res.json()) as { version: number }
+      mutate(s => {
+        const nextPending = { ...s.pending }
+        delete nextPending[setKey]
+        return {
+          ...s,
+          pending: nextPending,
+          versions: { ...s.versions, [setKey]: body.version },
+        }
+      })
+      retryAttempt.delete(setKey)
+      setStatus('idle')
+      emit({ type: 'pushed', setKey, version: body.version })
+      deps.broadcast?.postMessage({ type: 'pushed', setKey, data, version: body.version })
+    } catch (err) {
+      const attempt = (retryAttempt.get(setKey) ?? 0) + 1
+      retryAttempt.set(setKey, attempt)
+      const delay = RETRY_MS[Math.min(attempt - 1, RETRY_MS.length - 1)] ?? RETRY_MS[RETRY_MS.length - 1]!
+      const existing = retryTimers.get(setKey)
+      if (existing) cancel(existing)
+      const id = schedule(() => {
+        retryTimers.delete(setKey)
+        void pushSet(setKey).catch(() => {})
+      }, delay)
+      retryTimers.set(setKey, id)
+      setStatus('error')
+      if (attempt >= 3) {
+        emit({
+          type: 'error',
+          setKey,
+          consecutive: attempt,
+          message: err instanceof Error ? err.message : 'sync_error',
+        })
+      }
+    } finally {
+      inFlight.delete(setKey)
+    }
+  }
+
+  function applyServerVersion(setKey: SetKey, data: Inventory, version: number): void {
+    mutate(s => {
+      const nextPending = { ...s.pending }
+      delete nextPending[setKey]
+      return {
+        ...s,
+        pending: nextPending,
+        versions: { ...s.versions, [setKey]: version },
+      }
+    })
+    deps.onLocalApply?.(setKey, data)
+    emit({ type: 'pulled', setKey, data, version })
+    deps.broadcast?.postMessage({ type: 'pulled', setKey, data, version })
+  }
+
+  async function pullAll(): Promise<Record<SetKey, { data: Inventory; version: number }>> {
+    if (!signedIn) return {}
+    const res = await deps.fetch('/api/inventories', {
+      method: 'GET',
+      credentials: 'include',
+    })
+    if (res.status === 401) {
+      signedIn = false
+      setStatus('off')
+      emit({ type: 'signout' })
+      return {}
+    }
+    if (!res.ok) return {}
+    const body = (await res.json()) as {
+      sets: Record<SetKey, { data: Inventory; version: number; updatedAt: number }>
+    }
+    const sets = body.sets ?? {}
+    mutate(s => {
+      const nextVersions = { ...s.versions }
+      for (const [k, v] of Object.entries(sets)) nextVersions[k] = v.version
+      return { ...s, versions: nextVersions, lastPulledAt: now() }
+    })
+    return Object.fromEntries(
+      Object.entries(sets).map(([k, v]) => [k, { data: v.data, version: v.version }]),
+    )
+  }
+
+  async function pushAll(sets: Record<SetKey, Inventory>): Promise<void> {
+    if (!signedIn) return
+    const res = await deps.fetch('/api/inventories', {
+      method: 'PUT',
+      credentials: 'include',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ sets }),
+    })
+    if (res.status === 401) {
+      signedIn = false
+      setStatus('off')
+      emit({ type: 'signout' })
+      return
+    }
+    if (!res.ok) throw new Error(`bulk_failed_${res.status}`)
+    const body = (await res.json()) as {
+      sets: Record<SetKey, { data: Inventory; version: number }>
+    }
+    mutate(s => {
+      const nextVersions = { ...s.versions }
+      const nextPending = { ...s.pending }
+      for (const [k, v] of Object.entries(body.sets)) {
+        nextVersions[k] = v.version
+        delete nextPending[k]
+      }
+      return { ...s, versions: nextVersions, pending: nextPending, lastPulledAt: now() }
+    })
+    setStatus('idle')
+  }
+
+  async function flushDirty(): Promise<void> {
+    if (!signedIn) return
+    const pendingKeys = Object.keys(readState(deps.storage).pending)
+    await Promise.all(pendingKeys.map(k => pushSet(k).catch(() => {})))
+  }
+
+  function handleBroadcast(payload: BroadcastPayload): void {
+    if (payload.type !== 'pushed' && payload.type !== 'pulled') return
+    mutate(s => {
+      const nextPending = { ...s.pending }
+      delete nextPending[payload.setKey]
+      return {
+        ...s,
+        pending: nextPending,
+        versions: { ...s.versions, [payload.setKey]: payload.version },
+      }
+    })
+    deps.onLocalApply?.(payload.setKey, payload.data)
+    emit({
+      type: 'pulled',
+      setKey: payload.setKey,
+      data: payload.data,
+      version: payload.version,
+    })
+  }
+
+  function dispose(): void {
+    for (const t of debounces.values()) cancel(t.id)
+    for (const id of retryTimers.values()) cancel(id)
+    debounces.clear()
+    retryTimers.clear()
+    listeners.clear()
+    bcUnsub?.()
+  }
+
+  function status(): SyncStatus {
+    return currentStatus
+  }
+
+  return {
+    subscribe,
+    scheduleSync,
+    pullAll,
+    pushAll,
+    flushDirty,
+    setSignedIn,
+    markMigrationDone,
+    getState,
+    status,
+    dispose,
+  }
+}
+
+export function makeBrowserBroadcast(): CloudSyncDeps['broadcast'] {
+  if (typeof BroadcastChannel === 'undefined') return null
+  const channel = new BroadcastChannel('swu-sync')
+  return {
+    postMessage: event => channel.postMessage(event),
+    onMessage: handler => {
+      const listener = (ev: MessageEvent<BroadcastPayload>) => handler(ev.data)
+      channel.addEventListener('message', listener)
+      return () => channel.removeEventListener('message', listener)
+    },
+  }
+}

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,45 @@
+import { useCallback, useEffect, useState } from 'react'
+import { fetchMe, signOut as signOutRequest } from '../core/auth'
+
+export type AuthStatus = 'loading' | 'signedIn' | 'signedOut'
+
+export type AuthState = {
+  status: AuthStatus
+  email: string | null
+  refresh: () => Promise<void>
+  signOut: () => Promise<void>
+}
+
+export function useAuth(): AuthState {
+  const [status, setStatus] = useState<AuthStatus>('loading')
+  const [email, setEmail] = useState<string | null>(null)
+
+  const refresh = useCallback(async () => {
+    const me = await fetchMe()
+    if (me) {
+      setEmail(me.email)
+      setStatus('signedIn')
+    } else {
+      setEmail(null)
+      setStatus('signedOut')
+    }
+  }, [])
+
+  useEffect(() => {
+    void refresh()
+    const onSignout = () => {
+      setEmail(null)
+      setStatus('signedOut')
+    }
+    window.addEventListener('swu:auth-signout', onSignout)
+    return () => window.removeEventListener('swu:auth-signout', onSignout)
+  }, [refresh])
+
+  const signOut = useCallback(async () => {
+    await signOutRequest()
+    setEmail(null)
+    setStatus('signedOut')
+  }, [])
+
+  return { status, email, refresh, signOut }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,14 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': {
+        target: process.env.VITE_API_PROXY_TARGET ?? 'http://localhost:3001',
+        changeOrigin: false,
+      },
+    },
+  },
   test: {
     environment: 'jsdom',
   },


### PR DESCRIPTION
## Summary
- New `swu-api` service (Node/Express + `better-sqlite3` + `google-auth-library`) persists per-user inventories keyed on Google sign-in; runs alongside the SPA behind Traefik at `/api/*` on the same host, with a SQLite file bind-mounted from `/var/config/swu-organizer` (Portainer env-var pattern).
- Local writes remain synchronous through `localStorage` so the app stays usable offline. A new `src/core/cloudSync.ts` layers debounced (~1s per-set) background PUTs on top, tracks per-set version + pending state in `sync:state`, retries 5xx with backoff, applies server-wins on 409, and coordinates tabs via `BroadcastChannel`.
- First-sign-in `CloudMigrationModal` reconciles local vs. cloud state (upload / start fresh / use cloud / merge). Post-migration the client also pulls newer cloud sets on load and flushes any queued pending writes.
- Header gains an `AuthMenu` (Google sign-in / email dropdown / sync-status pill). Import + reset flows mark affected sets dirty so they sync too.

## Setup you still need to do
- Create a Google OAuth 2.0 Web client and add both `https://swu.mattyflix.com/api/auth/callback` and `http://localhost:5173/api/auth/callback` as redirect URIs.
- Set these vars in your Portainer stack (or an `.env` next to `docker-compose.yml`): `SESSION_SECRET`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `OAUTH_REDIRECT`, `POST_LOGIN_REDIRECT`, `ALLOWED_EMAILS`.
- Create `/var/config/swu-organizer/` on the host.

## Test plan
- [ ] `cd server && npm install && npm test`
- [ ] `npm install && npm test && npm run lint` at repo root
- [ ] `docker compose up -d --build`; `curl -i https://swu.mattyflix.com/api/health` returns 200
- [ ] Sign in from the app; edit a quantity and confirm a `PUT /api/inventories/<set>` fires within ~1s and the row appears in `/var/config/swu-organizer/swu.db`
- [ ] Open a second tab, edit → first tab updates via BroadcastChannel
- [ ] Stop `swu-api` mid-edit, restart, confirm the dirty flag auto-flushes on reconnect
- [ ] Sign out then edit → local edits still work, sync pauses; sign in again → queued edits push

🤖 Generated with [Claude Code](https://claude.com/claude-code)