### PR TITLE
fix(binder): keep long card names and subtitles fully visible

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3177,32 +3177,48 @@ export function Binder({
                       <>
                         {/* TOP-LEFT: Type then Name/Subtitle */}
                         <g transform={`translate(${x + 10}, ${y + 8})`} style={{ pointerEvents: 'none' }}>
-                          <foreignObject width={cellW - 20} height={60}>
+                          <foreignObject width={cellW - 20} height={72}>
                             <div
                                 style={{
                                   fontFamily: 'system-ui, -apple-system, Segoe UI, Roboto, Arial',
                                   color: labelColor,
-                                  lineHeight: 1.18,
-                                  display: 'flex', flexDirection: 'column', gap: 2,
+                                  lineHeight: 1.1,
+                                  display: 'flex', flexDirection: 'column', gap: 1,
                                 }}>
                               <div style={{ fontSize: 10, opacity: 0.85 }}>{cardAt?.Type || ''}</div>
-                              
+
                               {/* Main Name */}
-                              <div style={{
-                                fontSize: 12, fontWeight: 600,
-                              }}>
+                              <div
+                                title={cardAt?.Name}
+                                style={{
+                                  fontSize: 12,
+                                  fontWeight: 600,
+                                  display: '-webkit-box',
+                                  WebkitLineClamp: 2,
+                                  WebkitBoxOrient: 'vertical',
+                                  overflow: 'hidden',
+                                  wordBreak: 'break-word',
+                                }}
+                              >
                                 {cardAt?.Name}
                               </div>
-                              
-                              {/* Subtitle with smaller font */}
+
+                              {/* Subtitle with smaller font, clamped with ellipsis when it overflows */}
                               {cardAt?.Subtitle && (
-                                <div style={{
-                                  fontSize: 10, // Smaller font size
-                                  opacity: 0.8,
-                                  fontWeight: 500,
-                                  lineHeight: 1,
-                                  marginTop: 1,
-                                }}>
+                                <div
+                                  title={cardAt.Subtitle}
+                                  style={{
+                                    fontSize: 10,
+                                    opacity: 0.8,
+                                    fontWeight: 500,
+                                    lineHeight: 1.05,
+                                    display: '-webkit-box',
+                                    WebkitLineClamp: 3,
+                                    WebkitBoxOrient: 'vertical',
+                                    overflow: 'hidden',
+                                    wordBreak: 'break-word',
+                                  }}
+                                >
                                   {cardAt.Subtitle}
                                 </div>
                               )}


### PR DESCRIPTION
## Summary
The top-left label block inside each binder cell was rendered in a fixed 60px `foreignObject`, so when a card had a multi-line name plus a multi-line subtitle (e.g. **ASH 179 — Boba Fett's Rancor / Emotionally Complex Creature**), the last line of the subtitle got clipped mid-glyph — you'd see the top half of "Creature" and nothing under it.

- Grow the block from 60px to 72px and tighten `line-height` (1.18 → 1.1) and inter-row `gap` (2 → 1) so most cards still fit fully.
- Clamp the name to 2 lines and the subtitle to 3 lines with ellipsis + `title` tooltip. Overflow now degrades cleanly with a `…` instead of clipping a partial line.
- Add `word-break: break-word` so unusual single-word cards don't push past the cell width.

Vertical math: block bottom sits at ~y+80; QTY glyph top starts at ~y+84 — safe gap, no visual overlap.

## Test plan
- [x] `npm test` (79 tests pass)
- [x] `npm run lint` clean
- [x] `npm run dev`, verified ASH 179 renders type + name + subtitle fully in the binder view; hover shows full text as tooltip
- [ ] Spot-check other long-subtitle cards (e.g. leaders with multi-word epithets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)