### PR TITLE
fix(server): reuse compiled node_modules from build stage

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -7,14 +7,17 @@ RUN npm ci
 COPY tsconfig.json ./
 COPY src ./src
 RUN npm run build
+# Drop devDependencies here (build tools are still present, so native rebuilds
+# succeed). The runtime image reuses the resulting node_modules verbatim.
+RUN npm prune --omit=dev
 
 # ---------- runtime ----------
 FROM node:20-alpine
 WORKDIR /app
 RUN apk add --no-cache wget
 ENV NODE_ENV=production
-COPY package*.json ./
-RUN npm ci --omit=dev
+COPY --from=build /app/package*.json ./
+COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/dist ./dist
 COPY --from=build /app/src/schema.sql ./dist/schema.sql
 


### PR DESCRIPTION
## Summary
Fixes the Portainer/Docker build failure introduced in #38:

```
process "/bin/sh -c npm ci --omit=dev" did not complete successfully: exit code: 1
```

`better-sqlite3` is a native module. The build stage had `python3 / make / g++` and compiled it fine, but the runtime stage was calling `npm ci --omit=dev` on plain `node:20-alpine` (no toolchain), so the rebuild blew up.

- Build stage now runs `npm prune --omit=dev` right after `tsc` — devDeps drop out while the compiler is still installed.
- Runtime stage copies `node_modules/` verbatim from the build stage; no `npm` invocation, no rebuild.

## Test plan
- [ ] `docker compose build swu-api` completes cleanly
- [ ] `docker compose up -d --build` on the host, `curl -i https://swu.mattyflix.com/api/health` returns 200
- [ ] Sign-in + inventory sync still work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)