### PR TITLE
fix(server): switch Dockerfile base to debian bookworm-slim

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,20 +1,23 @@
 # ---------- build stage ----------
-FROM node:20-alpine AS build
+# Using bookworm-slim (Debian, glibc) because better-sqlite3 publishes
+# prebuilt linux-x64 binaries for glibc but NOT for Alpine's musl. On Alpine
+# we'd have to compile from source (python3/make/g++), which has been flaky
+# in Portainer builds. Debian pulls the prebuild and skips native compile.
+FROM node:20-bookworm-slim AS build
 WORKDIR /app
-RUN apk add --no-cache python3 make g++
 COPY package*.json ./
 RUN npm ci
 COPY tsconfig.json ./
 COPY src ./src
 RUN npm run build
-# Drop devDependencies here (build tools are still present, so native rebuilds
-# succeed). The runtime image reuses the resulting node_modules verbatim.
 RUN npm prune --omit=dev
 
 # ---------- runtime ----------
-FROM node:20-alpine
+FROM node:20-bookworm-slim
 WORKDIR /app
-RUN apk add --no-cache wget
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends wget \
+    && rm -rf /var/lib/apt/lists/*
 ENV NODE_ENV=production
 COPY --from=build /app/package*.json ./
 COPY --from=build /app/node_modules ./node_modules


### PR DESCRIPTION
## Summary
The prior fix in #39 rearranged the build stages but the underlying build still ran on `node:20-alpine`, where `better-sqlite3` has to compile from source via node-gyp. That compile has been failing intermittently in Portainer's build environment (this time on the build-stage `npm ci`).

- `better-sqlite3` publishes prebuilt binaries for linux-x64 glibc, arm64 glibc, darwin, and win32 — but not for Alpine's musl.
- Switching both stages to `node:20-bookworm-slim` (Debian, glibc) makes `npm ci` fetch the prebuild instead. No `python3 / make / g++` needed; native compilation is skipped entirely.
- Runtime image gains `wget` for the healthcheck via apt.

Image grows ~130 MB relative to Alpine — irrelevant for a personal-scale service, worth it for a reliable rebuild.

Follow-up to #38 / #39.

## Test plan
- [ ] Portainer redeploys `swu-api` without a build failure
- [ ] `curl -i https://swu.mattyflix.com/api/health` returns 200
- [ ] Sign-in + inventory sync still work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)