### PR TITLE
feat(deck): add Deck Check — paste a decklist, see owned vs. missing, cost to complete

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,8 @@ import {
 import { useAuth } from './hooks/useAuth';
 import { AuthMenu } from './components/AuthMenu';
 import { DataMenu } from './components/DataMenu';
+import { DeckCheckModal } from './components/DeckCheckModal';
+import { formatMissingLine, type DeckLookupSet } from './core/decklist';
 import {
   CloudMigrationModal,
   summarize,
@@ -696,6 +698,7 @@ export default function App() {
   const [importStats, setImportStats] = useState({ recognized: 0, skipped: 0 });
   const [importingFileName, setImportingFileName] = useState('');
   const [showResetModal, setShowResetModal] = useState(false);
+  const [showDeckCheckModal, setShowDeckCheckModal] = useState(false);
   const [listView, setListView] = React.useState<'inventory' | 'missing'>('inventory');
 
   // In-app toast notifications (replaces window.alert)
@@ -1291,6 +1294,27 @@ export default function App() {
     () => buildSearchSuggestions(query, searchCatalogs, setKey),
     [query, searchCatalogs, setKey],
   );
+
+  // Deck Check: cross-set card lookup (byNumber + baseCards), refreshed whenever the
+  // canonical catalog is (mirrors the searchCatalogs memo above).
+  const deckCheckParsedSets: Map<SetKey, DeckLookupSet> = useMemo(
+    () => {
+      const map = new Map<SetKey, DeckLookupSet>();
+      if (canonicalCatalog.size === 0) return map;
+      for (const [catalogSetKey, parsed] of parsedCacheRef.current) {
+        map.set(catalogSetKey, { byNumber: parsed.byNumber, baseCards: parsed.baseCards });
+      }
+      return map;
+    },
+    [canonicalCatalog],
+  );
+
+  // Deck Check: owned-quantity lookup spanning every set (not just the currently displayed one).
+  const buildOwnedLookup = useCallback(() => {
+    const snapshot = createInventoryExportSnapshot(localStorage, setKeys, setKey, inventory, canonicalCatalog);
+    return (targetSetKey: SetKey, baseNumber: number) => snapshot[targetSetKey]?.[baseNumber] ?? 0;
+  }, [setKeys, setKey, inventory, canonicalCatalog]);
+
   // Click outside to close dropdown
   useEffect(() => {
     const onDoc = (e: MouseEvent) => {
@@ -1977,15 +2001,8 @@ export default function App() {
         // r.Number is the base number for this row
         // Use byNumber to retrieve the Card object which contains Subtitle
         const card = byNumber.get(r.Number);
-        
-        // Construct the card name part: "Name - Subtitle"
-        const cardNamePart = card?.Subtitle 
-            ? `${r.Name} - ${card.Subtitle}` 
-            : r.Name;
-        
         const qty = tcgCopyMode === 'oneEach' ? 1 : r.Needed;
-        // Final format: QTY Name - Subtitle [setKey]
-        return `${qty} ${cardNamePart} [${setKey}]`;
+        return formatMissingLine(r.Name, card?.Subtitle, setKey, qty);
     }).join('\n');
 
     if (list.length === 0) {
@@ -2178,6 +2195,22 @@ export default function App() {
             onExport={exportAllInv}
             onReset={resetInv}
           />
+          <div className="toolbar-block">
+            <div className="toolbar-label">Deck</div>
+            <div className="toolbar-group">
+              <button
+                type="button"
+                className="tbtn"
+                onClick={() => setShowDeckCheckModal(true)}
+                disabled={canonicalCatalog.size === 0}
+                title="Check a decklist against your collection"
+                aria-label="Deck check"
+              >
+                <span className="icon" aria-hidden="true">checklist</span>
+                <span>Deck Check</span>
+              </button>
+            </div>
+          </div>
 
           {error && <span className="err">{error}</span>}
         </div>
@@ -2553,6 +2586,17 @@ export default function App() {
           )
         )}
       </div>
+
+      {showDeckCheckModal && (
+        <DeckCheckModal
+          canonicalCatalog={canonicalCatalog}
+          parsedSets={deckCheckParsedSets}
+          trackedSetKeys={setKeys}
+          buildOwnedLookup={buildOwnedLookup}
+          showToast={showToast}
+          onClose={() => setShowDeckCheckModal(false)}
+        />
+      )}
 
       {migrationPrompt && (
         <CloudMigrationModal

--- a/src/components/DeckCheckModal.tsx
+++ b/src/components/DeckCheckModal.tsx
@@ -1,0 +1,331 @@
+import React from 'react'
+import type { CanonicalCatalog } from '../core/inventory'
+import type { SetKey } from '../core/types'
+import {
+  computeDeckRows,
+  detectDeckFormat,
+  formatMissingLine,
+  parseDeckList,
+  resolveDeckList,
+  summarizeDeck,
+  type DeckLookupSet,
+  type DeckResolution,
+  type DeckRowWithNeed,
+} from '../core/decklist'
+
+type Props = {
+  canonicalCatalog: CanonicalCatalog
+  parsedSets: Map<SetKey, DeckLookupSet>
+  trackedSetKeys: SetKey[]
+  buildOwnedLookup: () => (setKey: SetKey, baseNumber: number) => number
+  showToast: (message: string, kind?: 'success' | 'error' | 'warning') => void
+  onClose: () => void
+}
+
+const FORMAT_LABEL: Record<DeckResolution['format'], string> = {
+  json: 'JSON',
+  melee: 'Melee text',
+  picklist: 'Picklist',
+  generic: 'Plain list',
+}
+
+const REASON_LABEL: Record<'unknown-set' | 'no-name-match' | 'malformed', string> = {
+  'unknown-set': 'Set not tracked or printing not found',
+  'no-name-match': 'No matching card found by name',
+  malformed: 'Could not parse this line',
+}
+
+const ROLE_LABEL: Record<'leader' | 'base' | 'deck' | 'sideboard', string> = {
+  leader: 'Leader',
+  base: 'Base',
+  deck: 'Deck',
+  sideboard: 'Sideboard',
+}
+
+function money(value: number): string {
+  return `$${value.toFixed(2)}`
+}
+
+function Row({ row }: { row: DeckRowWithNeed }) {
+  return (
+    <tr>
+      <td>{ROLE_LABEL[row.role]}</td>
+      <td>
+        {row.name}
+        {row.subtitle && <span className="muted"> - {row.subtitle}</span>}
+        {row.ambiguous && (
+          <span
+            className="muted"
+            title={
+              row.ambiguousOtherSets?.length
+                ? `Name also matches: ${row.ambiguousOtherSets.join(', ')} — guessed ${row.setKey}`
+                : 'Guessed which printing you meant'
+            }
+            style={{ marginLeft: 6 }}
+          >
+            ⚠
+          </span>
+        )}
+      </td>
+      <td className="mono">{row.setKey}</td>
+      <td className="mono">{row.have}</td>
+      <td className="mono">{row.count}</td>
+      <td className="mono">{row.needed}</td>
+      <td className="mono">{money(row.price)}</td>
+      <td className="mono">{money(row.rowCost)}</td>
+    </tr>
+  )
+}
+
+export function DeckCheckModal({
+  canonicalCatalog,
+  parsedSets,
+  trackedSetKeys,
+  buildOwnedLookup,
+  showToast,
+  onClose,
+}: Props) {
+  const [text, setText] = React.useState('')
+  const [resolution, setResolution] = React.useState<DeckResolution | null>(null)
+  const [rows, setRows] = React.useState<DeckRowWithNeed[]>([])
+  const [includeSideboard, setIncludeSideboard] = React.useState(false)
+  const [copyFeedback, setCopyFeedback] = React.useState<'idle' | 'copied' | 'failed'>('idle')
+  const copyFeedbackTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  React.useEffect(() => {
+    return () => {
+      if (copyFeedbackTimerRef.current != null) clearTimeout(copyFeedbackTimerRef.current)
+    }
+  }, [])
+
+  function handleParse() {
+    if (!text.trim()) {
+      showToast('Paste a decklist first.', 'warning')
+      return
+    }
+    if (canonicalCatalog.size === 0) {
+      showToast('Card catalog is still loading. Please try again.', 'warning')
+      return
+    }
+    const parsed = parseDeckList(text)
+    const owned = buildOwnedLookup()
+    const resolved = resolveDeckList(parsed, canonicalCatalog, parsedSets, trackedSetKeys, owned)
+    setResolution(resolved)
+    setRows(computeDeckRows(resolved.rows, owned))
+  }
+
+  const summary = React.useMemo(() => summarizeDeck(rows, includeSideboard), [rows, includeSideboard])
+  const mainRows = rows.filter(r => r.role !== 'sideboard')
+  const sideboardRows = rows.filter(r => r.role === 'sideboard')
+  const detectedFormat = text.trim() ? FORMAT_LABEL[detectDeckFormat(text)] : null
+
+  function copyMissingDeckCards() {
+    const list = rows
+      .filter(r => (r.role !== 'sideboard' || includeSideboard) && r.needed > 0)
+      .map(r => formatMissingLine(r.name, r.subtitle, r.setKey, r.needed))
+      .join('\n')
+
+    if (!list) {
+      showToast('No missing cards to copy!', 'warning')
+      return
+    }
+
+    if (copyFeedbackTimerRef.current != null) {
+      clearTimeout(copyFeedbackTimerRef.current)
+      copyFeedbackTimerRef.current = null
+    }
+
+    navigator.clipboard.writeText(list).then(
+      () => {
+        setCopyFeedback('copied')
+        copyFeedbackTimerRef.current = setTimeout(() => setCopyFeedback('idle'), 2200)
+      },
+      () => {
+        setCopyFeedback('failed')
+        showToast('Copy failed.', 'error')
+        copyFeedbackTimerRef.current = setTimeout(() => setCopyFeedback('idle'), 3200)
+      },
+    )
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Deck check"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0,0,0,0.5)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 100,
+      }}
+    >
+      <div
+        className="card"
+        style={{
+          maxWidth: 900,
+          width: '92%',
+          maxHeight: '85vh',
+          overflowY: 'auto',
+          padding: 20,
+          background: '#141821',
+        }}
+      >
+        <div className="row" style={{ justifyContent: 'space-between', flexWrap: 'nowrap' }}>
+          <h2 style={{ marginTop: 0 }}>Deck Check</h2>
+          <button type="button" className="tbtn" onClick={onClose} aria-label="Close">
+            <span className="icon" aria-hidden="true">close</span>
+          </button>
+        </div>
+
+        <p className="muted" style={{ marginTop: 0 }}>
+          Paste a decklist (JSON, Melee, Picklist, or a plain "3x Card Name" list) to see which cards
+          you own, which are missing, and what it would cost to complete the deck.
+        </p>
+
+        <textarea
+          value={text}
+          onChange={e => setText(e.target.value)}
+          placeholder="Paste your decklist here…"
+          rows={8}
+          style={{
+            width: '100%',
+            boxSizing: 'border-box',
+            background: '#0f1017',
+            color: '#eaeaf0',
+            border: '1px solid #2b2d3d',
+            borderRadius: 10,
+            padding: 12,
+            fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+            fontSize: 13,
+            resize: 'vertical',
+          }}
+        />
+
+        <div className="row" style={{ marginTop: 12 }}>
+          <button type="button" className="tbtn" onClick={handleParse}>
+            <span className="icon" aria-hidden="true">checklist</span>
+            <span>Check Deck</span>
+          </button>
+          {detectedFormat && <span className="pill">Detected: {detectedFormat}</span>}
+        </div>
+
+        {resolution && (
+          <>
+            <div className="row" style={{ marginTop: 20, justifyContent: 'space-between' }}>
+              <h3 style={{ margin: 0 }}>{resolution.deckName ?? 'Pasted decklist'}</h3>
+              <label className="row" style={{ gap: 6 }}>
+                <input
+                  type="checkbox"
+                  checked={includeSideboard}
+                  onChange={e => setIncludeSideboard(e.target.checked)}
+                />
+                <span>Include sideboard in totals &amp; export</span>
+              </label>
+            </div>
+
+            <div className="row" style={{ marginTop: 8, gap: 16 }}>
+              <span className="pill">Needed cards: {summary.totalNeededCards}</span>
+              <span className="pill">Cost to complete: {money(summary.totalCost)}</span>
+              {summary.leaderOwned !== null && (
+                <span className="pill">Leader: {summary.leaderOwned ? 'Owned ✓' : 'Missing'}</span>
+              )}
+              {summary.baseOwned !== null && (
+                <span className="pill">Base: {summary.baseOwned ? 'Owned ✓' : 'Missing'}</span>
+              )}
+            </div>
+
+            <div style={{ overflowX: 'auto' }}>
+              <table className="table" style={{ marginTop: 12 }}>
+                <thead>
+                  <tr>
+                    <th>Role</th>
+                    <th>Card</th>
+                    <th>Set</th>
+                    <th>Have</th>
+                    <th>Deck</th>
+                    <th>Needed</th>
+                    <th>Price</th>
+                    <th>Cost</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {mainRows.map(row => (
+                    <Row key={`${row.role}:${row.setKey}:${row.baseNumber}`} row={row} />
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            {sideboardRows.length > 0 && (
+              <>
+                <h4 style={{ marginBottom: 4 }}>Sideboard</h4>
+                <div style={{ overflowX: 'auto' }}>
+                  <table className="table">
+                    <thead>
+                      <tr>
+                        <th>Role</th>
+                        <th>Card</th>
+                        <th>Set</th>
+                        <th>Have</th>
+                        <th>Deck</th>
+                        <th>Needed</th>
+                        <th>Price</th>
+                        <th>Cost</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {sideboardRows.map(row => (
+                        <Row key={`${row.role}:${row.setKey}:${row.baseNumber}`} row={row} />
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </>
+            )}
+
+            {resolution.unresolved.length > 0 && (
+              <>
+                <h4 style={{ marginBottom: 4 }}>
+                  <span className="err">Unresolved ({resolution.unresolved.length})</span>
+                </h4>
+                <p className="muted" style={{ marginTop: 0 }}>
+                  These lines couldn't be matched to a card. Fix them in the pasted text and check again.
+                </p>
+                <ul style={{ margin: 0, padding: '0 0 0 18px' }}>
+                  {resolution.unresolved.map((entry, i) => (
+                    <li key={i} className="muted">
+                      {entry.count > 0 ? `${entry.count} ` : ''}
+                      {entry.name}
+                      {entry.subtitle ? ` - ${entry.subtitle}` : ''}
+                      {' — '}
+                      {REASON_LABEL[entry.reason]}
+                    </li>
+                  ))}
+                </ul>
+              </>
+            )}
+
+            <div className="row" style={{ marginTop: 16 }}>
+              <button type="button" className="tbtn" onClick={copyMissingDeckCards}>
+                <span className="icon" aria-hidden="true">
+                  {copyFeedback === 'copied' ? 'check_circle' : copyFeedback === 'failed' ? 'error' : 'content_paste'}
+                </span>
+                <span>
+                  {copyFeedback === 'copied'
+                    ? 'Copied!'
+                    : copyFeedback === 'failed'
+                    ? 'Copy failed'
+                    : 'Copy missing to clipboard'}
+                </span>
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/core/decklist.test.ts
+++ b/src/core/decklist.test.ts
@@ -1,0 +1,571 @@
+import { describe, expect, it } from 'vitest'
+import type { Card, SetKey } from './types'
+import type { CanonicalCatalog } from './inventory'
+import {
+  computeDeckRows,
+  detectDeckFormat,
+  formatMissingLine,
+  parseDeckGeneric,
+  parseDeckJson,
+  parseDeckMelee,
+  parseDeckPicklist,
+  resolveDeckList,
+  summarizeDeck,
+  type DeckLookupSet,
+} from './decklist'
+
+// ---------------------------------------------------------------------------
+// Shared fixtures: four fake tracked sets with a couple of same-named cards
+// across sets (to exercise ambiguity) and a couple of Type-less cards (to
+// exercise the leader/base ordinal fallback).
+// ---------------------------------------------------------------------------
+
+function card(partial: Partial<Card> & { Name: string; Number: number; Set: SetKey }): Card {
+  return { MarketPrice: 0, ...partial }
+}
+
+const ASH_CARDS: Card[] = [
+  card({ Set: 'ASH', Number: 10, Name: 'Bo-Katan Kryze', Subtitle: 'Reclaiming Mandalore', Type: 'Leader', MarketPrice: 5 }),
+  card({ Set: 'ASH', Number: 140, Name: 'Stronger Together', Type: 'Unit', MarketPrice: 2 }),
+  card({ Set: 'ASH', Number: 79, Name: 'Koska Reeves', Subtitle: 'Warrior of Mandalore', Type: 'Unit', MarketPrice: 3 }),
+  card({ Set: 'ASH', Number: 999, Name: 'Vanquish', Type: 'Event', MarketPrice: 1 }),
+  card({ Set: 'ASH', Number: 500, Name: 'Mystery Card A', MarketPrice: 1 }),
+]
+
+const JTL_CARDS: Card[] = [
+  card({ Set: 'JTL', Number: 19, Name: 'City in the Clouds', Type: 'Base', MarketPrice: 4 }),
+  card({ Set: 'JTL', Number: 999, Name: 'Vanquish', Type: 'Event', MarketPrice: 1 }),
+  card({ Set: 'JTL', Number: 501, Name: 'Mystery Card B', MarketPrice: 1 }),
+]
+
+const SEC_CARDS: Card[] = [
+  card({ Set: 'SEC', Number: 47, Name: 'Coronet', Subtitle: 'Stately Vessel', Type: 'Unit', MarketPrice: 2 }),
+]
+
+const LAW_CARDS: Card[] = [
+  card({ Set: 'LAW', Number: 133, Name: 'Lost and Forgotten', Type: 'Event', MarketPrice: 1 }),
+]
+
+const TRACKED_SET_KEYS: SetKey[] = ['ASH', 'JTL', 'SEC', 'LAW']
+
+const ALL_SET_CARDS: Record<SetKey, Card[]> = {
+  ASH: ASH_CARDS,
+  JTL: JTL_CARDS,
+  SEC: SEC_CARDS,
+  LAW: LAW_CARDS,
+}
+
+const PARSED_SETS: Map<SetKey, DeckLookupSet> = new Map(
+  TRACKED_SET_KEYS.map(setKey => [
+    setKey,
+    {
+      baseCards: ALL_SET_CARDS[setKey],
+      byNumber: new Map(ALL_SET_CARDS[setKey].map(c => [c.Number, c])),
+    },
+  ]),
+)
+
+const CATALOG: CanonicalCatalog = new Map(
+  TRACKED_SET_KEYS.flatMap(setKey =>
+    ALL_SET_CARDS[setKey].map(c => [
+      `${setKey}:${c.Number}`,
+      { setKey, printingNumber: c.Number, baseNumber: c.Number, type: c.Type },
+    ] as const),
+  ),
+)
+
+const NO_OWNERSHIP = () => 0
+
+// ---------------------------------------------------------------------------
+// detectDeckFormat
+// ---------------------------------------------------------------------------
+
+describe('detectDeckFormat', () => {
+  it('detects JSON format', () => {
+    expect(detectDeckFormat('{"leader":{"id":"ASH_010","count":1},"deck":[]}')).toBe('json')
+  })
+
+  it('detects Melee format', () => {
+    expect(detectDeckFormat('Leader\n1 | Bo-Katan Kryze\n\nMainDeck\n3 | Covert Veteran')).toBe('melee')
+  })
+
+  it('detects Picklist format', () => {
+    expect(detectDeckFormat('Picklist: My Deck\n\n[ ] Some Card\n ASH 010')).toBe('picklist')
+  })
+
+  it('falls back to generic for plain lines', () => {
+    expect(detectDeckFormat('3 Vanquish (SOR)\n2x Effective Position')).toBe('generic')
+  })
+
+  it('falls back to generic for empty text', () => {
+    expect(detectDeckFormat('   ')).toBe('generic')
+  })
+
+  it('falls back to generic for JSON without leader/base/deck shape', () => {
+    expect(detectDeckFormat('{"foo":1}')).toBe('generic')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseDeckJson
+// ---------------------------------------------------------------------------
+
+describe('parseDeckJson', () => {
+  const sample = JSON.stringify({
+    metadata: { name: 'So many MANDALORIANS!!!!!', author: 'Guydud3' },
+    leader: { id: 'ASH_010', count: 1 },
+    base: { id: 'JTL_019', count: 1 },
+    deck: [
+      { id: 'ASH_140', count: 2 },
+      { id: 'SEC_047', count: 2 },
+    ],
+    sideboard: [{ id: 'JTL_078', count: 3 }],
+  })
+
+  it('parses leader/base/deck/sideboard entries with exact identities', () => {
+    const parsed = parseDeckJson(sample)
+    expect(parsed.format).toBe('json')
+    expect(parsed.deckName).toBe('So many MANDALORIANS!!!!!')
+    expect(parsed.malformed).toEqual([])
+    expect(parsed.entries).toEqual([
+      { role: 'leader', name: 'ASH_010', count: 1, exact: { setKey: 'ASH', printingNumber: 10 } },
+      { role: 'base', name: 'JTL_019', count: 1, exact: { setKey: 'JTL', printingNumber: 19 } },
+      { role: 'deck', name: 'ASH_140', count: 2, exact: { setKey: 'ASH', printingNumber: 140 } },
+      { role: 'deck', name: 'SEC_047', count: 2, exact: { setKey: 'SEC', printingNumber: 47 } },
+      { role: 'sideboard', name: 'JTL_078', count: 3, exact: { setKey: 'JTL', printingNumber: 78 } },
+    ])
+  })
+
+  it('defaults sideboard to empty when absent', () => {
+    const parsed = parseDeckJson(
+      JSON.stringify({ leader: { id: 'ASH_010', count: 1 }, base: { id: 'JTL_019', count: 1 }, deck: [] }),
+    )
+    expect(parsed.entries.filter(e => e.role === 'sideboard')).toEqual([])
+  })
+
+  it('records a malformed id as skipped rather than throwing', () => {
+    const parsed = parseDeckJson(
+      JSON.stringify({ leader: { id: 'ASH_010', count: 1 }, base: { id: 'JTL_019', count: 1 }, deck: [{ id: 'not-an-id', count: 2 }] }),
+    )
+    expect(parsed.entries).toHaveLength(2)
+    expect(parsed.malformed).toHaveLength(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseDeckMelee
+// ---------------------------------------------------------------------------
+
+describe('parseDeckMelee', () => {
+  it('parses the sample Melee export', () => {
+    const text = [
+      'Leader',
+      '1 | Bo-Katan Kryze | Reclaiming Mandalore',
+      '',
+      'Base',
+      '1 | City in the Clouds',
+      '',
+      'MainDeck',
+      '3 | Covert Veteran',
+      '2 | Coronet | Stately Vessel',
+      '',
+      'Sideboard',
+      '3 | Direct Hit',
+    ].join('\n')
+
+    const parsed = parseDeckMelee(text)
+    expect(parsed.malformed).toEqual([])
+    expect(parsed.entries).toEqual([
+      { role: 'leader', name: 'Bo-Katan Kryze', subtitle: 'Reclaiming Mandalore', count: 1 },
+      { role: 'base', name: 'City in the Clouds', subtitle: undefined, count: 1 },
+      { role: 'deck', name: 'Covert Veteran', subtitle: undefined, count: 3 },
+      { role: 'deck', name: 'Coronet', subtitle: 'Stately Vessel', count: 2 },
+      { role: 'sideboard', name: 'Direct Hit', subtitle: undefined, count: 3 },
+    ])
+  })
+
+  it('handles Sideboard appearing before MainDeck', () => {
+    const text = ['Sideboard', '2 | Direct Hit', '', 'MainDeck', '3 | Covert Veteran'].join('\n')
+    const parsed = parseDeckMelee(text)
+    expect(parsed.entries.map(e => e.role)).toEqual(['sideboard', 'deck'])
+  })
+
+  it('ignores lines before any section header', () => {
+    const text = ['3 | Stray Line', 'MainDeck', '3 | Covert Veteran'].join('\n')
+    const parsed = parseDeckMelee(text)
+    expect(parsed.entries).toHaveLength(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseDeckPicklist
+// ---------------------------------------------------------------------------
+
+describe('parseDeckPicklist', () => {
+  const sample = [
+    'Picklist: So many MANDALORIANS!!!!!',
+    '',
+    '[ ]          Bo-Katan Kryze | Reclaiming Mandalore',
+    '             ASH 010, ASH 274, ASH 776',
+    '',
+    '[ ]          City in the Clouds',
+    '             JTL 019, JTL 281',
+    '',
+    '-----',
+    '',
+    '[ ] [ ] [ ]  Koska Reeves | Warrior of Mandalore',
+    '             P26 194, ASH 079, ASH 343, ASH 581',
+    '',
+    '[ ] [ ]      Stronger Together',
+    '             ASH 140, ASH 404, ASH 642',
+    '',
+    '-----',
+    '',
+    'Needed tokens: Advantage, Shield, Credit, Experience',
+  ].join('\n')
+
+  it('parses deck name, leader/base section, and main-deck section', () => {
+    const parsed = parseDeckPicklist(sample)
+    expect(parsed.deckName).toBe('So many MANDALORIANS!!!!!')
+    expect(parsed.malformed).toEqual([])
+    expect(parsed.entries).toEqual([
+      {
+        role: 'leaderOrBase',
+        name: 'Bo-Katan Kryze',
+        subtitle: 'Reclaiming Mandalore',
+        count: 1,
+        alternates: [
+          { setKey: 'ASH', printingNumber: 10 },
+          { setKey: 'ASH', printingNumber: 274 },
+          { setKey: 'ASH', printingNumber: 776 },
+        ],
+      },
+      {
+        role: 'leaderOrBase',
+        name: 'City in the Clouds',
+        subtitle: undefined,
+        count: 1,
+        alternates: [
+          { setKey: 'JTL', printingNumber: 19 },
+          { setKey: 'JTL', printingNumber: 281 },
+        ],
+      },
+      {
+        role: 'deck',
+        name: 'Koska Reeves',
+        subtitle: 'Warrior of Mandalore',
+        count: 3,
+        alternates: [
+          { setKey: 'P26', printingNumber: 194 },
+          { setKey: 'ASH', printingNumber: 79 },
+          { setKey: 'ASH', printingNumber: 343 },
+          { setKey: 'ASH', printingNumber: 581 },
+        ],
+      },
+      {
+        role: 'deck',
+        name: 'Stronger Together',
+        subtitle: undefined,
+        count: 2,
+        alternates: [
+          { setKey: 'ASH', printingNumber: 140 },
+          { setKey: 'ASH', printingNumber: 404 },
+          { setKey: 'ASH', printingNumber: 642 },
+        ],
+      },
+    ])
+  })
+
+  it('treats a third section as sideboard', () => {
+    const text = [
+      'Picklist: Deck',
+      '[ ] Leader Card',
+      'ASH 1',
+      '-----',
+      '[ ] Deck Card',
+      'ASH 2',
+      '-----',
+      '[ ] Side Card',
+      'ASH 3',
+    ].join('\n')
+    const parsed = parseDeckPicklist(text)
+    expect(parsed.entries.map(e => e.role)).toEqual(['leaderOrBase', 'deck', 'sideboard'])
+  })
+
+  it('ignores the trailing "Needed tokens:" line', () => {
+    const parsed = parseDeckPicklist(sample)
+    expect(parsed.entries.some(e => e.name.includes('Needed tokens'))).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseDeckGeneric
+// ---------------------------------------------------------------------------
+
+describe('parseDeckGeneric', () => {
+  it('parses "qty Name (SET)"', () => {
+    const parsed = parseDeckGeneric('3 Vanquish (SOR)')
+    expect(parsed.entries).toEqual([{ role: 'deck', name: 'Vanquish', subtitle: undefined, count: 3, setHint: 'SOR' }])
+  })
+
+  it('parses "qtyx Name" with no set hint', () => {
+    const parsed = parseDeckGeneric('3x Vanquish')
+    expect(parsed.entries).toEqual([{ role: 'deck', name: 'Vanquish', subtitle: undefined, count: 3, setHint: undefined }])
+  })
+
+  it('parses "qty Name - Subtitle"', () => {
+    const parsed = parseDeckGeneric('2 Coronet - Stately Vessel')
+    expect(parsed.entries).toEqual([{ role: 'deck', name: 'Coronet', subtitle: 'Stately Vessel', count: 2, setHint: undefined }])
+  })
+
+  it('marks lines without a leading quantity as malformed', () => {
+    const parsed = parseDeckGeneric('no count here')
+    expect(parsed.entries).toEqual([])
+    expect(parsed.malformed).toEqual(['no count here'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// resolveDeckList
+// ---------------------------------------------------------------------------
+
+describe('resolveDeckList', () => {
+  it('resolves an exact (Format A style) identity', () => {
+    const resolution = resolveDeckList(
+      { format: 'json', entries: [{ role: 'deck', name: 'ASH_140', count: 2, exact: { setKey: 'ASH', printingNumber: 140 } }], malformed: [] },
+      CATALOG,
+      PARSED_SETS,
+      TRACKED_SET_KEYS,
+      NO_OWNERSHIP,
+    )
+    expect(resolution.unresolved).toEqual([])
+    expect(resolution.rows).toEqual([
+      { role: 'deck', count: 2, setKey: 'ASH', baseNumber: 140, name: 'Stronger Together', subtitle: undefined, type: 'Unit', price: 2, ambiguous: false, ambiguousOtherSets: undefined },
+    ])
+  })
+
+  it('falls through untracked alternates to the first tracked one (Format C style)', () => {
+    const resolution = resolveDeckList(
+      {
+        format: 'picklist',
+        entries: [
+          {
+            role: 'deck',
+            name: 'Koska Reeves',
+            subtitle: 'Warrior of Mandalore',
+            count: 3,
+            alternates: [
+              { setKey: 'P26', printingNumber: 194 },
+              { setKey: 'ASH', printingNumber: 79 },
+            ],
+          },
+        ],
+        malformed: [],
+      },
+      CATALOG,
+      PARSED_SETS,
+      TRACKED_SET_KEYS,
+      NO_OWNERSHIP,
+    )
+    expect(resolution.unresolved).toEqual([])
+    expect(resolution.rows[0].setKey).toBe('ASH')
+    expect(resolution.rows[0].baseNumber).toBe(79)
+  })
+
+  it('marks a card unresolved when none of its alternates are tracked', () => {
+    const resolution = resolveDeckList(
+      { format: 'picklist', entries: [{ role: 'deck', name: 'Promo Only', count: 1, alternates: [{ setKey: 'P26', printingNumber: 1 }] }], malformed: [] },
+      CATALOG,
+      PARSED_SETS,
+      TRACKED_SET_KEYS,
+      NO_OWNERSHIP,
+    )
+    expect(resolution.rows).toEqual([])
+    expect(resolution.unresolved).toEqual([{ role: 'deck', name: 'Promo Only', subtitle: undefined, count: 1, reason: 'unknown-set' }])
+  })
+
+  it('resolves a unique name-only match', () => {
+    const resolution = resolveDeckList(
+      { format: 'melee', entries: [{ role: 'deck', name: 'Coronet', subtitle: 'Stately Vessel', count: 2 }], malformed: [] },
+      CATALOG,
+      PARSED_SETS,
+      TRACKED_SET_KEYS,
+      NO_OWNERSHIP,
+    )
+    expect(resolution.rows[0].setKey).toBe('SEC')
+    expect(resolution.rows[0].ambiguous).toBe(false)
+  })
+
+  it('disambiguates a name matching multiple sets by preferring a set the user already owns', () => {
+    const owned = (setKey: SetKey, baseNumber: number) => (setKey === 'JTL' && baseNumber === 999 ? 1 : 0)
+    const resolution = resolveDeckList(
+      { format: 'melee', entries: [{ role: 'deck', name: 'Vanquish', count: 3 }], malformed: [] },
+      CATALOG,
+      PARSED_SETS,
+      TRACKED_SET_KEYS,
+      owned,
+    )
+    expect(resolution.rows[0].setKey).toBe('JTL')
+    expect(resolution.rows[0].ambiguous).toBe(true)
+    expect(resolution.rows[0].ambiguousOtherSets).toEqual(['ASH'])
+  })
+
+  it('disambiguates a name matching multiple sets by manifest order when nothing is owned', () => {
+    const resolution = resolveDeckList(
+      { format: 'melee', entries: [{ role: 'deck', name: 'Vanquish', count: 3 }], malformed: [] },
+      CATALOG,
+      PARSED_SETS,
+      TRACKED_SET_KEYS, // ASH before JTL
+      NO_OWNERSHIP,
+    )
+    expect(resolution.rows[0].setKey).toBe('ASH')
+    expect(resolution.rows[0].ambiguous).toBe(true)
+  })
+
+  it('marks a name with no match anywhere as unresolved', () => {
+    const resolution = resolveDeckList(
+      { format: 'melee', entries: [{ role: 'deck', name: 'Nonexistent Card', count: 1 }], malformed: [] },
+      CATALOG,
+      PARSED_SETS,
+      TRACKED_SET_KEYS,
+      NO_OWNERSHIP,
+    )
+    expect(resolution.rows).toEqual([])
+    expect(resolution.unresolved).toEqual([{ role: 'deck', name: 'Nonexistent Card', subtitle: undefined, count: 1, reason: 'no-name-match' }])
+  })
+
+  it('marks an exact identity referencing an unknown printing as unresolved', () => {
+    const resolution = resolveDeckList(
+      { format: 'json', entries: [{ role: 'deck', name: 'ASH_9999', count: 1, exact: { setKey: 'ASH', printingNumber: 9999 } }], malformed: [] },
+      CATALOG,
+      PARSED_SETS,
+      TRACKED_SET_KEYS,
+      NO_OWNERSHIP,
+    )
+    expect(resolution.rows).toEqual([])
+    expect(resolution.unresolved[0].reason).toBe('unknown-set')
+  })
+
+  it('reclassifies leaderOrBase entries using the resolved card Type', () => {
+    const resolution = resolveDeckList(
+      {
+        format: 'picklist',
+        entries: [
+          { role: 'leaderOrBase', name: 'City in the Clouds', count: 1, alternates: [{ setKey: 'JTL', printingNumber: 19 }] },
+          { role: 'leaderOrBase', name: 'Bo-Katan Kryze', subtitle: 'Reclaiming Mandalore', count: 1, alternates: [{ setKey: 'ASH', printingNumber: 10 }] },
+        ],
+        malformed: [],
+      },
+      CATALOG,
+      PARSED_SETS,
+      TRACKED_SET_KEYS,
+      NO_OWNERSHIP,
+    )
+    const base = resolution.rows.find(r => r.baseNumber === 19)
+    const leader = resolution.rows.find(r => r.baseNumber === 10)
+    expect(base?.role).toBe('base')
+    expect(leader?.role).toBe('leader')
+  })
+
+  it('falls back to first-is-leader/second-is-base ordering when Type is unavailable', () => {
+    const resolution = resolveDeckList(
+      {
+        format: 'picklist',
+        entries: [
+          { role: 'leaderOrBase', name: 'Mystery Card A', count: 1, alternates: [{ setKey: 'ASH', printingNumber: 500 }] },
+          { role: 'leaderOrBase', name: 'Mystery Card B', count: 1, alternates: [{ setKey: 'JTL', printingNumber: 501 }] },
+        ],
+        malformed: [],
+      },
+      CATALOG,
+      PARSED_SETS,
+      TRACKED_SET_KEYS,
+      NO_OWNERSHIP,
+    )
+    const first = resolution.rows.find(r => r.baseNumber === 500)
+    const second = resolution.rows.find(r => r.baseNumber === 501)
+    expect(first?.role).toBe('leader')
+    expect(second?.role).toBe('base')
+  })
+
+  it('surfaces malformed parser lines in the unresolved list', () => {
+    const resolution = resolveDeckList(
+      { format: 'generic', entries: [], malformed: ['garbled line'] },
+      CATALOG,
+      PARSED_SETS,
+      TRACKED_SET_KEYS,
+      NO_OWNERSHIP,
+    )
+    expect(resolution.unresolved).toEqual([{ role: 'deck', name: 'garbled line', count: 0, reason: 'malformed' }])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// computeDeckRows / summarizeDeck
+// ---------------------------------------------------------------------------
+
+describe('computeDeckRows and summarizeDeck', () => {
+  const baseRows = [
+    { role: 'leader' as const, count: 1, setKey: 'ASH', baseNumber: 10, name: 'Bo-Katan Kryze', subtitle: 'Reclaiming Mandalore', type: 'Leader', price: 5, ambiguous: false },
+    { role: 'base' as const, count: 1, setKey: 'JTL', baseNumber: 19, name: 'City in the Clouds', type: 'Base', price: 4, ambiguous: false },
+    { role: 'deck' as const, count: 3, setKey: 'ASH', baseNumber: 140, name: 'Stronger Together', type: 'Unit', price: 2, ambiguous: false },
+    { role: 'sideboard' as const, count: 2, setKey: 'SEC', baseNumber: 47, name: 'Coronet', subtitle: 'Stately Vessel', type: 'Unit', price: 2, ambiguous: false },
+  ]
+
+  it('computes have/needed/cost per row', () => {
+    const owned = (setKey: SetKey, baseNumber: number) => (setKey === 'ASH' && baseNumber === 140 ? 1 : 0)
+    const computed = computeDeckRows(baseRows, owned)
+    const stronger = computed.find(r => r.baseNumber === 140)!
+    expect(stronger.have).toBe(1)
+    expect(stronger.needed).toBe(2)
+    expect(stronger.rowCost).toBe(4)
+  })
+
+  it('floors needed at zero when the user owns enough', () => {
+    const owned = () => 10
+    const computed = computeDeckRows(baseRows, owned)
+    expect(computed.every(r => r.needed === 0)).toBe(true)
+  })
+
+  it('excludes sideboard from totals by default', () => {
+    const computed = computeDeckRows(baseRows, NO_OWNERSHIP)
+    const summary = summarizeDeck(computed, false)
+    // leader(1) + base(1) + deck(3) = 5, sideboard(2) excluded
+    expect(summary.totalNeededCards).toBe(5)
+  })
+
+  it('includes sideboard in totals when toggled on', () => {
+    const computed = computeDeckRows(baseRows, NO_OWNERSHIP)
+    const summary = summarizeDeck(computed, true)
+    expect(summary.totalNeededCards).toBe(7)
+  })
+
+  it('reports leaderOwned/baseOwned based on ownership, and null when absent', () => {
+    const owned = (setKey: SetKey, baseNumber: number) => (setKey === 'ASH' && baseNumber === 10 ? 1 : 0)
+    const computed = computeDeckRows(baseRows, owned)
+    const summary = summarizeDeck(computed, false)
+    expect(summary.leaderOwned).toBe(true)
+    expect(summary.baseOwned).toBe(false)
+
+    const noLeaderBase = computeDeckRows(baseRows.filter(r => r.role === 'deck'), NO_OWNERSHIP)
+    const summaryNoLeaderBase = summarizeDeck(noLeaderBase, false)
+    expect(summaryNoLeaderBase.leaderOwned).toBeNull()
+    expect(summaryNoLeaderBase.baseOwned).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// formatMissingLine
+// ---------------------------------------------------------------------------
+
+describe('formatMissingLine', () => {
+  it('formats with a subtitle', () => {
+    expect(formatMissingLine('Bo-Katan Kryze', 'Reclaiming Mandalore', 'ASH', 2)).toBe(
+      '2 Bo-Katan Kryze - Reclaiming Mandalore [ASH]',
+    )
+  })
+
+  it('formats without a subtitle', () => {
+    expect(formatMissingLine('Stronger Together', undefined, 'ASH', 3)).toBe('3 Stronger Together [ASH]')
+  })
+})

--- a/src/core/decklist.ts
+++ b/src/core/decklist.ts
@@ -1,0 +1,594 @@
+import type { Card, SetKey } from './types'
+import type { CanonicalCatalog } from './inventory'
+import { normalize } from './search'
+
+export type DeckRole = 'leader' | 'base' | 'deck' | 'sideboard'
+/** Picklist format doesn't label its first two entries; the resolver splits this into leader/base. */
+type InternalRole = DeckRole | 'leaderOrBase'
+
+export type DeckEntryCandidate = { setKey: SetKey; printingNumber: number }
+
+export type RawDeckEntry = {
+  role: InternalRole
+  name: string
+  subtitle?: string
+  count: number
+  /** Format A: exact identity. */
+  exact?: DeckEntryCandidate
+  /** Format C: acceptable (set, printing#) alternates, in source order. */
+  alternates?: DeckEntryCandidate[]
+  /** Generic fallback: an explicit (SET) hint, used only as a disambiguation tiebreaker. */
+  setHint?: SetKey
+}
+
+export type DeckFormat = 'json' | 'melee' | 'picklist' | 'generic'
+
+export type ParsedDeckList = {
+  format: DeckFormat
+  deckName?: string
+  entries: RawDeckEntry[]
+  /** Lines/entries that couldn't be parsed at all. */
+  malformed: string[]
+}
+
+export type ResolvedDeckRow = {
+  role: DeckRole
+  count: number
+  setKey: SetKey
+  baseNumber: number
+  name: string
+  subtitle?: string
+  type?: string
+  price: number
+  /** True if this row's set was guessed because the same name matched more than one tracked set. */
+  ambiguous: boolean
+  ambiguousOtherSets?: SetKey[]
+}
+
+export type UnresolvedDeckEntry = {
+  role: DeckRole
+  name: string
+  subtitle?: string
+  count: number
+  reason: 'unknown-set' | 'no-name-match' | 'malformed'
+}
+
+export type DeckResolution = {
+  deckName?: string
+  format: DeckFormat
+  rows: ResolvedDeckRow[]
+  unresolved: UnresolvedDeckEntry[]
+}
+
+export type DeckLookupSet = { byNumber: Map<number, Card>; baseCards: Card[] }
+
+export type DeckRowWithNeed = ResolvedDeckRow & { have: number; needed: number; rowCost: number }
+
+export type DeckSummary = {
+  totalNeededCards: number
+  totalCost: number
+  /** null when the decklist had no leader/base entry at all. */
+  leaderOwned: boolean | null
+  baseOwned: boolean | null
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+function normalizeRoleForDisplay(role: InternalRole): DeckRole {
+  return role === 'leaderOrBase' ? 'leader' : role
+}
+
+// ---------------------------------------------------------------------------
+// Format detection
+// ---------------------------------------------------------------------------
+
+export function detectDeckFormat(text: string): DeckFormat {
+  const trimmed = text.trim()
+  if (!trimmed) return 'generic'
+
+  if (trimmed.startsWith('{')) {
+    try {
+      const payload: unknown = JSON.parse(trimmed)
+      if (
+        isRecord(payload) &&
+        (Array.isArray(payload.deck) || isRecord(payload.leader) || isRecord(payload.base))
+      ) {
+        return 'json'
+      }
+    } catch {
+      // not JSON after all — fall through to text-format detection
+    }
+  }
+
+  if (/^Picklist:/m.test(trimmed)) return 'picklist'
+  if (/^(Leader|Base|MainDeck|Sideboard)\s*$/m.test(trimmed)) return 'melee'
+  return 'generic'
+}
+
+// ---------------------------------------------------------------------------
+// Format A — JSON
+// ---------------------------------------------------------------------------
+
+function parseCardId(id: unknown): DeckEntryCandidate | null {
+  if (typeof id !== 'string') return null
+  const idx = id.lastIndexOf('_')
+  if (idx <= 0 || idx === id.length - 1) return null
+  const setKey = id.slice(0, idx).trim().toUpperCase()
+  const printingNumber = Number(id.slice(idx + 1))
+  if (!setKey || !Number.isInteger(printingNumber) || printingNumber <= 0) return null
+  return { setKey, printingNumber }
+}
+
+export function parseDeckJson(text: string): ParsedDeckList {
+  const payload: unknown = JSON.parse(text)
+  if (!isRecord(payload)) throw new Error('Invalid decklist JSON payload.')
+
+  const entries: RawDeckEntry[] = []
+  const malformed: string[] = []
+
+  function pushRef(role: InternalRole, ref: unknown, label: string) {
+    if (ref === undefined) return
+    const record = isRecord(ref) ? ref : null
+    const count = record ? Number(record.count) : NaN
+    const candidate = record ? parseCardId(record.id) : null
+    if (!record || !candidate || !Number.isFinite(count) || count <= 0) {
+      malformed.push(`${label}: ${JSON.stringify(ref)}`)
+      return
+    }
+    entries.push({
+      role,
+      name: typeof record.id === 'string' ? record.id : label,
+      count,
+      exact: candidate,
+    })
+  }
+
+  pushRef('leader', payload.leader, 'leader')
+  pushRef('base', payload.base, 'base')
+  if (Array.isArray(payload.deck)) {
+    payload.deck.forEach((item, i) => pushRef('deck', item, `deck[${i}]`))
+  }
+  if (Array.isArray(payload.sideboard)) {
+    payload.sideboard.forEach((item, i) => pushRef('sideboard', item, `sideboard[${i}]`))
+  }
+
+  const deckName =
+    isRecord(payload.metadata) && typeof payload.metadata.name === 'string'
+      ? payload.metadata.name
+      : undefined
+
+  return { format: 'json', deckName, entries, malformed }
+}
+
+// ---------------------------------------------------------------------------
+// Format B — Melee text
+// ---------------------------------------------------------------------------
+
+const MELEE_HEADERS: Record<string, DeckRole> = {
+  Leader: 'leader',
+  Base: 'base',
+  MainDeck: 'deck',
+  Sideboard: 'sideboard',
+}
+
+const MELEE_CARD_LINE = /^(\d+)\s*\|\s*([^|]+?)\s*(?:\|\s*(.+))?$/
+
+export function parseDeckMelee(text: string): ParsedDeckList {
+  const lines = text.split(/\r\n|\r|\n/)
+  const entries: RawDeckEntry[] = []
+  const malformed: string[] = []
+  let currentRole: DeckRole | null = null
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim()
+    if (!line) continue
+    if (line in MELEE_HEADERS) {
+      currentRole = MELEE_HEADERS[line]
+      continue
+    }
+    if (!currentRole) continue
+
+    const match = MELEE_CARD_LINE.exec(line)
+    if (!match) {
+      malformed.push(line)
+      continue
+    }
+    const count = Number(match[1])
+    const name = match[2].trim()
+    const subtitle = match[3]?.trim() || undefined
+    if (!Number.isFinite(count) || count <= 0 || !name) {
+      malformed.push(line)
+      continue
+    }
+    entries.push({ role: currentRole, name, subtitle, count })
+  }
+
+  return { format: 'melee', entries, malformed }
+}
+
+// ---------------------------------------------------------------------------
+// Format C — Picklist text
+// ---------------------------------------------------------------------------
+
+const BRACKET_LINE = /^((?:\[\s?\]\s*)+)(.+)$/
+const ALT_ENTRY = /^([A-Za-z0-9]+)\s+(\d+)$/
+
+function splitSections(lines: string[]): string[][] {
+  const sections: string[][] = [[]]
+  for (const line of lines) {
+    if (line.trim() === '-----') {
+      sections.push([])
+    } else {
+      sections[sections.length - 1].push(line)
+    }
+  }
+  return sections
+}
+
+function parseAlternatesLine(line: string): DeckEntryCandidate[] | null {
+  const parts = line.split(',').map(p => p.trim()).filter(Boolean)
+  if (!parts.length) return null
+  const candidates: DeckEntryCandidate[] = []
+  for (const part of parts) {
+    const match = ALT_ENTRY.exec(part)
+    if (!match) return null
+    candidates.push({ setKey: match[1].toUpperCase(), printingNumber: Number(match[2]) })
+  }
+  return candidates
+}
+
+function roleForSection(sectionIndex: number, totalSections: number): 'leaderOrBase' | 'deck' | 'sideboard' {
+  if (sectionIndex === 0) return 'leaderOrBase'
+  if (totalSections >= 3 && sectionIndex === totalSections - 1) return 'sideboard'
+  return 'deck'
+}
+
+export function parseDeckPicklist(text: string): ParsedDeckList {
+  const allLines = text.split(/\r\n|\r|\n/)
+  const malformed: string[] = []
+  let deckName: string | undefined
+  let bodyLines = allLines
+
+  const firstContentIdx = allLines.findIndex(l => l.trim().length > 0)
+  if (firstContentIdx >= 0) {
+    const headerMatch = /^Picklist:\s*(.*)$/i.exec(allLines[firstContentIdx].trim())
+    if (headerMatch) {
+      deckName = headerMatch[1].trim() || undefined
+      bodyLines = allLines.slice(firstContentIdx + 1)
+    } else {
+      malformed.push('missing "Picklist:" header')
+    }
+  }
+
+  const sections = splitSections(bodyLines)
+  const entries: RawDeckEntry[] = []
+
+  sections.forEach((sectionLines, sectionIndex) => {
+    const role = roleForSection(sectionIndex, sections.length)
+
+    for (let i = 0; i < sectionLines.length; i++) {
+      const line = sectionLines[i].trim()
+      if (!line) continue
+      if (/^Needed tokens:/i.test(line)) continue
+
+      const bracketMatch = BRACKET_LINE.exec(line)
+      if (!bracketMatch) {
+        malformed.push(line)
+        continue
+      }
+      const count = (bracketMatch[1].match(/\[\s?\]/g) ?? []).length
+      const rest = bracketMatch[2].trim()
+      const parts = rest.split('|').map(s => s.trim())
+      const namePart = parts[0]
+      const subtitlePart = parts[1] || undefined
+
+      if (!count || !namePart) {
+        malformed.push(line)
+        continue
+      }
+
+      let j = i + 1
+      while (j < sectionLines.length && sectionLines[j].trim() === '') j++
+      const altLine = j < sectionLines.length ? sectionLines[j].trim() : ''
+      const alternates = altLine ? parseAlternatesLine(altLine) : null
+
+      if (!alternates) {
+        malformed.push(line)
+        continue
+      }
+
+      entries.push({ role, name: namePart, subtitle: subtitlePart, count, alternates })
+      i = j
+    }
+  })
+
+  return { format: 'picklist', deckName, entries, malformed }
+}
+
+// ---------------------------------------------------------------------------
+// Generic fallback — one card per line, mirrors the app's own missing-card export
+// ---------------------------------------------------------------------------
+
+const TRAILING_SET = /[([]([A-Za-z0-9]{2,6})[)\]]\s*$/
+const QTY_NAME = /^(\d+)\s*x?\s+(.+)$/i
+const NAME_SUBTITLE = /^(.*?)\s[-–]\s(.*)$/
+
+export function parseDeckGeneric(text: string): ParsedDeckList {
+  const lines = text.split(/\r\n|\r|\n/)
+  const entries: RawDeckEntry[] = []
+  const malformed: string[] = []
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim()
+    if (!line) continue
+
+    let working = line
+    let setHint: SetKey | undefined
+    const setMatch = TRAILING_SET.exec(working)
+    if (setMatch) {
+      setHint = setMatch[1].toUpperCase()
+      working = working.slice(0, setMatch.index).trim()
+    }
+
+    const qtyMatch = QTY_NAME.exec(working)
+    if (!qtyMatch) {
+      malformed.push(line)
+      continue
+    }
+    const count = Number(qtyMatch[1])
+    const rest = qtyMatch[2].trim()
+    if (!Number.isFinite(count) || count <= 0 || !rest) {
+      malformed.push(line)
+      continue
+    }
+
+    let name = rest
+    let subtitle: string | undefined
+    const dashMatch = NAME_SUBTITLE.exec(rest)
+    if (dashMatch && dashMatch[1].trim()) {
+      name = dashMatch[1].trim()
+      subtitle = dashMatch[2].trim()
+    }
+
+    entries.push({ role: 'deck', name, subtitle, count, setHint })
+  }
+
+  return { format: 'generic', entries, malformed }
+}
+
+// ---------------------------------------------------------------------------
+// Top-level dispatcher
+// ---------------------------------------------------------------------------
+
+export function parseDeckList(text: string): ParsedDeckList {
+  const format = detectDeckFormat(text)
+  if (format === 'json') {
+    try {
+      return parseDeckJson(text)
+    } catch {
+      return parseDeckGeneric(text)
+    }
+  }
+  if (format === 'melee') return parseDeckMelee(text)
+  if (format === 'picklist') return parseDeckPicklist(text)
+  return parseDeckGeneric(text)
+}
+
+// ---------------------------------------------------------------------------
+// Resolver — RawDeckEntry[] + catalog/inventory -> DeckResolution
+// ---------------------------------------------------------------------------
+
+function cardMatchKey(name: string, subtitle?: string): string {
+  return `${normalize(name)}|${normalize(subtitle ?? '')}`
+}
+
+type ResolvedIdentity = { setKey: SetKey; baseNumber: number; card: Card }
+
+function resolveExact(
+  candidate: DeckEntryCandidate,
+  catalog: CanonicalCatalog,
+  parsedSets: Map<SetKey, DeckLookupSet>,
+): ResolvedIdentity | null {
+  const ref = catalog.get(`${candidate.setKey}:${candidate.printingNumber}`)
+  if (!ref) return null
+  const card = parsedSets.get(ref.setKey)?.byNumber.get(ref.baseNumber)
+  if (!card) return null
+  return { setKey: ref.setKey, baseNumber: ref.baseNumber, card }
+}
+
+export function resolveDeckList(
+  parsed: ParsedDeckList,
+  catalog: CanonicalCatalog,
+  parsedSets: Map<SetKey, DeckLookupSet>,
+  trackedSetKeys: SetKey[],
+  ownedByBase: (setKey: SetKey, baseNumber: number) => number,
+): DeckResolution {
+  const nameIndex = new Map<string, Array<{ setKey: SetKey; card: Card }>>()
+  for (const setKeyIter of trackedSetKeys) {
+    const set = parsedSets.get(setKeyIter)
+    if (!set) continue
+    for (const card of set.baseCards) {
+      const key = cardMatchKey(card.Name, card.Subtitle)
+      const arr = nameIndex.get(key) ?? []
+      arr.push({ setKey: setKeyIter, card })
+      nameIndex.set(key, arr)
+    }
+  }
+
+  const rowMap = new Map<string, ResolvedDeckRow>()
+  const unresolved: UnresolvedDeckEntry[] = []
+  let leaderBaseOrdinal = 0
+
+  for (const entry of parsed.entries) {
+    if (entry.count <= 0) {
+      unresolved.push({
+        role: normalizeRoleForDisplay(entry.role),
+        name: entry.name,
+        subtitle: entry.subtitle,
+        count: entry.count,
+        reason: 'malformed',
+      })
+      continue
+    }
+
+    let resolved: ResolvedIdentity | null = null
+    let ambiguous = false
+    let ambiguousOtherSets: SetKey[] | undefined
+
+    if (entry.exact) {
+      resolved = resolveExact(entry.exact, catalog, parsedSets)
+      if (!resolved) {
+        unresolved.push({
+          role: normalizeRoleForDisplay(entry.role),
+          name: entry.name,
+          subtitle: entry.subtitle,
+          count: entry.count,
+          reason: 'unknown-set',
+        })
+        continue
+      }
+    } else if (entry.alternates) {
+      for (const alt of entry.alternates) {
+        if (!trackedSetKeys.includes(alt.setKey)) continue
+        const candidate = resolveExact(alt, catalog, parsedSets)
+        if (candidate) {
+          resolved = candidate
+          break
+        }
+      }
+      if (!resolved) {
+        unresolved.push({
+          role: normalizeRoleForDisplay(entry.role),
+          name: entry.name,
+          subtitle: entry.subtitle,
+          count: entry.count,
+          reason: 'unknown-set',
+        })
+        continue
+      }
+    } else {
+      const key = cardMatchKey(entry.name, entry.subtitle)
+      const candidates = nameIndex.get(key) ?? []
+      if (candidates.length === 0) {
+        unresolved.push({
+          role: normalizeRoleForDisplay(entry.role),
+          name: entry.name,
+          subtitle: entry.subtitle,
+          count: entry.count,
+          reason: 'no-name-match',
+        })
+        continue
+      }
+      if (candidates.length === 1) {
+        resolved = {
+          setKey: candidates[0].setKey,
+          baseNumber: candidates[0].card.Number,
+          card: candidates[0].card,
+        }
+      } else {
+        ambiguous = true
+        let chosen = entry.setHint ? candidates.find(c => c.setKey === entry.setHint) : undefined
+        if (!chosen) {
+          const owned = candidates.filter(c => ownedByBase(c.setKey, c.card.Number) > 0)
+          if (owned.length === 1) chosen = owned[0]
+        }
+        if (!chosen) {
+          chosen = [...candidates].sort(
+            (a, b) => trackedSetKeys.indexOf(a.setKey) - trackedSetKeys.indexOf(b.setKey),
+          )[0]
+        }
+        resolved = { setKey: chosen.setKey, baseNumber: chosen.card.Number, card: chosen.card }
+        ambiguousOtherSets = candidates.filter(c => c.setKey !== chosen!.setKey).map(c => c.setKey)
+      }
+    }
+
+    let role: DeckRole
+    if (entry.role === 'leaderOrBase') {
+      const cardType = (resolved.card.Type ?? '').trim().toLowerCase()
+      if (cardType === 'base') role = 'base'
+      else if (cardType === 'leader') role = 'leader'
+      else role = leaderBaseOrdinal === 0 ? 'leader' : 'base'
+      leaderBaseOrdinal++
+    } else {
+      role = entry.role
+    }
+
+    const rowKey = `${role}:${resolved.setKey}:${resolved.baseNumber}`
+    const existing = rowMap.get(rowKey)
+    if (existing) {
+      existing.count += entry.count
+    } else {
+      rowMap.set(rowKey, {
+        role,
+        count: entry.count,
+        setKey: resolved.setKey,
+        baseNumber: resolved.baseNumber,
+        name: resolved.card.Name,
+        subtitle: resolved.card.Subtitle,
+        type: resolved.card.Type,
+        price: Number(resolved.card.MarketPrice ?? 0),
+        ambiguous,
+        ambiguousOtherSets,
+      })
+    }
+  }
+
+  for (const line of parsed.malformed) {
+    unresolved.push({ role: 'deck', name: line, count: 0, reason: 'malformed' })
+  }
+
+  return {
+    deckName: parsed.deckName,
+    format: parsed.format,
+    rows: [...rowMap.values()],
+    unresolved,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Cost computation
+// ---------------------------------------------------------------------------
+
+export function computeDeckRows(
+  rows: ResolvedDeckRow[],
+  ownedByBase: (setKey: SetKey, baseNumber: number) => number,
+): DeckRowWithNeed[] {
+  return rows.map(row => {
+    const have = ownedByBase(row.setKey, row.baseNumber)
+    const needed = Math.max(0, row.count - have)
+    return { ...row, have, needed, rowCost: needed * row.price }
+  })
+}
+
+export function summarizeDeck(rows: DeckRowWithNeed[], includeSideboard: boolean): DeckSummary {
+  let totalNeededCards = 0
+  let totalCost = 0
+  let leaderOwned: boolean | null = null
+  let baseOwned: boolean | null = null
+
+  for (const row of rows) {
+    if (row.role === 'sideboard' && !includeSideboard) continue
+    totalNeededCards += row.needed
+    totalCost += row.rowCost
+    if (row.role === 'leader') leaderOwned = row.have >= row.count
+    if (row.role === 'base') baseOwned = row.have >= row.count
+  }
+
+  return { totalNeededCards, totalCost, leaderOwned, baseOwned }
+}
+
+// ---------------------------------------------------------------------------
+// Shared clipboard-export line format (mirrors App.tsx's existing missing-card export)
+// ---------------------------------------------------------------------------
+
+export function formatMissingLine(
+  name: string,
+  subtitle: string | undefined,
+  setKey: SetKey,
+  qty: number,
+): string {
+  const namePart = subtitle ? `${name} - ${subtitle}` : name
+  return `${qty} ${namePart} [${setKey}]`
+}

--- a/src/core/search.ts
+++ b/src/core/search.ts
@@ -20,7 +20,7 @@ export type SearchSuggestion = {
 
 type RankedSuggestion = SearchSuggestion & { score: number }
 
-function normalize(value: string): string {
+export function normalize(value: string): string {
   return value.toLowerCase().replace(/[^a-z0-9]/g, '')
 }
 


### PR DESCRIPTION
## Summary
- Paste a decklist and see which cards you own vs. are missing, plus the $ cost to complete the deck
- Supports three real-world decklist export formats — JSON (swudb-style, exact printing IDs), "Melee" text (Leader/Base/MainDeck/Sideboard sections), and "Picklist" text (checkbox-style with alternate printings) — plus a generic `qty Name (SET)` fallback, all auto-detected
- Resolves cards across every tracked set (not just the currently displayed one), reusing the app's existing canonical catalog and cross-set card cache
- Ambiguous name-only matches (same name in multiple sets) are flagged in the UI rather than silently guessed; unresolvable lines are listed separately so the user can fix and re-check
- Sideboard cards are shown separately with a toggle for whether they count toward totals/export (default off)
- "Copy missing to clipboard" reuses the exact TCGPlayer-ready line format from the existing whole-set missing-cards export (refactored into a shared `formatMissingLine` helper)

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npx vitest run --pool=threads` — 117/117 tests pass (37 new in `decklist.test.ts` covering all formats + resolver ambiguity/unresolved cases + cost computation)
- [x] Manually exercised in a running dev server: opened the Deck Check modal, pasted all three real-world sample formats plus a generic fallback list, toggled the sideboard checkbox, and used "Copy missing to clipboard"

🤖 Generated with [Claude Code](https://claude.com/claude-code)