### PR TITLE
Anchor nav bar, add set-switch shortcuts, collapse Data menu, redesign cloud sync widget

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
       body { margin: 0; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Arial, "Apple Color Emoji", "Segoe UI Emoji"; background:#0b0b0f; color:#eaeaf0; padding-bottom: var(--gh-badge-space); }
       .container { max-width: min(1920px, calc(100vw - 24px)); width: 100%; margin: 24px auto; padding: 0 16px; box-sizing: border-box; }
       .card { background:#11121a; border: 1px solid #232433; border-radius: 16px; padding: 16px; }
+      .nav-bar { position: sticky; top: 0; z-index: 40; box-shadow: 0 4px 12px rgba(0,0,0,0.35); }
       .row { display:flex; gap:12px; flex-wrap:wrap; align-items: center; }
       .row > * { flex: none; }
       input, select { background:#0f1017; color:#eaeaf0; border:1px solid #2b2d3d; border-radius:10px; padding:10px 12px; outline:none; }
@@ -342,6 +343,12 @@
         font-size: 18px;        /* tweak per spot if needed */
         -webkit-font-smoothing: antialiased;
       }
+      .icon-sm{ font-size: 15px; }
+      .icon-spin{ animation: icon-spin 1.2s linear infinite; }
+      @keyframes icon-spin{
+        from{ transform: rotate(0deg); }
+        to{ transform: rotate(360deg); }
+      }
       .controls-row .autocomplete .search-icon .icon{
         font-family: 'Material Symbols Rounded';
         font-weight: 400;
@@ -486,6 +493,11 @@
       .controls-row .set-switch-btn:focus-visible{
         outline: 2px solid #8b5cf6;
         outline-offset: 2px;
+      }
+      .controls-row .set-switch-btn .key-pill{
+        font-size: 0.55em;
+        margin: 0 2px;
+        vertical-align: middle;
       }
 
       .key-pill {

--- a/src/App.keyboard.test.tsx
+++ b/src/App.keyboard.test.tsx
@@ -57,4 +57,48 @@ describe('App binder keyboard shortcuts', () => {
     });
     await waitFor(() => expect(subtitle()).toContain('Page 2 (left) | Page 3 (right)'));
   });
+
+  it('uses [ and ] to cycle sets, but ignores them while typing in the search box', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith('/sets/manifest.json')) {
+        return {
+          ok: true,
+          json: async () => ({
+            sets: [
+              { key: 'AAA', label: 'Set AAA', file: 'aaa.json' },
+              { key: 'BBB', label: 'Set BBB', file: 'bbb.json' },
+            ],
+          }),
+        } as Response;
+      }
+      if (url.endsWith('/sets/aaa.json') || url.endsWith('/sets/bbb.json')) {
+        return { ok: true, json: async () => cards } as Response;
+      }
+      return { ok: false, json: async () => ({}) } as Response;
+    }));
+
+    const { container } = render(<App />);
+    const setSelect = () => container.querySelector<HTMLSelectElement>('.set-switch-group select');
+
+    // Newest set (last in manifest) is selected initially.
+    await waitFor(() => expect(setSelect()?.value).toBe('BBB'));
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '[' }));
+    });
+    await waitFor(() => expect(setSelect()?.value).toBe('AAA'));
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: ']' }));
+    });
+    await waitFor(() => expect(setSelect()?.value).toBe('BBB'));
+
+    const search = screen.getByRole('textbox', { name: 'Search cards' });
+    search.focus();
+    act(() => {
+      search.dispatchEvent(new KeyboardEvent('keydown', { key: '[', bubbles: true }));
+    });
+    expect(setSelect()?.value).toBe('BBB');
+  });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,6 +38,7 @@ import {
 } from './core/cloudSync';
 import { useAuth } from './hooks/useAuth';
 import { AuthMenu } from './components/AuthMenu';
+import { DataMenu } from './components/DataMenu';
 import {
   CloudMigrationModal,
   summarize,
@@ -690,7 +691,6 @@ export default function App() {
   const setKeys = useMemo(() => sets.map(set => set.key as SetKey), [sets]);
   const searchRef = useRef<HTMLInputElement | null>(null);
   const submitSearchRef = useRef<() => void>(() => {});
-  const importRef = useRef<HTMLInputElement>(null);
   const [showImportModal, setShowImportModal] = useState(false);
   const [importData, setImportData] = useState<Record<SetKey, Inventory>>({});
   const [importStats, setImportStats] = useState({ recognized: 0, skipped: 0 });
@@ -724,6 +724,7 @@ export default function App() {
   const cloudSyncRef = useRef<CloudSync | null>(null);
   const applyRemoteInventoryRef = useRef<(setKey: SetKey, data: Inventory) => void>(() => {});
   const [syncStatus, setSyncStatus] = useState<SyncStatus>('off');
+  const [lastSyncedAt, setLastSyncedAt] = useState<number | null>(null);
   const [migrationPrompt, setMigrationPrompt] = useState<null | {
     local: Record<SetKey, Inventory>;
     cloud: Record<SetKey, { data: Inventory; version: number }>;
@@ -867,9 +868,15 @@ export default function App() {
   useEffect(() => {
     const sync = cloudSyncRef.current;
     if (!sync) return;
+    const persistedLastPulledAt = sync.getState().lastPulledAt;
+    if (persistedLastPulledAt) setLastSyncedAt(persistedLastPulledAt);
     const unsub = sync.subscribe((event: SyncEvent) => {
       if (event.type === 'status') {
         setSyncStatus(event.status);
+        return;
+      }
+      if (event.type === 'pulled' || event.type === 'pushed') {
+        setLastSyncedAt(Date.now());
         return;
       }
       if (event.type === 'signout') {
@@ -1792,6 +1799,17 @@ export default function App() {
           return;
         } // End Page Flip Logic
 
+        // Set switching shortcuts ("[" and "]")
+        if (e.key === '[') {
+          e.preventDefault();
+          changeSet('prev');
+          return;
+        } else if (e.key === ']') {
+          e.preventDefault();
+          changeSet('next');
+          return;
+        }
+
         // Card selection movement (Arrow keys) and Qty Adjust
         if (active) {
           if (e.key === 'ArrowLeft') {
@@ -1819,7 +1837,7 @@ export default function App() {
 
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [active, query, totalSpreads, updateActivePosition, inc, dec, byNumber, totalPages]);
+  }, [active, query, totalSpreads, updateActivePosition, inc, dec, byNumber, totalPages, changeSet]);
 
   const fmtUSD = (n: number) =>
     n.toLocaleString('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 2 });
@@ -2005,7 +2023,7 @@ export default function App() {
             }}
         >
       {/* Top bar (no page control here anymore) */}
-      <div className="card" style={{ marginBottom: 16 }}>
+      <div className="card nav-bar" style={{ marginBottom: 16 }}>
         <h1 className="title">SWU Binder Organizer</h1>
         <div className="row controls-row" style={{ marginTop: 8 }} ref={boxRef}>
           <div
@@ -2019,10 +2037,10 @@ export default function App() {
               className="btn set-switch-btn"
               disabled={!prevSetKey}
               onClick={() => changeSet('prev')}
-              title={prevSetKey ? `Switch to set ${prevSetKey}` : undefined}
-              aria-label={prevSetKey ? `Previous set: ${prevSetKey}` : 'Previous set (none)'}
+              title={prevSetKey ? `Switch to set ${prevSetKey} — keyboard [` : undefined}
+              aria-label={prevSetKey ? `Previous set: ${prevSetKey}, keyboard [` : 'Previous set (none)'}
             >
-              ‹
+              ‹ <span className="key-pill">[</span>
             </button>
             <label className="pill">
               <span className="set-label">Set</span>
@@ -2040,10 +2058,10 @@ export default function App() {
               className="btn set-switch-btn"
               disabled={!nextSetKey}
               onClick={() => changeSet('next')}
-              title={nextSetKey ? `Switch to set ${nextSetKey}` : undefined}
-              aria-label={nextSetKey ? `Next set: ${nextSetKey}` : 'Next set (none)'}
+              title={nextSetKey ? `Switch to set ${nextSetKey} — keyboard ]` : undefined}
+              aria-label={nextSetKey ? `Next set: ${nextSetKey}, keyboard ]` : 'Next set (none)'}
             >
-              ›
+              <span className="key-pill">]</span> ›
             </button>
           </div>
 
@@ -2151,44 +2169,15 @@ export default function App() {
             authStatus={auth.status}
             email={auth.email}
             syncStatus={syncStatus}
+            lastSyncedAt={lastSyncedAt}
             onSignOut={auth.signOut}
+            onSyncNow={() => cloudSyncRef.current?.flushDirty() ?? Promise.resolve()}
           />
-          <div className="toolbar-block">
-            <div className="toolbar-label">Inventory Controls</div>
-            <div className="toolbar-group">
-              {/* Import button points to the hidden file input */}
-              <button className="tbtn" onClick={() => importRef.current?.click()} title="Import inventory data (JSON / CSV / XLSX)" aria-label="Import inventory data">
-                  <span className="icon" aria-hidden="true">upload</span> <span>Import…</span>
-              </button>
-              <input 
-                  ref={importRef} 
-                  type="file" 
-                  accept=".json,.csv,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-                  style={{ display: 'none' }} 
-                  onChange={handleFileChange}
-              />
-              {/* Save / Export */}
-              <button
-                className="tbtn"
-                onClick={() => exportAllInv()}
-                title="Save inventory to JSON"
-                aria-label="Save inventory to JSON"
-              >
-                <span className="icon" aria-hidden="true">save</span>
-                <span>Save</span>
-              </button>
-
-              {/* Reset */}
-              <button 
-                  className="tbtn tbtn-danger" 
-                  onClick={resetInv} 
-                  title="Reset inventory" 
-                  aria-label="Reset inventory" 
-              > 
-                  <span className="icon" aria-hidden="true">delete</span> <span>Reset</span>
-              </button>
-            </div>
-          </div>
+          <DataMenu
+            onImportFile={handleFileChange}
+            onExport={exportAllInv}
+            onReset={resetInv}
+          />
 
           {error && <span className="err">{error}</span>}
         </div>
@@ -3341,6 +3330,12 @@ export function Binder({
                         <td style={{ padding: '8px 0' }}>Flip Page Left/Right</td>
                         <td style={{ padding: '8px 0' }}>
                           <span className="key-pill">,</span> / <span className="key-pill">.</span>
+                        </td>
+                    </tr>
+                    <tr style={{ borderBottom: '1px dotted #424452' }}>
+                        <td style={{ padding: '8px 0' }}>Previous/Next Set</td>
+                        <td style={{ padding: '8px 0' }}>
+                          <span className="key-pill">[</span> / <span className="key-pill">]</span>
                         </td>
                     </tr>
                     <tr style={{ borderBottom: '1px dotted #424452' }}>

--- a/src/components/AuthMenu.tsx
+++ b/src/components/AuthMenu.tsx
@@ -6,25 +6,40 @@ type Props = {
   authStatus: 'loading' | 'signedIn' | 'signedOut'
   email: string | null
   syncStatus: SyncStatus
+  lastSyncedAt: number | null
   onSignOut: () => void | Promise<void>
+  onSyncNow: () => void | Promise<void>
 }
 
-function statusLabel(status: SyncStatus): string {
+type StatusMeta = { icon: string; color: string; label: string; spin?: boolean }
+
+function statusMeta(status: SyncStatus): StatusMeta {
   switch (status) {
     case 'off':
-      return 'Cloud sync off'
+      return { icon: 'cloud_off', color: '#9aa0b4', label: 'Cloud sync off' }
     case 'idle':
-      return 'Cloud sync on'
+      return { icon: 'cloud_done', color: '#22c55e', label: 'Cloud sync on' }
     case 'pushing':
-      return 'Syncing…'
+      return { icon: 'sync', color: '#facc15', label: 'Syncing…', spin: true }
     case 'error':
-      return 'Sync retrying'
+      return { icon: 'sync_problem', color: '#f87171', label: 'Sync retrying' }
     case 'offline':
-      return 'Offline — queued'
+      return { icon: 'cloud_off', color: '#fb923c', label: 'Offline — queued' }
   }
 }
 
-export function AuthMenu({ authStatus, email, syncStatus, onSignOut }: Props) {
+function formatLastSynced(ts: number | null): string {
+  if (!ts) return 'Never synced'
+  const diffMs = Date.now() - ts
+  if (diffMs < 60_000) return 'Just now'
+  const minutes = Math.floor(diffMs / 60_000)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  return new Date(ts).toLocaleDateString()
+}
+
+export function AuthMenu({ authStatus, email, syncStatus, lastSyncedAt, onSignOut, onSyncNow }: Props) {
   const [menuOpen, setMenuOpen] = React.useState(false)
 
   if (authStatus === 'loading') {
@@ -32,19 +47,19 @@ export function AuthMenu({ authStatus, email, syncStatus, onSignOut }: Props) {
       <div className="toolbar-block">
         <div className="toolbar-label">Cloud</div>
         <div className="toolbar-group">
-          <span className="muted" style={{ fontSize: 12 }}>
-            Checking sign-in…
+          <span className="tbtn" style={{ cursor: 'default' }} title="Checking sign-in…" aria-label="Checking sign-in…">
+            <span className="icon icon-spin" aria-hidden="true">sync</span>
           </span>
         </div>
       </div>
     )
   }
 
-  return (
-    <div className="toolbar-block">
-      <div className="toolbar-label">Cloud</div>
-      <div className="toolbar-group" style={{ position: 'relative' }}>
-        {authStatus === 'signedOut' ? (
+  if (authStatus === 'signedOut') {
+    return (
+      <div className="toolbar-block">
+        <div className="toolbar-label">Cloud</div>
+        <div className="toolbar-group">
           <button
             type="button"
             className="tbtn"
@@ -53,87 +68,104 @@ export function AuthMenu({ authStatus, email, syncStatus, onSignOut }: Props) {
             aria-label="Sign in with Google"
           >
             <span className="icon" aria-hidden="true">login</span>
-            <span>Sign in with Google</span>
           </button>
-        ) : (
-          <>
+        </div>
+      </div>
+    )
+  }
+
+  const meta = statusMeta(syncStatus)
+
+  return (
+    <div className="toolbar-block">
+      <div className="toolbar-label">Cloud</div>
+      <div className="toolbar-group" style={{ position: 'relative', overflow: 'visible' }}>
+        <button
+          type="button"
+          className="tbtn sync-status-trigger"
+          onClick={() => setMenuOpen(v => !v)}
+          aria-haspopup="menu"
+          aria-expanded={menuOpen}
+          title={`${email ?? 'Signed in'} — ${meta.label}`}
+          aria-label={`Cloud sync: ${meta.label}`}
+        >
+          <span style={{ position: 'relative', display: 'inline-flex' }}>
+            <span className="icon" aria-hidden="true">account_circle</span>
+            <span
+              aria-hidden="true"
+              style={{
+                position: 'absolute',
+                right: -2,
+                bottom: -2,
+                width: 8,
+                height: 8,
+                borderRadius: '50%',
+                background: meta.color,
+                border: '1.5px solid #14161f',
+              }}
+            />
+          </span>
+        </button>
+        {menuOpen && (
+          <div
+            role="menu"
+            style={{
+              position: 'absolute',
+              top: '100%',
+              right: 0,
+              marginTop: 4,
+              background: '#1a1c25',
+              border: '1px solid #333',
+              borderRadius: 6,
+              padding: 6,
+              zIndex: 20,
+              minWidth: 220,
+            }}
+          >
+            <div style={{ padding: '6px 8px', color: '#eaeaf0', fontSize: 13, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              {email ?? 'Signed in'}
+            </div>
+            <div style={{ padding: '0 8px 6px', display: 'flex', alignItems: 'center', gap: 6, fontSize: 12 }}>
+              <span
+                className={`icon icon-sm${meta.spin ? ' icon-spin' : ''}`}
+                aria-hidden="true"
+                style={{ color: meta.color }}
+              >
+                {meta.icon}
+              </span>
+              <span style={{ color: meta.color }}>{meta.label}</span>
+            </div>
+            <div style={{ padding: '0 8px 6px', color: '#9aa0b4', fontSize: 11 }}>
+              Last synced: {formatLastSynced(lastSyncedAt)}
+            </div>
             <button
               type="button"
+              role="menuitem"
               className="tbtn"
-              onClick={() => setMenuOpen(v => !v)}
-              aria-haspopup="menu"
-              aria-expanded={menuOpen}
-              title={email ?? undefined}
-              style={{ maxWidth: 220, overflow: 'hidden', textOverflow: 'ellipsis' }}
+              style={{ width: '100%', justifyContent: 'flex-start' }}
+              onClick={() => {
+                void onSyncNow()
+              }}
             >
-              <span className="icon" aria-hidden="true">account_circle</span>
-              <span
-                style={{
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  whiteSpace: 'nowrap',
-                  maxWidth: 160,
-                }}
-              >
-                {email ?? 'Signed in'}
-              </span>
-              <span aria-hidden="true">▾</span>
+              <span className="icon" aria-hidden="true">sync</span>
+              <span>Sync now</span>
             </button>
-            {menuOpen && (
-              <div
-                role="menu"
-                style={{
-                  position: 'absolute',
-                  top: '100%',
-                  right: 0,
-                  marginTop: 4,
-                  background: '#1a1c25',
-                  border: '1px solid #333',
-                  borderRadius: 6,
-                  padding: 6,
-                  zIndex: 20,
-                  minWidth: 180,
-                }}
-              >
-                <button
-                  type="button"
-                  role="menuitem"
-                  className="tbtn"
-                  style={{ width: '100%', justifyContent: 'flex-start' }}
-                  onClick={() => {
-                    setMenuOpen(false)
-                    void onSignOut()
-                  }}
-                >
-                  <span className="icon" aria-hidden="true">logout</span>
-                  <span>Sign out</span>
-                </button>
-              </div>
-            )}
-          </>
+            <div style={{ height: 1, background: '#333', margin: '6px 2px' }} />
+            <button
+              type="button"
+              role="menuitem"
+              className="tbtn"
+              style={{ width: '100%', justifyContent: 'flex-start' }}
+              onClick={() => {
+                setMenuOpen(false)
+                void onSignOut()
+              }}
+            >
+              <span className="icon" aria-hidden="true">logout</span>
+              <span>Sign out</span>
+            </button>
+          </div>
         )}
-        <span
-          aria-label={statusLabel(syncStatus)}
-          title={statusLabel(syncStatus)}
-          style={{
-            fontSize: 11,
-            padding: '2px 8px',
-            borderRadius: 999,
-            border: '1px solid currentColor',
-            opacity: 0.75,
-            color:
-              syncStatus === 'error'
-                ? '#f87171'
-                : syncStatus === 'off'
-                  ? '#9aa0b4'
-                  : syncStatus === 'pushing'
-                    ? '#facc15'
-                    : '#22c55e',
-            whiteSpace: 'nowrap',
-          }}
-        >
-          {statusLabel(syncStatus)}
-        </span>
       </div>
     </div>
   )

--- a/src/components/DataMenu.tsx
+++ b/src/components/DataMenu.tsx
@@ -1,0 +1,99 @@
+import React from 'react'
+
+type Props = {
+  onImportFile: (e: React.ChangeEvent<HTMLInputElement>) => void
+  onExport: () => void
+  onReset: () => void
+}
+
+export function DataMenu({ onImportFile, onExport, onReset }: Props) {
+  const [menuOpen, setMenuOpen] = React.useState(false)
+  const importRef = React.useRef<HTMLInputElement>(null)
+
+  return (
+    <div className="toolbar-block">
+      <div className="toolbar-label">Data</div>
+      <div className="toolbar-group" style={{ position: 'relative', overflow: 'visible' }}>
+        <button
+          type="button"
+          className="tbtn"
+          onClick={() => setMenuOpen(v => !v)}
+          aria-haspopup="menu"
+          aria-expanded={menuOpen}
+          title="Import, export, or reset inventory data"
+          aria-label="Data menu"
+        >
+          <span className="icon" aria-hidden="true">database</span>
+        </button>
+        {menuOpen && (
+          <div
+            role="menu"
+            style={{
+              position: 'absolute',
+              top: '100%',
+              right: 0,
+              marginTop: 4,
+              background: '#1a1c25',
+              border: '1px solid #333',
+              borderRadius: 6,
+              padding: 6,
+              zIndex: 20,
+              minWidth: 200,
+            }}
+          >
+            <button
+              type="button"
+              role="menuitem"
+              className="tbtn"
+              style={{ width: '100%', justifyContent: 'flex-start' }}
+              onClick={() => {
+                setMenuOpen(false)
+                importRef.current?.click()
+              }}
+              title="Import inventory data (JSON / CSV / XLSX)"
+            >
+              <span className="icon" aria-hidden="true">upload</span>
+              <span>Import…</span>
+            </button>
+            <input
+              ref={importRef}
+              type="file"
+              accept=".json,.csv,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+              style={{ display: 'none' }}
+              onChange={onImportFile}
+            />
+            <button
+              type="button"
+              role="menuitem"
+              className="tbtn"
+              style={{ width: '100%', justifyContent: 'flex-start' }}
+              onClick={() => {
+                setMenuOpen(false)
+                onExport()
+              }}
+              title="Export inventory to JSON"
+            >
+              <span className="icon" aria-hidden="true">save</span>
+              <span>Export</span>
+            </button>
+            <div style={{ height: 1, background: '#333', margin: '6px 2px' }} />
+            <button
+              type="button"
+              role="menuitem"
+              className="tbtn tbtn-danger"
+              style={{ width: '100%', justifyContent: 'flex-start' }}
+              onClick={() => {
+                setMenuOpen(false)
+                onReset()
+              }}
+              title="Reset inventory"
+            >
+              <span className="icon" aria-hidden="true">delete</span>
+              <span>Reset…</span>
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Pin the top bar (`position: sticky`) so the active set stays visible while scrolling the binder.
- Add `[` / `]` keyboard shortcuts to cycle sets, mirroring the existing `,`/`.` page-flip shortcuts (with a key-pill hint and Help modal entry).
- Collapse Import / Export / Reset into a single `DataMenu` dropdown now that cloud sync reduces reliance on manual import/export.
- Redesign the cloud sync widget (`AuthMenu`) into a compact status icon + colored dot, with a dropdown showing email, status, last-synced time, and a manual "Sync now" button.
- Fix a pre-existing bug where `.toolbar-group`'s `overflow: hidden` silently clipped floating dropdown menus (affected the original AuthMenu dropdown too).

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — 80/80 tests pass (includes new `[`/`]` shortcut tests with an isTyping guard case)
- [x] Manually drove the app in a headless browser: confirmed the nav bar stays pinned while scrolling, the Data menu opens and shows Import…/Export/Reset, and `[`/`]` cycle sets
- [ ] Cloud sync dropdown not visually verified signed-in (no OAuth backend available in the dev sandbox) — shares the same dropdown pattern verified via the Data menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)