### PR TITLE
Track precon ownership and saved decks separately from binders

### DIFF
--- a/public/precons/ASH-Luke.json
+++ b/public/precons/ASH-Luke.json
@@ -1,0 +1,130 @@
+{
+  "leader": {
+    "setKey": "ASH",
+    "baseNumber": 5,
+    "count": 1
+  },
+  "base": {
+    "setKey": "ASH",
+    "baseNumber": 24,
+    "count": 1
+  },
+  "mainDeck": [
+    {
+      "setKey": "ASH",
+      "baseNumber": 31,
+      "count": 1
+    },
+    {
+      "setKey": "ASH",
+      "baseNumber": 60,
+      "count": 1
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 47,
+      "count": 1
+    },
+    {
+      "setKey": "ASH",
+      "baseNumber": 72,
+      "count": 2
+    },
+    {
+      "setKey": "ASH",
+      "baseNumber": 166,
+      "count": 3
+    },
+    {
+      "setKey": "ASH",
+      "baseNumber": 59,
+      "count": 3
+    },
+    {
+      "setKey": "ASH",
+      "baseNumber": 156,
+      "count": 2
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 254,
+      "count": 3
+    },
+    {
+      "setKey": "ASH",
+      "baseNumber": 158,
+      "count": 3
+    },
+    {
+      "setKey": "ASH",
+      "baseNumber": 61,
+      "count": 3
+    },
+    {
+      "setKey": "ASH",
+      "baseNumber": 255,
+      "count": 3
+    },
+    {
+      "setKey": "ASH",
+      "baseNumber": 153,
+      "count": 1
+    },
+    {
+      "setKey": "ASH",
+      "baseNumber": 71,
+      "count": 3
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 62,
+      "count": 2
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 51,
+      "count": 3
+    },
+    {
+      "setKey": "ASH",
+      "baseNumber": 78,
+      "count": 2
+    },
+    {
+      "setKey": "ASH",
+      "baseNumber": 159,
+      "count": 2
+    },
+    {
+      "setKey": "ASH",
+      "baseNumber": 65,
+      "count": 2
+    },
+    {
+      "setKey": "ASH",
+      "baseNumber": 163,
+      "count": 1
+    },
+    {
+      "setKey": "ASH",
+      "baseNumber": 184,
+      "count": 2
+    },
+    {
+      "setKey": "ASH",
+      "baseNumber": 162,
+      "count": 2
+    },
+    {
+      "setKey": "ASH",
+      "baseNumber": 66,
+      "count": 3
+    },
+    {
+      "setKey": "ASH",
+      "baseNumber": 88,
+      "count": 2
+    }
+  ],
+  "sideboard": []
+}

--- a/public/precons/ASH-Palpatine.json
+++ b/public/precons/ASH-Palpatine.json
@@ -1,0 +1,130 @@
+{
+  "leader": {
+    "setKey": "ASH",
+    "baseNumber": 15,
+    "count": 1
+  },
+  "base": {
+    "setKey": "ASH",
+    "baseNumber": 21,
+    "count": 1
+  },
+  "mainDeck": [
+    {
+      "setKey": "ASH",
+      "baseNumber": 118,
+      "count": 1
+    },
+    {
+      "setKey": "ASH",
+      "baseNumber": 36,
+      "count": 1
+    },
+    {
+      "setKey": "ASH",
+      "baseNumber": 101,
+      "count": 1
+    },
+    {
+      "setKey": "ASH",
+      "baseNumber": 116,
+      "count": 3
+    },
+    {
+      "setKey": "ASH",
+      "baseNumber": 189,
+      "count": 3
+    },
+    {
+      "setKey": "ASH",
+      "baseNumber": 94,
+      "count": 3
+    },
+    {
+      "setKey": "ASH",
+      "baseNumber": 218,
+      "count": 2
+    },
+    {
+      "setKey": "ASH",
+      "baseNumber": 96,
+      "count": 3
+    },
+    {
+      "setKey": "ASH",
+      "baseNumber": 97,
+      "count": 2
+    },
+    {
+      "setKey": "ASH",
+      "baseNumber": 193,
+      "count": 3
+    },
+    {
+      "setKey": "ASH",
+      "baseNumber": 243,
+      "count": 3
+    },
+    {
+      "setKey": "ASH",
+      "baseNumber": 128,
+      "count": 1
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 185,
+      "count": 2
+    },
+    {
+      "setKey": "ASH",
+      "baseNumber": 215,
+      "count": 3
+    },
+    {
+      "setKey": "ASH",
+      "baseNumber": 191,
+      "count": 2
+    },
+    {
+      "setKey": "ASH",
+      "baseNumber": 221,
+      "count": 2
+    },
+    {
+      "setKey": "ASH",
+      "baseNumber": 99,
+      "count": 2
+    },
+    {
+      "setKey": "ASH",
+      "baseNumber": 197,
+      "count": 3
+    },
+    {
+      "setKey": "ASH",
+      "baseNumber": 103,
+      "count": 2
+    },
+    {
+      "setKey": "ASH",
+      "baseNumber": 139,
+      "count": 2
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 91,
+      "count": 1
+    },
+    {
+      "setKey": "ASH",
+      "baseNumber": 198,
+      "count": 2
+    },
+    {
+      "setKey": "ASH",
+      "baseNumber": 199,
+      "count": 3
+    }
+  ],
+  "sideboard": []
+}

--- a/public/precons/IBH-Leia.json
+++ b/public/precons/IBH-Leia.json
@@ -1,0 +1,130 @@
+{
+  "leader": {
+    "setKey": "IBH",
+    "baseNumber": 1,
+    "count": 1
+  },
+  "base": {
+    "setKey": "IBH",
+    "baseNumber": 2,
+    "count": 1
+  },
+  "mainDeck": [
+    {
+      "setKey": "IBH",
+      "baseNumber": 3,
+      "count": 2
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 8,
+      "count": 3
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 9,
+      "count": 2
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 10,
+      "count": 2
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 14,
+      "count": 2
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 18,
+      "count": 2
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 21,
+      "count": 2
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 31,
+      "count": 1
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 7,
+      "count": 3
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 12,
+      "count": 3
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 13,
+      "count": 1
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 20,
+      "count": 1
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 4,
+      "count": 3
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 5,
+      "count": 2
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 6,
+      "count": 3
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 11,
+      "count": 2
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 15,
+      "count": 3
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 16,
+      "count": 2
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 19,
+      "count": 2
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 22,
+      "count": 3
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 23,
+      "count": 2
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 37,
+      "count": 3
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 52,
+      "count": 1
+    }
+  ],
+  "sideboard": []
+}

--- a/public/precons/IBH-Vader.json
+++ b/public/precons/IBH-Vader.json
@@ -1,0 +1,135 @@
+{
+  "leader": {
+    "setKey": "IBH",
+    "baseNumber": 53,
+    "count": 1
+  },
+  "base": {
+    "setKey": "IBH",
+    "baseNumber": 54,
+    "count": 1
+  },
+  "mainDeck": [
+    {
+      "setKey": "IBH",
+      "baseNumber": 55,
+      "count": 3
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 56,
+      "count": 2
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 57,
+      "count": 3
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 58,
+      "count": 3
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 60,
+      "count": 2
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 61,
+      "count": 2
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 62,
+      "count": 2
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 63,
+      "count": 3
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 64,
+      "count": 2
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 66,
+      "count": 2
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 68,
+      "count": 2
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 69,
+      "count": 2
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 70,
+      "count": 3
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 59,
+      "count": 2
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 72,
+      "count": 1
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 74,
+      "count": 2
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 75,
+      "count": 3
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 76,
+      "count": 1
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 78,
+      "count": 3
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 79,
+      "count": 2
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 82,
+      "count": 2
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 95,
+      "count": 1
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 99,
+      "count": 1
+    },
+    {
+      "setKey": "IBH",
+      "baseNumber": 104,
+      "count": 1
+    }
+  ],
+  "sideboard": []
+}

--- a/public/precons/JTL-BobaFett.json
+++ b/public/precons/JTL-BobaFett.json
@@ -1,0 +1,130 @@
+{
+  "leader": {
+    "setKey": "JTL",
+    "baseNumber": 9,
+    "count": 1
+  },
+  "base": {
+    "setKey": "SHD",
+    "baseNumber": 26,
+    "count": 1
+  },
+  "mainDeck": [
+    {
+      "setKey": "JTL",
+      "baseNumber": 132,
+      "count": 3
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 133,
+      "count": 1
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 139,
+      "count": 2
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 140,
+      "count": 1
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 141,
+      "count": 1
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 144,
+      "count": 3
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 165,
+      "count": 2
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 183,
+      "count": 3
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 185,
+      "count": 3
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 187,
+      "count": 3
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 189,
+      "count": 1
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 230,
+      "count": 1
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 237,
+      "count": 3
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 240,
+      "count": 3
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 178,
+      "count": 3
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 130,
+      "count": 3
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 131,
+      "count": 2
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 132,
+      "count": 2
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 139,
+      "count": 3
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 184,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 186,
+      "count": 3
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 171,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 181,
+      "count": 2
+    }
+  ],
+  "sideboard": []
+}

--- a/public/precons/JTL-HanSolo.json
+++ b/public/precons/JTL-HanSolo.json
@@ -1,0 +1,140 @@
+{
+  "leader": {
+    "setKey": "JTL",
+    "baseNumber": 17,
+    "count": 1
+  },
+  "base": {
+    "setKey": "SOR",
+    "baseNumber": 24,
+    "count": 1
+  },
+  "mainDeck": [
+    {
+      "setKey": "JTL",
+      "baseNumber": 93,
+      "count": 1
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 96,
+      "count": 2
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 97,
+      "count": 2
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 103,
+      "count": 3
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 124,
+      "count": 2
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 196,
+      "count": 3
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 200,
+      "count": 3
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 208,
+      "count": 3
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 209,
+      "count": 1
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 210,
+      "count": 1
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 215,
+      "count": 2
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 217,
+      "count": 1
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 235,
+      "count": 1
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 245,
+      "count": 2
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 249,
+      "count": 3
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 95,
+      "count": 3
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 195,
+      "count": 3
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 97,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 192,
+      "count": 2
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 204,
+      "count": 2
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 217,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 222,
+      "count": 3
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 110,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 114,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 191,
+      "count": 3
+    }
+  ],
+  "sideboard": []
+}

--- a/public/precons/LAW-Jabba.json
+++ b/public/precons/LAW-Jabba.json
@@ -1,0 +1,130 @@
+{
+  "leader": {
+    "setKey": "LAW",
+    "baseNumber": 15,
+    "count": 1
+  },
+  "base": {
+    "setKey": "LAW",
+    "baseNumber": 23,
+    "count": 1
+  },
+  "mainDeck": [
+    {
+      "setKey": "LAW",
+      "baseNumber": 170,
+      "count": 1
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 158,
+      "count": 2
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 168,
+      "count": 3
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 252,
+      "count": 1
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 184,
+      "count": 3
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 134,
+      "count": 1
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 65,
+      "count": 2
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 216,
+      "count": 2
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 211,
+      "count": 3
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 189,
+      "count": 2
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 244,
+      "count": 3
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 231,
+      "count": 3
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 246,
+      "count": 2
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 210,
+      "count": 3
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 214,
+      "count": 1
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 249,
+      "count": 3
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 186,
+      "count": 2
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 215,
+      "count": 1
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 152,
+      "count": 2
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 163,
+      "count": 3
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 136,
+      "count": 2
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 212,
+      "count": 3
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 216,
+      "count": 2
+    }
+  ],
+  "sideboard": []
+}

--- a/public/precons/LAW-Leia.json
+++ b/public/precons/LAW-Leia.json
@@ -1,0 +1,130 @@
+{
+  "leader": {
+    "setKey": "LAW",
+    "baseNumber": 10,
+    "count": 1
+  },
+  "base": {
+    "setKey": "LAW",
+    "baseNumber": 20,
+    "count": 1
+  },
+  "mainDeck": [
+    {
+      "setKey": "LAW",
+      "baseNumber": 38,
+      "count": 3
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 252,
+      "count": 2
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 152,
+      "count": 2
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 167,
+      "count": 3
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 119,
+      "count": 1
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 166,
+      "count": 2
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 147,
+      "count": 3
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 250,
+      "count": 1
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 93,
+      "count": 2
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 145,
+      "count": 3
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 41,
+      "count": 2
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 104,
+      "count": 1
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 108,
+      "count": 3
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 67,
+      "count": 1
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 45,
+      "count": 2
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 37,
+      "count": 3
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 146,
+      "count": 3
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 142,
+      "count": 2
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 35,
+      "count": 2
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 103,
+      "count": 1
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 95,
+      "count": 3
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 105,
+      "count": 2
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 111,
+      "count": 3
+    }
+  ],
+  "sideboard": []
+}

--- a/public/precons/LOF-Maul.json
+++ b/public/precons/LOF-Maul.json
@@ -1,0 +1,130 @@
+{
+  "leader": {
+    "setKey": "LOF",
+    "baseNumber": 9,
+    "count": 1
+  },
+  "base": {
+    "setKey": "LOF",
+    "baseNumber": 21,
+    "count": 1
+  },
+  "mainDeck": [
+    {
+      "setKey": "LOF",
+      "baseNumber": 31,
+      "count": 2
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 35,
+      "count": 3
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 38,
+      "count": 1
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 39,
+      "count": 3
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 41,
+      "count": 3
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 59,
+      "count": 3
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 63,
+      "count": 1
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 67,
+      "count": 2
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 129,
+      "count": 2
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 131,
+      "count": 3
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 136,
+      "count": 2
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 137,
+      "count": 2
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 138,
+      "count": 1
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 139,
+      "count": 2
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 140,
+      "count": 3
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 156,
+      "count": 2
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 160,
+      "count": 2
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 164,
+      "count": 3
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 229,
+      "count": 2
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 231,
+      "count": 3
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 233,
+      "count": 3
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 137,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 138,
+      "count": 1
+    }
+  ],
+  "sideboard": []
+}

--- a/public/precons/LOF-QuiGon.json
+++ b/public/precons/LOF-QuiGon.json
@@ -1,0 +1,130 @@
+{
+  "leader": {
+    "setKey": "LOF",
+    "baseNumber": 16,
+    "count": 1
+  },
+  "base": {
+    "setKey": "LOF",
+    "baseNumber": 23,
+    "count": 1
+  },
+  "mainDeck": [
+    {
+      "setKey": "JTL",
+      "baseNumber": 203,
+      "count": 1
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 96,
+      "count": 3
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 99,
+      "count": 2
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 100,
+      "count": 2
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 104,
+      "count": 1
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 111,
+      "count": 2
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 190,
+      "count": 3
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 193,
+      "count": 3
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 194,
+      "count": 2
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 196,
+      "count": 3
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 197,
+      "count": 3
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 198,
+      "count": 2
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 199,
+      "count": 2
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 201,
+      "count": 3
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 218,
+      "count": 2
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 227,
+      "count": 3
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 242,
+      "count": 3
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 249,
+      "count": 1
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 255,
+      "count": 3
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 96,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 219,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 193,
+      "count": 2
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 217,
+      "count": 2
+    }
+  ],
+  "sideboard": []
+}

--- a/public/precons/SEC-Amidala.json
+++ b/public/precons/SEC-Amidala.json
@@ -1,0 +1,155 @@
+{
+  "leader": {
+    "setKey": "SEC",
+    "baseNumber": 16,
+    "count": 1
+  },
+  "base": {
+    "setKey": "SEC",
+    "baseNumber": 22,
+    "count": 1
+  },
+  "mainDeck": [
+    {
+      "setKey": "JTL",
+      "baseNumber": 111,
+      "count": 1
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 123,
+      "count": 2
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 100,
+      "count": 1
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 192,
+      "count": 2
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 194,
+      "count": 3
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 198,
+      "count": 2
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 93,
+      "count": 1
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 94,
+      "count": 2
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 96,
+      "count": 3
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 98,
+      "count": 3
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 99,
+      "count": 1
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 103,
+      "count": 1
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 106,
+      "count": 1
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 111,
+      "count": 1
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 115,
+      "count": 1
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 116,
+      "count": 2
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 120,
+      "count": 2
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 127,
+      "count": 1
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 129,
+      "count": 2
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 197,
+      "count": 3
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 198,
+      "count": 2
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 199,
+      "count": 2
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 201,
+      "count": 3
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 208,
+      "count": 1
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 226,
+      "count": 3
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 234,
+      "count": 2
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 248,
+      "count": 1
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 256,
+      "count": 1
+    }
+  ],
+  "sideboard": []
+}

--- a/public/precons/SEC-Palpatine.json
+++ b/public/precons/SEC-Palpatine.json
@@ -1,0 +1,145 @@
+{
+  "leader": {
+    "setKey": "SEC",
+    "baseNumber": 1,
+    "count": 1
+  },
+  "base": {
+    "setKey": "SEC",
+    "baseNumber": 22,
+    "count": 1
+  },
+  "mainDeck": [
+    {
+      "setKey": "JTL",
+      "baseNumber": 33,
+      "count": 3
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 43,
+      "count": 1
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 82,
+      "count": 2
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 27,
+      "count": 3
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 31,
+      "count": 1
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 33,
+      "count": 2
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 34,
+      "count": 3
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 36,
+      "count": 3
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 37,
+      "count": 1
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 55,
+      "count": 2
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 70,
+      "count": 2
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 76,
+      "count": 1
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 77,
+      "count": 2
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 79,
+      "count": 3
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 81,
+      "count": 1
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 82,
+      "count": 1
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 83,
+      "count": 3
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 84,
+      "count": 2
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 85,
+      "count": 1
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 87,
+      "count": 1
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 92,
+      "count": 3
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 111,
+      "count": 1
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 123,
+      "count": 2
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 124,
+      "count": 2
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 241,
+      "count": 3
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 245,
+      "count": 1
+    }
+  ],
+  "sideboard": []
+}

--- a/public/precons/SHD-Mando.json
+++ b/public/precons/SHD-Mando.json
@@ -1,0 +1,155 @@
+{
+  "leader": {
+    "setKey": "SHD",
+    "baseNumber": 18,
+    "count": 1
+  },
+  "base": {
+    "setKey": "SOR",
+    "baseNumber": 21,
+    "count": 1
+  },
+  "mainDeck": [
+    {
+      "setKey": "SHD",
+      "baseNumber": 258,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 64,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 43,
+      "count": 3
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 68,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 223,
+      "count": 2
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 47,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 261,
+      "count": 2
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 78,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 73,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 74,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 66,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 220,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 221,
+      "count": 2
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 253,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 247,
+      "count": 2
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 44,
+      "count": 3
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 220,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 69,
+      "count": 2
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 70,
+      "count": 2
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 216,
+      "count": 2
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 245,
+      "count": 3
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 196,
+      "count": 3
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 60,
+      "count": 3
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 41,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 206,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 56,
+      "count": 3
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 40,
+      "count": 2
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 251,
+      "count": 3
+    }
+  ],
+  "sideboard": []
+}

--- a/public/precons/SHD-MoffGideon.json
+++ b/public/precons/SHD-MoffGideon.json
@@ -1,0 +1,150 @@
+{
+  "leader": {
+    "setKey": "SHD",
+    "baseNumber": 7,
+    "count": 1
+  },
+  "base": {
+    "setKey": "SHD",
+    "baseNumber": 19,
+    "count": 1
+  },
+  "mainDeck": [
+    {
+      "setKey": "SHD",
+      "baseNumber": 31,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 93,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 238,
+      "count": 2
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 262,
+      "count": 2
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 130,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 85,
+      "count": 3
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 125,
+      "count": 2
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 113,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 71,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 234,
+      "count": 3
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 120,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 83,
+      "count": 3
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 30,
+      "count": 3
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 124,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 82,
+      "count": 3
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 63,
+      "count": 2
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 89,
+      "count": 2
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 81,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 129,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 28,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 236,
+      "count": 2
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 242,
+      "count": 3
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 84,
+      "count": 3
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 118,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 39,
+      "count": 3
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 128,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 110,
+      "count": 2
+    }
+  ],
+  "sideboard": []
+}

--- a/public/precons/SOR-Luke.json
+++ b/public/precons/SOR-Luke.json
@@ -1,0 +1,160 @@
+{
+  "leader": {
+    "setKey": "SOR",
+    "baseNumber": 5,
+    "count": 1
+  },
+  "base": {
+    "setKey": "SOR",
+    "baseNumber": 29,
+    "count": 1
+  },
+  "mainDeck": [
+    {
+      "setKey": "SOR",
+      "baseNumber": 44,
+      "count": 2
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 45,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 46,
+      "count": 3
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 48,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 49,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 53,
+      "count": 3
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 59,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 63,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 66,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 69,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 74,
+      "count": 2
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 78,
+      "count": 3
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 189,
+      "count": 3
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 194,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 195,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 196,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 198,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 217,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 218,
+      "count": 2
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 220,
+      "count": 2
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 222,
+      "count": 2
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 236,
+      "count": 3
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 237,
+      "count": 3
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 238,
+      "count": 3
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 239,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 240,
+      "count": 3
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 241,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 242,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 244,
+      "count": 1
+    }
+  ],
+  "sideboard": []
+}

--- a/public/precons/SOR-Vader.json
+++ b/public/precons/SOR-Vader.json
@@ -1,0 +1,150 @@
+{
+  "leader": {
+    "setKey": "SOR",
+    "baseNumber": 10,
+    "count": 1
+  },
+  "base": {
+    "setKey": "SOR",
+    "baseNumber": 23,
+    "count": 1
+  },
+  "mainDeck": [
+    {
+      "setKey": "SOR",
+      "baseNumber": 79,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 83,
+      "count": 3
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 84,
+      "count": 3
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 86,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 88,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 89,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 92,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 123,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 126,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 128,
+      "count": 3
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 129,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 130,
+      "count": 2
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 132,
+      "count": 3
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 135,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 136,
+      "count": 3
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 139,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 172,
+      "count": 3
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 225,
+      "count": 2
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 226,
+      "count": 3
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 227,
+      "count": 2
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 228,
+      "count": 2
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 229,
+      "count": 3
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 230,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 231,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 232,
+      "count": 2
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 233,
+      "count": 3
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 234,
+      "count": 1
+    }
+  ],
+  "sideboard": []
+}

--- a/public/precons/TS26-against-the-odds.json
+++ b/public/precons/TS26-against-the-odds.json
@@ -1,0 +1,420 @@
+{
+  "leader": {
+    "setKey": "TS26",
+    "baseNumber": 8,
+    "count": 1
+  },
+  "secondLeader": {
+    "setKey": "TS26",
+    "baseNumber": 6,
+    "count": 1
+  },
+  "base": {
+    "setKey": "TS26",
+    "baseNumber": 9,
+    "count": 1
+  },
+  "mainDeck": [
+    {
+      "setKey": "TS26",
+      "baseNumber": 63,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 83,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 43,
+      "count": 1
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 207,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 141,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 84,
+      "count": 1
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 200,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 47,
+      "count": 1
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 45,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 217,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 71,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 147,
+      "count": 1
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 180,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 32,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 172,
+      "count": 1
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 58,
+      "count": 1
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 51,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 36,
+      "count": 1
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 246,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 193,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 41,
+      "count": 1
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 226,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 45,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 68,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 220,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 66,
+      "count": 1
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 83,
+      "count": 1
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 192,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 30,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 77,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 76,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 49,
+      "count": 1
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 232,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 150,
+      "count": 1
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 70,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 189,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 145,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 67,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 35,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 221,
+      "count": 1
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 43,
+      "count": 1
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 151,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 204,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 62,
+      "count": 1
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 199,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 162,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 140,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 69,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 78,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 44,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 52,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 39,
+      "count": 1
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 233,
+      "count": 1
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 57,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 81,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 64,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 171,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 79,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 37,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 154,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 82,
+      "count": 1
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 44,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 20,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 42,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 77,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 48,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 65,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 171,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 80,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 173,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 65,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 199,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 34,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 43,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 67,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 174,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 31,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 45,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 146,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 146,
+      "count": 1
+    }
+  ],
+  "sideboard": []
+}

--- a/public/precons/TS26-aggressive-negotiations.json
+++ b/public/precons/TS26-aggressive-negotiations.json
@@ -1,0 +1,420 @@
+{
+  "leader": {
+    "setKey": "TS26",
+    "baseNumber": 2,
+    "count": 1
+  },
+  "secondLeader": {
+    "setKey": "TS26",
+    "baseNumber": 4,
+    "count": 1
+  },
+  "base": {
+    "setKey": "TS26",
+    "baseNumber": 11,
+    "count": 1
+  },
+  "mainDeck": [
+    {
+      "setKey": "TWI",
+      "baseNumber": 169,
+      "count": 1
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 176,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 90,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 19,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 251,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 46,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 61,
+      "count": 1
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 144,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 91,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 104,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 54,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 92,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 144,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 44,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 15,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 17,
+      "count": 1
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 179,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 105,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 55,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 114,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 20,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 62,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 42,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 153,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 142,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 115,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 106,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 60,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 43,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 240,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 71,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 149,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 14,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 148,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 43,
+      "count": 1
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 170,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 109,
+      "count": 1
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 162,
+      "count": 1
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 59,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 50,
+      "count": 1
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 111,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 23,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 47,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 57,
+      "count": 1
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 68,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 95,
+      "count": 1
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 254,
+      "count": 1
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 146,
+      "count": 1
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 95,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 44,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 55,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 56,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 173,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 41,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 66,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 107,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 46,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 72,
+      "count": 1
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 63,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 129,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 141,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 25,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 18,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 56,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 97,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 160,
+      "count": 1
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 64,
+      "count": 1
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 160,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 64,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 67,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 53,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 84,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 40,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 70,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 149,
+      "count": 1
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 48,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 68,
+      "count": 1
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 254,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 24,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 45,
+      "count": 1
+    }
+  ],
+  "sideboard": []
+}

--- a/public/precons/TS26-blood-brothers.json
+++ b/public/precons/TS26-blood-brothers.json
@@ -1,0 +1,420 @@
+{
+  "leader": {
+    "setKey": "TS26",
+    "baseNumber": 3,
+    "count": 1
+  },
+  "secondLeader": {
+    "setKey": "TS26",
+    "baseNumber": 5,
+    "count": 1
+  },
+  "base": {
+    "setKey": "TS26",
+    "baseNumber": 12,
+    "count": 1
+  },
+  "mainDeck": [
+    {
+      "setKey": "LOF",
+      "baseNumber": 107,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 67,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 185,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 80,
+      "count": 1
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 136,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 24,
+      "count": 1
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 179,
+      "count": 1
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 224,
+      "count": 1
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 184,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 132,
+      "count": 1
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 131,
+      "count": 1
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 192,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 58,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 30,
+      "count": 1
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 82,
+      "count": 1
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 228,
+      "count": 1
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 119,
+      "count": 1
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 123,
+      "count": 1
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 225,
+      "count": 1
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 140,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 137,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 136,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 82,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 134,
+      "count": 1
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 86,
+      "count": 1
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 60,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 56,
+      "count": 1
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 210,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 22,
+      "count": 1
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 226,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 68,
+      "count": 1
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 135,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 74,
+      "count": 1
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 81,
+      "count": 1
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 75,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 134,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 54,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 57,
+      "count": 1
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 173,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 66,
+      "count": 1
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 116,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 29,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 25,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 83,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 52,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 59,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 124,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 137,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 60,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 133,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 51,
+      "count": 1
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 79,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 172,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 27,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 81,
+      "count": 1
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 183,
+      "count": 1
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 113,
+      "count": 1
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 159,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 244,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 72,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 70,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 21,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 76,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 80,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 26,
+      "count": 1
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 70,
+      "count": 1
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 85,
+      "count": 1
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 217,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 71,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 225,
+      "count": 1
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 166,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 126,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 77,
+      "count": 1
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 81,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 219,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 84,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 28,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 53,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 65,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 90,
+      "count": 1
+    }
+  ],
+  "sideboard": []
+}

--- a/public/precons/TS26-master-and-apprentice.json
+++ b/public/precons/TS26-master-and-apprentice.json
@@ -1,0 +1,420 @@
+{
+  "leader": {
+    "setKey": "TS26",
+    "baseNumber": 1,
+    "count": 1
+  },
+  "secondLeader": {
+    "setKey": "TS26",
+    "baseNumber": 7,
+    "count": 1
+  },
+  "base": {
+    "setKey": "TS26",
+    "baseNumber": 10,
+    "count": 1
+  },
+  "mainDeck": [
+    {
+      "setKey": "SEC",
+      "baseNumber": 215,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 84,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 36,
+      "count": 1
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 71,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 38,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 61,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 51,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 38,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 76,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 85,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 187,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 77,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 48,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 45,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 81,
+      "count": 1
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 217,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 122,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 60,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 210,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 27,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 252,
+      "count": 1
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 123,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 128,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 180,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 56,
+      "count": 1
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 65,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 230,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 183,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 53,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 52,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 186,
+      "count": 1
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 191,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 81,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 31,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 33,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 33,
+      "count": 1
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 118,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 83,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 17,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 78,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 50,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 185,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 54,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 44,
+      "count": 1
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 33,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 74,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 80,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 15,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 85,
+      "count": 1
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 39,
+      "count": 1
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 33,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 42,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 79,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 229,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 49,
+      "count": 1
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 263,
+      "count": 1
+    },
+    {
+      "setKey": "JTL",
+      "baseNumber": 229,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 75,
+      "count": 1
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 120,
+      "count": 1
+    },
+    {
+      "setKey": "SEC",
+      "baseNumber": 91,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 113,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 207,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 190,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 31,
+      "count": 1
+    },
+    {
+      "setKey": "LOF",
+      "baseNumber": 110,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 79,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 29,
+      "count": 1
+    },
+    {
+      "setKey": "LAW",
+      "baseNumber": 97,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 238,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 37,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 92,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 47,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 43,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 71,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 16,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 73,
+      "count": 1
+    },
+    {
+      "setKey": "TS26",
+      "baseNumber": 13,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 178,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 71,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 181,
+      "count": 1
+    }
+  ],
+  "sideboard": []
+}

--- a/public/precons/TWI-Ahsoka.json
+++ b/public/precons/TWI-Ahsoka.json
@@ -1,0 +1,160 @@
+{
+  "leader": {
+    "setKey": "TWI",
+    "baseNumber": 11,
+    "count": 1
+  },
+  "base": {
+    "setKey": "TWI",
+    "baseNumber": 24,
+    "count": 1
+  },
+  "mainDeck": [
+    {
+      "setKey": "TWI",
+      "baseNumber": 240,
+      "count": 3
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 141,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 241,
+      "count": 3
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 159,
+      "count": 2
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 158,
+      "count": 2
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 91,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 90,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 106,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 92,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 144,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 109,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 243,
+      "count": 2
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 94,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 164,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 147,
+      "count": 3
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 114,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 97,
+      "count": 3
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 111,
+      "count": 2
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 142,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 111,
+      "count": 2
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 244,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 246,
+      "count": 1
+    },
+    {
+      "setKey": "SHD",
+      "baseNumber": 128,
+      "count": 2
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 171,
+      "count": 2
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 99,
+      "count": 1
+    },
+    {
+      "setKey": "SOR",
+      "baseNumber": 172,
+      "count": 3
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 126,
+      "count": 2
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 251,
+      "count": 2
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 248,
+      "count": 3
+    }
+  ],
+  "sideboard": []
+}

--- a/public/precons/TWI-Grievous.json
+++ b/public/precons/TWI-Grievous.json
@@ -1,0 +1,165 @@
+{
+  "leader": {
+    "setKey": "TWI",
+    "baseNumber": 15,
+    "count": 1
+  },
+  "base": {
+    "setKey": "TWI",
+    "baseNumber": 23,
+    "count": 1
+  },
+  "mainDeck": [
+    {
+      "setKey": "TWI",
+      "baseNumber": 79,
+      "count": 2
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 80,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 82,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 83,
+      "count": 3
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 84,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 86,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 87,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 104,
+      "count": 3
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 107,
+      "count": 2
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 112,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 179,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 180,
+      "count": 3
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 184,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 190,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 206,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 207,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 217,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 218,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 221,
+      "count": 2
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 222,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 226,
+      "count": 2
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 228,
+      "count": 2
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 229,
+      "count": 3
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 230,
+      "count": 2
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 233,
+      "count": 2
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 234,
+      "count": 1
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 236,
+      "count": 3
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 237,
+      "count": 2
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 238,
+      "count": 3
+    },
+    {
+      "setKey": "TWI",
+      "baseNumber": 257,
+      "count": 1
+    }
+  ],
+  "sideboard": []
+}

--- a/public/precons/manifest.json
+++ b/public/precons/manifest.json
@@ -1,0 +1,158 @@
+{
+  "precons": [
+    {
+      "key": "TS26-master-and-apprentice",
+      "label": "Master and Apprentice (Twin Suns)",
+      "setKey": "TS26",
+      "aspect": "Twin Suns",
+      "file": "TS26-master-and-apprentice.json"
+    },
+    {
+      "key": "TS26-aggressive-negotiations",
+      "label": "Aggressive Negotiations (Twin Suns)",
+      "setKey": "TS26",
+      "aspect": "Twin Suns",
+      "file": "TS26-aggressive-negotiations.json"
+    },
+    {
+      "key": "TS26-blood-brothers",
+      "label": "Blood Brothers (Twin Suns)",
+      "setKey": "TS26",
+      "aspect": "Twin Suns",
+      "file": "TS26-blood-brothers.json"
+    },
+    {
+      "key": "TS26-against-the-odds",
+      "label": "Against the Odds (Twin Suns)",
+      "setKey": "TS26",
+      "aspect": "Twin Suns",
+      "file": "TS26-against-the-odds.json"
+    },
+    {
+      "key": "SOR-Luke",
+      "label": "Luke Skywalker (Spark of Rebellion)",
+      "setKey": "SOR",
+      "aspect": "Heroism",
+      "file": "SOR-Luke.json"
+    },
+    {
+      "key": "SOR-Vader",
+      "label": "Darth Vader (Spark of Rebellion)",
+      "setKey": "SOR",
+      "aspect": "Villainy",
+      "file": "SOR-Vader.json"
+    },
+    {
+      "key": "SHD-Mando",
+      "label": "The Mandalorian (Shadows of the Galaxy)",
+      "setKey": "SHD",
+      "aspect": "Heroism",
+      "file": "SHD-Mando.json"
+    },
+    {
+      "key": "SHD-MoffGideon",
+      "label": "Moff Gideon (Shadows of the Galaxy)",
+      "setKey": "SHD",
+      "aspect": "Villainy",
+      "file": "SHD-MoffGideon.json"
+    },
+    {
+      "key": "TWI-Ahsoka",
+      "label": "Ahsoka Tano (Twilight of the Republic)",
+      "setKey": "TWI",
+      "aspect": "Heroism",
+      "file": "TWI-Ahsoka.json"
+    },
+    {
+      "key": "TWI-Grievous",
+      "label": "General Grievous (Twilight of the Republic)",
+      "setKey": "TWI",
+      "aspect": "Villainy",
+      "file": "TWI-Grievous.json"
+    },
+    {
+      "key": "JTL-BobaFett",
+      "label": "Boba Fett (Jump to Lightspeed)",
+      "setKey": "JTL",
+      "aspect": "Villainy",
+      "file": "JTL-BobaFett.json"
+    },
+    {
+      "key": "JTL-HanSolo",
+      "label": "Han Solo (Jump to Lightspeed)",
+      "setKey": "JTL",
+      "aspect": "Heroism",
+      "file": "JTL-HanSolo.json"
+    },
+    {
+      "key": "LOF-Maul",
+      "label": "Darth Maul (Legends of the Force)",
+      "setKey": "LOF",
+      "aspect": "Villainy",
+      "file": "LOF-Maul.json"
+    },
+    {
+      "key": "LOF-QuiGon",
+      "label": "Qui-Gon Jinn (Legends of the Force)",
+      "setKey": "LOF",
+      "aspect": "Heroism",
+      "file": "LOF-QuiGon.json"
+    },
+    {
+      "key": "SEC-Amidala",
+      "label": "Padme Amidala (Secrets of Power)",
+      "setKey": "SEC",
+      "aspect": "Heroism",
+      "file": "SEC-Amidala.json"
+    },
+    {
+      "key": "SEC-Palpatine",
+      "label": "Chancellor Palpatine (Secrets of Power)",
+      "setKey": "SEC",
+      "aspect": "Villainy",
+      "file": "SEC-Palpatine.json"
+    },
+    {
+      "key": "LAW-Jabba",
+      "label": "Jabba the Hutt (A Lawless Time)",
+      "setKey": "LAW",
+      "aspect": "Villainy",
+      "file": "LAW-Jabba.json"
+    },
+    {
+      "key": "LAW-Leia",
+      "label": "Leia Organa (A Lawless Time)",
+      "setKey": "LAW",
+      "aspect": "Heroism",
+      "file": "LAW-Leia.json"
+    },
+    {
+      "key": "ASH-Luke",
+      "label": "Luke Skywalker (Ashes of the Empire)",
+      "setKey": "ASH",
+      "aspect": "Heroism",
+      "file": "ASH-Luke.json"
+    },
+    {
+      "key": "ASH-Palpatine",
+      "label": "Emperor Palpatine (Ashes of the Empire)",
+      "setKey": "ASH",
+      "aspect": "Villainy",
+      "file": "ASH-Palpatine.json"
+    },
+    {
+      "key": "IBH-Vader",
+      "label": "Darth Vader (Intro Battle: Hoth)",
+      "setKey": "IBH",
+      "aspect": "Villainy",
+      "file": "IBH-Vader.json"
+    },
+    {
+      "key": "IBH-Leia",
+      "label": "Leia Organa (Intro Battle: Hoth)",
+      "setKey": "IBH",
+      "aspect": "Heroism",
+      "file": "IBH-Leia.json"
+    }
+  ]
+}

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -7,6 +7,7 @@ import type { Config } from './config.js'
 import { attachSession } from './auth/session.js'
 import { makeAuthRouter } from './auth/routes.js'
 import { makeInventoryRouter } from './inventories/routes.js'
+import { makeDeckRouter } from './decks/routes.js'
 import { makeGoogleClient } from './auth/google.js'
 
 export type AppDeps = {
@@ -49,6 +50,7 @@ export function makeApp({ db, config, logger }: AppDeps): Express {
     }),
   )
   app.use('/api/inventories', makeInventoryRouter({ db }))
+  app.use('/api/decks', makeDeckRouter({ db }))
 
   return app
 }

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -25,7 +25,9 @@ function bootstrap(db: Db): void {
   const currentVersion = Number(
     (db.pragma('user_version', { simple: true }) as number | bigint) ?? 0,
   )
-  if (currentVersion >= 1) return
+  // schema.sql is idempotent (CREATE TABLE IF NOT EXISTS), so re-running it against an
+  // already-bootstrapped database only adds whatever's new since its last recorded version.
+  if (currentVersion >= 2) return
   const schema = readFileSync(SCHEMA_PATH, 'utf8')
   db.exec(schema)
 }

--- a/server/src/decks/repo.ts
+++ b/server/src/decks/repo.ts
@@ -1,0 +1,74 @@
+import type { Db } from '../db.js'
+
+export type DeckLibrary = {
+  customDecks: unknown[]
+  preconOwnership: Record<string, number>
+}
+
+export type DeckLibraryRow = {
+  data: DeckLibrary
+  version: number
+  updatedAt: number
+}
+
+export type PutOutcome =
+  | { ok: true; version: number }
+  | { ok: false; current: DeckLibraryRow }
+
+const EMPTY_LIBRARY: DeckLibrary = { customDecks: [], preconOwnership: {} }
+
+function parseData(json: string): DeckLibrary {
+  try {
+    const parsed = JSON.parse(json)
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return { ...EMPTY_LIBRARY }
+    const customDecks = Array.isArray(parsed.customDecks) ? parsed.customDecks : []
+    const preconOwnership =
+      parsed.preconOwnership && typeof parsed.preconOwnership === 'object' && !Array.isArray(parsed.preconOwnership)
+        ? parsed.preconOwnership
+        : {}
+    return { customDecks, preconOwnership }
+  } catch {
+    return { ...EMPTY_LIBRARY }
+  }
+}
+
+export function getOne(db: Db, userId: number): DeckLibraryRow | null {
+  const row = db
+    .prepare(
+      'SELECT data_json AS dataJson, version, updated_at AS updatedAt FROM deck_library WHERE user_id = ?',
+    )
+    .get(userId) as { dataJson: string; version: number; updatedAt: number } | undefined
+  if (!row) return null
+  return { data: parseData(row.dataJson), version: row.version, updatedAt: row.updatedAt }
+}
+
+export function upsertOne(
+  db: Db,
+  userId: number,
+  data: DeckLibrary,
+  expectedVersion: number,
+  now = Date.now(),
+): PutOutcome {
+  const json = JSON.stringify(data)
+  const tx = db.transaction((): PutOutcome => {
+    const current = getOne(db, userId)
+    if (!current) {
+      if (expectedVersion !== 0) {
+        return { ok: false, current: { data: { ...EMPTY_LIBRARY }, version: 0, updatedAt: 0 } }
+      }
+      db.prepare(
+        'INSERT INTO deck_library (user_id, data_json, version, updated_at) VALUES (?, ?, ?, ?)',
+      ).run(userId, json, 1, now)
+      return { ok: true, version: 1 }
+    }
+    if (current.version !== expectedVersion) {
+      return { ok: false, current }
+    }
+    const nextVersion = current.version + 1
+    db.prepare(
+      'UPDATE deck_library SET data_json = ?, version = ?, updated_at = ? WHERE user_id = ?',
+    ).run(json, nextVersion, now, userId)
+    return { ok: true, version: nextVersion }
+  })
+  return tx()
+}

--- a/server/src/decks/routes.ts
+++ b/server/src/decks/routes.ts
@@ -1,0 +1,58 @@
+import { Router } from 'express'
+import { z } from 'zod'
+import type { Db } from '../db.js'
+import { requireAuth } from '../auth/session.js'
+import { getOne, upsertOne, type DeckLibrary, type DeckLibraryRow } from './repo.js'
+
+const DeckLibrarySchema = z.object({
+  customDecks: z.array(z.unknown()),
+  preconOwnership: z.record(z.string(), z.number()),
+})
+const PutBody = z.object({ data: DeckLibrarySchema })
+
+type Deps = { db: Db }
+
+function toResponse(row: DeckLibraryRow | null): { data: DeckLibrary; version: number; updatedAt: number } {
+  if (!row) return { data: { customDecks: [], preconOwnership: {} }, version: 0, updatedAt: 0 }
+  return { data: row.data, version: row.version, updatedAt: row.updatedAt }
+}
+
+export function makeDeckRouter(deps: Deps): Router {
+  const router = Router()
+  router.use(requireAuth())
+
+  router.get('/', (req, res) => {
+    const row = getOne(deps.db, req.session!.userId)
+    res.json(toResponse(row))
+  })
+
+  router.put('/', (req, res) => {
+    const parsedBody = PutBody.safeParse(req.body)
+    if (!parsedBody.success) {
+      res.status(400).json({ error: 'invalid_body', issues: parsedBody.error.issues })
+      return
+    }
+    const ifMatch = req.header('if-match')
+    const expected = ifMatch === undefined ? NaN : Number(ifMatch)
+    if (!Number.isInteger(expected) || expected < 0) {
+      res.status(428).json({ error: 'if_match_required' })
+      return
+    }
+
+    const outcome = upsertOne(deps.db, req.session!.userId, parsedBody.data.data, expected)
+    if (outcome.ok) {
+      res.json({ version: outcome.version })
+      return
+    }
+    res.status(409).json({
+      error: 'version_conflict',
+      current: {
+        data: outcome.current.data,
+        version: outcome.current.version,
+        updatedAt: outcome.current.updatedAt,
+      },
+    })
+  })
+
+  return router
+}

--- a/server/src/schema.sql
+++ b/server/src/schema.sql
@@ -25,4 +25,12 @@ CREATE TABLE IF NOT EXISTS inventories (
   PRIMARY KEY (user_id, set_key)
 );
 
-PRAGMA user_version = 1;
+-- One row per user: the whole personal deck library (precon ownership + saved decks) as one blob.
+CREATE TABLE IF NOT EXISTS deck_library (
+  user_id INTEGER PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+  data_json TEXT NOT NULL,
+  version INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+PRAGMA user_version = 2;

--- a/server/test/decks-repo.test.ts
+++ b/server/test/decks-repo.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import { memoryDb } from './helpers.js'
+import { getOne, upsertOne } from '../src/decks/repo.js'
+
+function seedUser(db: ReturnType<typeof memoryDb>): number {
+  const result = db
+    .prepare('INSERT INTO users (google_sub, email, created_at) VALUES (?, ?, ?)')
+    .run('sub', 'a@b.c', Date.now())
+  return Number(result.lastInsertRowid)
+}
+
+describe('deck library repo', () => {
+  it('returns null for a user with no saved library', () => {
+    const db = memoryDb()
+    const userId = seedUser(db)
+    expect(getOne(db, userId)).toBeNull()
+  })
+
+  it('upserts with optimistic concurrency', () => {
+    const db = memoryDb()
+    const userId = seedUser(db)
+    const library = { customDecks: [], preconOwnership: { 'SOR-heroism': 1 } }
+
+    const create = upsertOne(db, userId, library, 0)
+    expect(create).toEqual({ ok: true, version: 1 })
+
+    const stale = upsertOne(db, userId, library, 0)
+    expect(stale.ok).toBe(false)
+    if (!stale.ok) expect(stale.current.version).toBe(1)
+
+    const next = upsertOne(db, userId, { customDecks: [], preconOwnership: { 'SOR-villainy': 1 } }, 1)
+    expect(next).toEqual({ ok: true, version: 2 })
+
+    const row = getOne(db, userId)
+    expect(row).toMatchObject({
+      data: { customDecks: [], preconOwnership: { 'SOR-villainy': 1 } },
+      version: 2,
+    })
+  })
+
+  it('rejects a first-write with a non-zero If-Match', () => {
+    const db = memoryDb()
+    const userId = seedUser(db)
+    const outcome = upsertOne(db, userId, { customDecks: [], preconOwnership: {} }, 5)
+    expect(outcome.ok).toBe(false)
+    if (!outcome.ok) expect(outcome.current.version).toBe(0)
+  })
+
+  it('scopes rows per user', () => {
+    const db = memoryDb()
+    const userA = seedUser(db)
+    const userB = Number(
+      db
+        .prepare('INSERT INTO users (google_sub, email, created_at) VALUES (?, ?, ?)')
+        .run('sub-b', 'b@b.c', Date.now()).lastInsertRowid,
+    )
+    upsertOne(db, userA, { customDecks: [], preconOwnership: { a: 1 } }, 0)
+    expect(getOne(db, userB)).toBeNull()
+  })
+})

--- a/server/test/decks.test.ts
+++ b/server/test/decks.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest'
+import request from 'supertest'
+import { makeTestApp, memoryDb, seedUserWithSession } from './helpers.js'
+
+describe('decks API', () => {
+  it('rejects unauthenticated requests', async () => {
+    const db = memoryDb()
+    const app = makeTestApp(db)
+    const res = await request(app).get('/api/decks')
+    expect(res.status).toBe(401)
+  })
+
+  it('returns an empty library for a fresh user', async () => {
+    const db = memoryDb()
+    const app = makeTestApp(db)
+    const { cookie } = seedUserWithSession(db)
+    const res = await request(app).get('/api/decks').set('Cookie', cookie)
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ data: { customDecks: [], preconOwnership: {} }, version: 0, updatedAt: 0 })
+  })
+
+  it('creates a new deck library when If-Match: 0', async () => {
+    const db = memoryDb()
+    const app = makeTestApp(db)
+    const { cookie } = seedUserWithSession(db)
+    const res = await request(app)
+      .put('/api/decks')
+      .set('Cookie', cookie)
+      .set('If-Match', '0')
+      .send({ data: { customDecks: [], preconOwnership: { 'SOR-heroism': 1 } } })
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ version: 1 })
+
+    const get = await request(app).get('/api/decks').set('Cookie', cookie)
+    expect(get.body.data).toEqual({ customDecks: [], preconOwnership: { 'SOR-heroism': 1 } })
+    expect(get.body.version).toBe(1)
+  })
+
+  it('bumps version on subsequent writes with matching If-Match', async () => {
+    const db = memoryDb()
+    const app = makeTestApp(db)
+    const { cookie } = seedUserWithSession(db)
+    await request(app)
+      .put('/api/decks')
+      .set('Cookie', cookie)
+      .set('If-Match', '0')
+      .send({ data: { customDecks: [], preconOwnership: { a: 1 } } })
+    const res = await request(app)
+      .put('/api/decks')
+      .set('Cookie', cookie)
+      .set('If-Match', '1')
+      .send({ data: { customDecks: [], preconOwnership: { a: 1, b: 1 } } })
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ version: 2 })
+  })
+
+  it('returns 409 with the current state when If-Match is stale', async () => {
+    const db = memoryDb()
+    const app = makeTestApp(db)
+    const { cookie } = seedUserWithSession(db)
+    await request(app)
+      .put('/api/decks')
+      .set('Cookie', cookie)
+      .set('If-Match', '0')
+      .send({ data: { customDecks: [], preconOwnership: { a: 1 } } })
+    const res = await request(app)
+      .put('/api/decks')
+      .set('Cookie', cookie)
+      .set('If-Match', '0')
+      .send({ data: { customDecks: [], preconOwnership: { a: 9 } } })
+    expect(res.status).toBe(409)
+    expect(res.body.error).toBe('version_conflict')
+    expect(res.body.current).toMatchObject({ data: { customDecks: [], preconOwnership: { a: 1 } }, version: 1 })
+  })
+
+  it('requires an If-Match header on PUT', async () => {
+    const db = memoryDb()
+    const app = makeTestApp(db)
+    const { cookie } = seedUserWithSession(db)
+    const res = await request(app)
+      .put('/api/decks')
+      .set('Cookie', cookie)
+      .send({ data: { customDecks: [], preconOwnership: {} } })
+    expect(res.status).toBe(428)
+  })
+
+  it('rejects a malformed body', async () => {
+    const db = memoryDb()
+    const app = makeTestApp(db)
+    const { cookie } = seedUserWithSession(db)
+    const res = await request(app)
+      .put('/api/decks')
+      .set('Cookie', cookie)
+      .set('If-Match', '0')
+      .send({ data: { customDecks: [], preconOwnership: { a: 'not-a-number' } } })
+    expect(res.status).toBe(400)
+  })
+
+  it('scopes deck libraries per user', async () => {
+    const db = memoryDb()
+    const app = makeTestApp(db)
+    const userA = seedUserWithSession(db, 'a@example.com')
+    await request(app)
+      .put('/api/decks')
+      .set('Cookie', userA.cookie)
+      .set('If-Match', '0')
+      .send({ data: { customDecks: [], preconOwnership: { a: 1 } } })
+
+    const userB = seedUserWithSession(db, 'b@example.com')
+    const res = await request(app).get('/api/decks').set('Cookie', userB.cookie)
+    expect(res.body.data).toEqual({ customDecks: [], preconOwnership: {} })
+  })
+})

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,12 +40,27 @@ import { useAuth } from './hooks/useAuth';
 import { AuthMenu } from './components/AuthMenu';
 import { DataMenu } from './components/DataMenu';
 import { DeckCheckModal } from './components/DeckCheckModal';
+import { DecksView } from './components/DecksView';
 import { formatMissingLine, type DeckLookupSet } from './core/decklist';
 import {
   CloudMigrationModal,
   summarize,
   type MigrationChoice,
 } from './components/CloudMigrationModal';
+import { fetchPreconCatalog, type PreconCatalogEntry } from './core/precons';
+import {
+  deriveOwnedTotals,
+  loadDeckLibrary,
+  persistDeckLibrary,
+  type DeckLibrary,
+  type SavedDeck,
+} from './core/decks';
+import {
+  createDeckSync,
+  makeDeckBroadcast,
+  type DeckSync,
+  type DeckSyncEvent,
+} from './core/deckSync';
 
 /** Last entry in `manifest.json` is the newest set (release order). */
 function newestSetKeyFromManifest(list: SetMeta[]): SetKey {
@@ -700,6 +715,10 @@ export default function App() {
   const [showResetModal, setShowResetModal] = useState(false);
   const [showDeckCheckModal, setShowDeckCheckModal] = useState(false);
   const [listView, setListView] = React.useState<'inventory' | 'missing'>('inventory');
+  const [view, setView] = useState<'binder' | 'decks'>('binder');
+  const [ownershipScope, setOwnershipScope] = useState<'combined' | 'bindersOnly'>('combined');
+  const [preconCatalog, setPreconCatalog] = useState<PreconCatalogEntry[]>([]);
+  const [deckLibrary, setDeckLibrary] = useState<DeckLibrary>(() => loadDeckLibrary(localStorage));
 
   // In-app toast notifications (replaces window.alert)
   type ToastKind = 'success' | 'error' | 'warning';
@@ -740,6 +759,23 @@ export default function App() {
       onLocalApply: (incomingKey, data) => applyRemoteInventoryRef.current(incomingKey, data),
     });
   }
+
+  const deckSyncRef = useRef<DeckSync | null>(null);
+  const applyRemoteDeckLibraryRef = useRef<(data: DeckLibrary) => void>(() => {});
+  if (deckSyncRef.current == null) {
+    deckSyncRef.current = createDeckSync({
+      storage: localStorage,
+      fetch: (input, init) => fetch(input, init),
+      broadcast: makeDeckBroadcast(),
+      onLocalApply: data => applyRemoteDeckLibraryRef.current(data),
+    });
+  }
+
+  useEffect(() => {
+    fetchPreconCatalog(fetch).then(setPreconCatalog).catch(() => {
+      // Precon catalog is optional/additive — a fetch failure just means no precon checklist for this load.
+    });
+  }, []);
 
   useEffect(() => {
     fetch('/sets/manifest.json')
@@ -868,6 +904,43 @@ export default function App() {
     };
   }, [canonicalCatalog, setKey]);
 
+  // Deck library (precon ownership + saved decks) — kept separate from binder inventory.
+  useEffect(() => {
+    if (!persistDeckLibrary(localStorage, deckLibrary)) {
+      showToast('Deck library could not be saved on this device.', 'error');
+      return;
+    }
+    deckSyncRef.current?.scheduleSync(deckLibrary);
+  }, [deckLibrary, showToast]);
+
+  useEffect(() => {
+    applyRemoteDeckLibraryRef.current = data => setDeckLibrary(data);
+  }, []);
+
+  useEffect(() => {
+    const sync = deckSyncRef.current;
+    if (!sync) return;
+    const unsub = sync.subscribe((event: DeckSyncEvent) => {
+      if (event.type === 'signout') {
+        showToast('Signed out — deck library sync paused. Sign in again to resume.', 'warning');
+        return;
+      }
+      if (event.type === 'error' && event.consecutive >= 3) {
+        showToast(`Deck library sync retrying (${event.consecutive} failed attempts).`, 'warning');
+      }
+    });
+    const onOnline = () => {
+      void sync.flushDirty().catch(() => {});
+    };
+    window.addEventListener('online', onOnline);
+    return () => {
+      unsub();
+      window.removeEventListener('online', onOnline);
+    };
+  }, [showToast]);
+
+  useEffect(() => () => deckSyncRef.current?.dispose(), []);
+
   useEffect(() => {
     const sync = cloudSyncRef.current;
     if (!sync) return;
@@ -972,6 +1045,51 @@ export default function App() {
       cancelled = true;
     };
   }, [auth.status, canonicalCatalog, setKey, setKeys]);
+
+  const deckBootstrappedRef = useRef(false);
+  useEffect(() => {
+    const sync = deckSyncRef.current;
+    if (!sync) return;
+    if (auth.status === 'loading') return;
+    if (auth.status === 'signedOut') {
+      sync.setSignedIn(false);
+      deckBootstrappedRef.current = false;
+      return;
+    }
+    if (deckBootstrappedRef.current) return;
+    deckBootstrappedRef.current = true;
+
+    let cancelled = false;
+    sync.setSignedIn(true);
+    (async () => {
+      let cloud: { data: DeckLibrary; version: number } | null = null;
+      try {
+        cloud = await sync.pull();
+      } catch {
+        return;
+      }
+      if (cancelled || !cloud) return;
+      // New feature, no legacy pre-migration state — union-merge local and cloud rather than
+      // prompting, unlike the inventory migration flow.
+      setDeckLibrary(local => {
+        const customById = new Map(local.customDecks.map(d => [d.id, d]));
+        for (const deck of cloud!.data.customDecks) {
+          if (!customById.has(deck.id)) customById.set(deck.id, deck);
+        }
+        const preconOwnership: Record<string, number> = { ...local.preconOwnership };
+        for (const [key, owned] of Object.entries(cloud!.data.preconOwnership)) {
+          preconOwnership[key] = Math.max(preconOwnership[key] ?? 0, owned);
+        }
+        return { customDecks: [...customById.values()], preconOwnership };
+      });
+      if (cancelled) return;
+      await sync.flushDirty();
+    })().catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [auth.status]);
+
   const pruneZeros = (inv: Inventory) =>
     Object.fromEntries(Object.entries(inv).filter(([,q]) => (q as number) > 0)) as Inventory;
   useEffect(() => {
@@ -1310,10 +1428,44 @@ export default function App() {
   );
 
   // Deck Check: owned-quantity lookup spanning every set (not just the currently displayed one).
+  // Binder quantities stay capped at the playset quota; owned precons + physical decks are added
+  // on top, uncapped, unless the user has switched to "Binders only".
+  const deckOwnedTotals = useMemo(
+    () => (ownershipScope === 'combined' ? deriveOwnedTotals(deckLibrary, preconCatalog) : {}),
+    [ownershipScope, deckLibrary, preconCatalog],
+  );
   const buildOwnedLookup = useCallback(() => {
     const snapshot = createInventoryExportSnapshot(localStorage, setKeys, setKey, inventory, canonicalCatalog);
-    return (targetSetKey: SetKey, baseNumber: number) => snapshot[targetSetKey]?.[baseNumber] ?? 0;
-  }, [setKeys, setKey, inventory, canonicalCatalog]);
+    return (targetSetKey: SetKey, baseNumber: number) =>
+      (snapshot[targetSetKey]?.[baseNumber] ?? 0) + (deckOwnedTotals[targetSetKey]?.[baseNumber] ?? 0);
+  }, [setKeys, setKey, inventory, canonicalCatalog, deckOwnedTotals]);
+
+  const togglePrecon = useCallback((key: string) => {
+    setDeckLibrary(lib => {
+      const owned = (lib.preconOwnership[key] ?? 0) > 0;
+      return { ...lib, preconOwnership: { ...lib.preconOwnership, [key]: owned ? 0 : 1 } };
+    });
+  }, []);
+
+  const saveDeck = useCallback((deck: SavedDeck) => {
+    setDeckLibrary(lib => ({ ...lib, customDecks: [...lib.customDecks, deck] }));
+  }, []);
+
+  const updateDeck = useCallback(
+    (id: string, patch: Partial<Pick<SavedDeck, 'name' | 'physical' | 'copies'>>) => {
+      setDeckLibrary(lib => ({
+        ...lib,
+        customDecks: lib.customDecks.map(d =>
+          d.id === id ? { ...d, ...patch, updatedAt: new Date().toISOString() } : d,
+        ),
+      }));
+    },
+    [],
+  );
+
+  const deleteDeck = useCallback((id: string) => {
+    setDeckLibrary(lib => ({ ...lib, customDecks: lib.customDecks.filter(d => d.id !== id) }));
+  }, []);
 
   // Click outside to close dropdown
   useEffect(() => {
@@ -2196,6 +2348,33 @@ export default function App() {
             onReset={resetInv}
           />
           <div className="toolbar-block">
+            <div className="toolbar-label">View</div>
+            <div className="toolbar-group" role="tablist" aria-label="Binders or Decks">
+              <button
+                type="button"
+                className="tbtn"
+                role="tab"
+                aria-selected={view === 'binder'}
+                onClick={() => setView('binder')}
+                title="Your card collection binders"
+                style={view === 'binder' ? { backgroundColor: '#213c6a', color: '#fff', border: '1px solid #213c6a' } : undefined}
+              >
+                Binders
+              </button>
+              <button
+                type="button"
+                className="tbtn"
+                role="tab"
+                aria-selected={view === 'decks'}
+                onClick={() => setView('decks')}
+                title="Precon decks you own and your saved decklists"
+                style={view === 'decks' ? { backgroundColor: '#213c6a', color: '#fff', border: '1px solid #213c6a' } : undefined}
+              >
+                Decks
+              </button>
+            </div>
+          </div>
+          <div className="toolbar-block">
             <div className="toolbar-label">Deck</div>
             <div className="toolbar-group">
               <button
@@ -2210,12 +2389,36 @@ export default function App() {
                 <span>Deck Check</span>
               </button>
             </div>
+            <div className="toolbar-group" role="group" aria-label="Ownership scope" style={{ marginTop: 4 }}>
+              <button
+                type="button"
+                className="tbtn"
+                aria-pressed={ownershipScope === 'combined'}
+                onClick={() => setOwnershipScope('combined')}
+                title="Count owned precons and physical decks as owned, on top of your binders"
+                style={ownershipScope === 'combined' ? { backgroundColor: '#213c6a', color: '#fff', border: '1px solid #213c6a' } : undefined}
+              >
+                Binders + Decks
+              </button>
+              <button
+                type="button"
+                className="tbtn"
+                aria-pressed={ownershipScope === 'bindersOnly'}
+                onClick={() => setOwnershipScope('bindersOnly')}
+                title="Only count what's in your binders as owned"
+                style={ownershipScope === 'bindersOnly' ? { backgroundColor: '#213c6a', color: '#fff', border: '1px solid #213c6a' } : undefined}
+              >
+                Binders only
+              </button>
+            </div>
           </div>
 
           {error && <span className="err">{error}</span>}
         </div>
       </div>
 
+      {view === 'binder' && (
+      <>
       {/* Binder (with spread pager + dropdown) — minimal padding so the grid can use width */}
       <div className="card" ref={binderRef} style={{ padding: 8 }}>
         <Binder
@@ -2586,6 +2789,24 @@ export default function App() {
           )
         )}
       </div>
+      </>
+      )}
+
+      {view === 'decks' && (
+        <DecksView
+          preconCatalog={preconCatalog}
+          deckLibrary={deckLibrary}
+          onTogglePrecon={togglePrecon}
+          onSaveDeck={saveDeck}
+          onUpdateDeck={updateDeck}
+          onDeleteDeck={deleteDeck}
+          canonicalCatalog={canonicalCatalog}
+          parsedSets={deckCheckParsedSets}
+          trackedSetKeys={setKeys}
+          buildOwnedLookup={buildOwnedLookup}
+          showToast={showToast}
+        />
+      )}
 
       {showDeckCheckModal && (
         <DeckCheckModal
@@ -2594,6 +2815,7 @@ export default function App() {
           trackedSetKeys={setKeys}
           buildOwnedLookup={buildOwnedLookup}
           showToast={showToast}
+          onSaveDeck={saveDeck}
           onClose={() => setShowDeckCheckModal(false)}
         />
       )}

--- a/src/components/DeckCheckModal.tsx
+++ b/src/components/DeckCheckModal.tsx
@@ -12,6 +12,8 @@ import {
   type DeckResolution,
   type DeckRowWithNeed,
 } from '../core/decklist'
+import { DeckRowsTable } from './DeckRowsTable'
+import { createSavedDeck, type SavedDeck } from '../core/decks'
 
 type Props = {
   canonicalCatalog: CanonicalCatalog
@@ -19,6 +21,7 @@ type Props = {
   trackedSetKeys: SetKey[]
   buildOwnedLookup: () => (setKey: SetKey, baseNumber: number) => number
   showToast: (message: string, kind?: 'success' | 'error' | 'warning') => void
+  onSaveDeck: (deck: SavedDeck) => void
   onClose: () => void
 }
 
@@ -35,46 +38,8 @@ const REASON_LABEL: Record<'unknown-set' | 'no-name-match' | 'malformed', string
   malformed: 'Could not parse this line',
 }
 
-const ROLE_LABEL: Record<'leader' | 'base' | 'deck' | 'sideboard', string> = {
-  leader: 'Leader',
-  base: 'Base',
-  deck: 'Deck',
-  sideboard: 'Sideboard',
-}
-
 function money(value: number): string {
   return `$${value.toFixed(2)}`
-}
-
-function Row({ row }: { row: DeckRowWithNeed }) {
-  return (
-    <tr>
-      <td>{ROLE_LABEL[row.role]}</td>
-      <td>
-        {row.name}
-        {row.subtitle && <span className="muted"> - {row.subtitle}</span>}
-        {row.ambiguous && (
-          <span
-            className="muted"
-            title={
-              row.ambiguousOtherSets?.length
-                ? `Name also matches: ${row.ambiguousOtherSets.join(', ')} — guessed ${row.setKey}`
-                : 'Guessed which printing you meant'
-            }
-            style={{ marginLeft: 6 }}
-          >
-            ⚠
-          </span>
-        )}
-      </td>
-      <td className="mono">{row.setKey}</td>
-      <td className="mono">{row.have}</td>
-      <td className="mono">{row.count}</td>
-      <td className="mono">{row.needed}</td>
-      <td className="mono">{money(row.price)}</td>
-      <td className="mono">{money(row.rowCost)}</td>
-    </tr>
-  )
 }
 
 export function DeckCheckModal({
@@ -83,6 +48,7 @@ export function DeckCheckModal({
   trackedSetKeys,
   buildOwnedLookup,
   showToast,
+  onSaveDeck,
   onClose,
 }: Props) {
   const [text, setText] = React.useState('')
@@ -91,6 +57,10 @@ export function DeckCheckModal({
   const [includeSideboard, setIncludeSideboard] = React.useState(false)
   const [copyFeedback, setCopyFeedback] = React.useState<'idle' | 'copied' | 'failed'>('idle')
   const copyFeedbackTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+  const [showSaveForm, setShowSaveForm] = React.useState(false)
+  const [saveName, setSaveName] = React.useState('')
+  const [savePhysical, setSavePhysical] = React.useState(false)
+  const [saveCopies, setSaveCopies] = React.useState(1)
 
   React.useEffect(() => {
     return () => {
@@ -112,6 +82,32 @@ export function DeckCheckModal({
     const resolved = resolveDeckList(parsed, canonicalCatalog, parsedSets, trackedSetKeys, owned)
     setResolution(resolved)
     setRows(computeDeckRows(resolved.rows, owned))
+    setShowSaveForm(false)
+    setSaveName(resolved.deckName ?? '')
+    setSavePhysical(false)
+    setSaveCopies(1)
+  }
+
+  function handleSaveDeck() {
+    if (!resolution) return
+    const result = createSavedDeck(resolution.rows, {
+      name: saveName,
+      physical: savePhysical,
+      copies: saveCopies,
+      sourceText: text,
+    })
+    if (!result.ok) {
+      showToast(
+        result.reason === 'missing-leader'
+          ? "This decklist doesn't have a leader — it can't be saved yet."
+          : "This decklist doesn't have a base — it can't be saved yet.",
+        'warning',
+      )
+      return
+    }
+    onSaveDeck(result.deck)
+    showToast('Deck saved.', 'success')
+    setShowSaveForm(false)
   }
 
   const summary = React.useMemo(() => summarizeDeck(rows, includeSideboard), [rows, includeSideboard])
@@ -241,52 +237,12 @@ export function DeckCheckModal({
               )}
             </div>
 
-            <div style={{ overflowX: 'auto' }}>
-              <table className="table" style={{ marginTop: 12 }}>
-                <thead>
-                  <tr>
-                    <th>Role</th>
-                    <th>Card</th>
-                    <th>Set</th>
-                    <th>Have</th>
-                    <th>Deck</th>
-                    <th>Needed</th>
-                    <th>Price</th>
-                    <th>Cost</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {mainRows.map(row => (
-                    <Row key={`${row.role}:${row.setKey}:${row.baseNumber}`} row={row} />
-                  ))}
-                </tbody>
-              </table>
-            </div>
+            <DeckRowsTable rows={mainRows} />
 
             {sideboardRows.length > 0 && (
               <>
                 <h4 style={{ marginBottom: 4 }}>Sideboard</h4>
-                <div style={{ overflowX: 'auto' }}>
-                  <table className="table">
-                    <thead>
-                      <tr>
-                        <th>Role</th>
-                        <th>Card</th>
-                        <th>Set</th>
-                        <th>Have</th>
-                        <th>Deck</th>
-                        <th>Needed</th>
-                        <th>Price</th>
-                        <th>Cost</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {sideboardRows.map(row => (
-                        <Row key={`${row.role}:${row.setKey}:${row.baseNumber}`} row={row} />
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
+                <DeckRowsTable rows={sideboardRows} />
               </>
             )}
 
@@ -312,7 +268,7 @@ export function DeckCheckModal({
               </>
             )}
 
-            <div className="row" style={{ marginTop: 16 }}>
+            <div className="row" style={{ marginTop: 16, gap: 8 }}>
               <button type="button" className="tbtn" onClick={copyMissingDeckCards}>
                 <span className="icon" aria-hidden="true">
                   {copyFeedback === 'copied' ? 'check_circle' : copyFeedback === 'failed' ? 'error' : 'content_paste'}
@@ -325,7 +281,66 @@ export function DeckCheckModal({
                     : 'Copy missing to clipboard'}
                 </span>
               </button>
+              <button type="button" className="tbtn" onClick={() => setShowSaveForm(v => !v)}>
+                <span className="icon" aria-hidden="true">bookmark_add</span>
+                <span>Save as Deck</span>
+              </button>
             </div>
+
+            {showSaveForm && (
+              <div
+                className="row"
+                style={{ marginTop: 12, gap: 12, flexWrap: 'wrap', alignItems: 'center' }}
+              >
+                <input
+                  type="text"
+                  value={saveName}
+                  onChange={e => setSaveName(e.target.value)}
+                  placeholder="Deck name"
+                  style={{
+                    background: '#0f1017',
+                    color: '#eaeaf0',
+                    border: '1px solid #2b2d3d',
+                    borderRadius: 8,
+                    padding: '6px 10px',
+                    minWidth: 200,
+                  }}
+                />
+                <label className="row" style={{ gap: 6 }}>
+                  <input
+                    type="checkbox"
+                    checked={savePhysical}
+                    onChange={e => setSavePhysical(e.target.checked)}
+                  />
+                  <span title="Turn this on if this deck is physically built/boxed and not counted in your binder — its cards will count as owned.">
+                    Physical (owned outside my binder)
+                  </span>
+                </label>
+                {savePhysical && (
+                  <label className="row" style={{ gap: 6 }}>
+                    <span>Copies</span>
+                    <input
+                      type="number"
+                      min={1}
+                      value={saveCopies}
+                      onChange={e => setSaveCopies(Math.max(1, Number(e.target.value) || 1))}
+                      style={{
+                        width: 60,
+                        background: '#0f1017',
+                        color: '#eaeaf0',
+                        border: '1px solid #2b2d3d',
+                        borderRadius: 8,
+                        padding: '6px 10px',
+                      }}
+                    />
+                  </label>
+                )}
+                <button type="button" className="tbtn" onClick={handleSaveDeck}>
+                  <span className="icon" aria-hidden="true">save</span>
+                  <span>Save</span>
+                </button>
+              </div>
+            )}
           </>
         )}
       </div>

--- a/src/components/DeckRowsTable.tsx
+++ b/src/components/DeckRowsTable.tsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import type { DeckRowWithNeed } from '../core/decklist'
+
+const ROLE_LABEL: Record<'leader' | 'base' | 'deck' | 'sideboard', string> = {
+  leader: 'Leader',
+  base: 'Base',
+  deck: 'Deck',
+  sideboard: 'Sideboard',
+}
+
+function money(value: number): string {
+  return `$${value.toFixed(2)}`
+}
+
+function Row({ row }: { row: DeckRowWithNeed }) {
+  return (
+    <tr>
+      <td>{ROLE_LABEL[row.role]}</td>
+      <td>
+        {row.name}
+        {row.subtitle && <span className="muted"> - {row.subtitle}</span>}
+        {row.ambiguous && (
+          <span
+            className="muted"
+            title={
+              row.ambiguousOtherSets?.length
+                ? `Name also matches: ${row.ambiguousOtherSets.join(', ')} — guessed ${row.setKey}`
+                : 'Guessed which printing you meant'
+            }
+            style={{ marginLeft: 6 }}
+          >
+            ⚠
+          </span>
+        )}
+      </td>
+      <td className="mono">{row.setKey}</td>
+      <td className="mono">{row.have}</td>
+      <td className="mono">{row.count}</td>
+      <td className="mono">{row.needed}</td>
+      <td className="mono">{money(row.price)}</td>
+      <td className="mono">{money(row.rowCost)}</td>
+    </tr>
+  )
+}
+
+export function DeckRowsTable({ rows }: { rows: DeckRowWithNeed[] }) {
+  return (
+    <div style={{ overflowX: 'auto' }}>
+      <table className="table" style={{ marginTop: 12 }}>
+        <thead>
+          <tr>
+            <th>Role</th>
+            <th>Card</th>
+            <th>Set</th>
+            <th>Have</th>
+            <th>Deck</th>
+            <th>Needed</th>
+            <th>Price</th>
+            <th>Cost</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map(row => (
+            <Row key={`${row.role}:${row.setKey}:${row.baseNumber}`} row={row} />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/src/components/DecksView.tsx
+++ b/src/components/DecksView.tsx
@@ -1,0 +1,508 @@
+import React from 'react'
+import type { CanonicalCatalog } from '../core/inventory'
+import type { SetKey } from '../core/types'
+import {
+  computeDeckRows,
+  parseDeckList,
+  resolveDeckList,
+  type DeckLookupSet,
+  type DeckResolution,
+  type DeckRowWithNeed,
+} from '../core/decklist'
+import { allCardRefs, deckContentsFromRows, type DeckCardRef, type DeckContents } from '../core/deckContents'
+import { createSavedDeck, type DeckLibrary, type SavedDeck } from '../core/decks'
+import type { PreconCatalogEntry } from '../core/precons'
+import { DeckRowsTable } from './DeckRowsTable'
+
+type Props = {
+  preconCatalog: PreconCatalogEntry[]
+  deckLibrary: DeckLibrary
+  onTogglePrecon: (key: string) => void
+  onSaveDeck: (deck: SavedDeck) => void
+  onUpdateDeck: (id: string, patch: Partial<Pick<SavedDeck, 'name' | 'physical' | 'copies'>>) => void
+  onDeleteDeck: (id: string) => void
+  canonicalCatalog: CanonicalCatalog
+  parsedSets: Map<SetKey, DeckLookupSet>
+  trackedSetKeys: SetKey[]
+  buildOwnedLookup: () => (setKey: SetKey, baseNumber: number) => number
+  showToast: (message: string, kind?: 'success' | 'error' | 'warning') => void
+}
+
+const inputStyle: React.CSSProperties = {
+  background: '#0f1017',
+  color: '#eaeaf0',
+  border: '1px solid #2b2d3d',
+  borderRadius: 8,
+  padding: '6px 10px',
+}
+
+function cardRefToRow(
+  ref: DeckCardRef,
+  role: 'leader' | 'base' | 'deck' | 'sideboard',
+  parsedSets: Map<SetKey, DeckLookupSet>,
+  ownedByBase: (setKey: SetKey, baseNumber: number) => number,
+): DeckRowWithNeed | null {
+  const card = parsedSets.get(ref.setKey)?.byNumber.get(ref.baseNumber)
+  if (!card) return null
+  const have = ownedByBase(ref.setKey, ref.baseNumber)
+  const price = Number(card.MarketPrice ?? 0)
+  const needed = Math.max(0, ref.count - have)
+  return {
+    role,
+    count: ref.count,
+    setKey: ref.setKey,
+    baseNumber: ref.baseNumber,
+    name: card.Name,
+    subtitle: card.Subtitle,
+    type: card.Type,
+    price,
+    ambiguous: false,
+    have,
+    needed,
+    rowCost: needed * price,
+  }
+}
+
+function contentsToRows(
+  contents: DeckContents,
+  parsedSets: Map<SetKey, DeckLookupSet>,
+  ownedByBase: (setKey: SetKey, baseNumber: number) => number,
+): DeckRowWithNeed[] {
+  const roled: Array<[DeckCardRef, 'leader' | 'base' | 'deck' | 'sideboard']> = [[contents.leader, 'leader']]
+  if (contents.secondLeader) roled.push([contents.secondLeader, 'leader'])
+  roled.push([contents.base, 'base'])
+  for (const ref of contents.mainDeck) roled.push([ref, 'deck'])
+  for (const ref of contents.sideboard) roled.push([ref, 'sideboard'])
+
+  const rows: DeckRowWithNeed[] = []
+  for (const [ref, role] of roled) {
+    const row = cardRefToRow(ref, role, parsedSets, ownedByBase)
+    if (row) rows.push(row)
+  }
+  return rows
+}
+
+function cardsNeeded(contents: DeckContents, ownedByBase: (setKey: SetKey, baseNumber: number) => number): number {
+  let needed = 0
+  for (const ref of allCardRefs(contents)) needed += Math.max(0, ref.count - ownedByBase(ref.setKey, ref.baseNumber))
+  return needed
+}
+
+function copyToClipboard(text: string, showToast: Props['showToast'], label: string) {
+  navigator.clipboard.writeText(text).then(
+    () => showToast(`${label} copied to clipboard.`, 'success'),
+    () => showToast('Copy failed.', 'error'),
+  )
+}
+
+function DeckImportForm({
+  canonicalCatalog,
+  parsedSets,
+  trackedSetKeys,
+  buildOwnedLookup,
+  onSaveDeck,
+  showToast,
+  onDone,
+}: Pick<Props, 'canonicalCatalog' | 'parsedSets' | 'trackedSetKeys' | 'buildOwnedLookup' | 'onSaveDeck' | 'showToast'> & {
+  onDone: () => void
+}) {
+  const [text, setText] = React.useState('')
+  const [resolution, setResolution] = React.useState<DeckResolution | null>(null)
+  const [name, setName] = React.useState('')
+  const [physical, setPhysical] = React.useState(false)
+  const [copies, setCopies] = React.useState(1)
+
+  function handleResolve() {
+    if (!text.trim()) {
+      showToast('Paste a decklist first.', 'warning')
+      return
+    }
+    if (canonicalCatalog.size === 0) {
+      showToast('Card catalog is still loading. Please try again.', 'warning')
+      return
+    }
+    const parsed = parseDeckList(text)
+    const owned = buildOwnedLookup()
+    const resolved = resolveDeckList(parsed, canonicalCatalog, parsedSets, trackedSetKeys, owned)
+    setResolution(resolved)
+    setName(resolved.deckName ?? '')
+  }
+
+  function handleSave() {
+    if (!resolution) return
+    const result = createSavedDeck(resolution.rows, { name, physical, copies, sourceText: text })
+    if (!result.ok) {
+      showToast(
+        result.reason === 'missing-leader'
+          ? "This decklist doesn't have a leader — it can't be saved yet."
+          : "This decklist doesn't have a base — it can't be saved yet.",
+        'warning',
+      )
+      return
+    }
+    onSaveDeck(result.deck)
+    showToast('Deck saved.', 'success')
+    onDone()
+  }
+
+  const owned = React.useMemo(() => buildOwnedLookup(), [buildOwnedLookup])
+  const previewRows = resolution ? computeDeckRows(resolution.rows, owned) : []
+
+  return (
+    <div className="card" style={{ padding: 12, marginTop: 8 }}>
+      <textarea
+        value={text}
+        onChange={e => setText(e.target.value)}
+        placeholder="Paste your decklist here…"
+        rows={6}
+        style={{ width: '100%', boxSizing: 'border-box', ...inputStyle, fontFamily: 'ui-monospace, monospace', fontSize: 13, resize: 'vertical' }}
+      />
+      <div className="row" style={{ marginTop: 8, gap: 8 }}>
+        <button type="button" className="tbtn" onClick={handleResolve}>
+          <span className="icon" aria-hidden="true">checklist</span>
+          <span>Resolve</span>
+        </button>
+      </div>
+
+      {resolution && (
+        <>
+          {previewRows.length > 0 && <DeckRowsTable rows={previewRows} />}
+          {resolution.unresolved.length > 0 && (
+            <p className="muted">{resolution.unresolved.length} line(s) couldn't be matched to a card.</p>
+          )}
+          <div className="row" style={{ marginTop: 12, gap: 12, flexWrap: 'wrap', alignItems: 'center' }}>
+            <input
+              type="text"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              placeholder="Deck name"
+              style={{ ...inputStyle, minWidth: 200 }}
+            />
+            <label className="row" style={{ gap: 6 }}>
+              <input type="checkbox" checked={physical} onChange={e => setPhysical(e.target.checked)} />
+              <span title="Turn this on if this deck is physically built/boxed and not counted in your binder.">
+                Physical (owned outside my binder)
+              </span>
+            </label>
+            {physical && (
+              <label className="row" style={{ gap: 6 }}>
+                <span>Copies</span>
+                <input
+                  type="number"
+                  min={1}
+                  value={copies}
+                  onChange={e => setCopies(Math.max(1, Number(e.target.value) || 1))}
+                  style={{ ...inputStyle, width: 60 }}
+                />
+              </label>
+            )}
+            <button type="button" className="tbtn" onClick={handleSave}>
+              <span className="icon" aria-hidden="true">save</span>
+              <span>Save deck</span>
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
+function PreconJsonBuilder({
+  canonicalCatalog,
+  parsedSets,
+  trackedSetKeys,
+  showToast,
+}: Pick<Props, 'canonicalCatalog' | 'parsedSets' | 'trackedSetKeys' | 'showToast'>) {
+  const [text, setText] = React.useState('')
+  const [resolution, setResolution] = React.useState<DeckResolution | null>(null)
+  const [key, setKey] = React.useState('')
+  const [label, setLabel] = React.useState('')
+  const [setKeyInput, setSetKeyInput] = React.useState('')
+  const [aspect, setAspect] = React.useState('Heroism')
+
+  function handleResolve() {
+    if (!text.trim()) {
+      showToast('Paste a precon decklist first.', 'warning')
+      return
+    }
+    if (canonicalCatalog.size === 0) {
+      showToast('Card catalog is still loading. Please try again.', 'warning')
+      return
+    }
+    const parsed = parseDeckList(text)
+    const resolved = resolveDeckList(parsed, canonicalCatalog, parsedSets, trackedSetKeys, () => 0)
+    setResolution(resolved)
+  }
+
+  const contentsResult = resolution ? deckContentsFromRows(resolution.rows) : null
+
+  function handleCopyFile() {
+    if (!contentsResult?.ok) return
+    copyToClipboard(JSON.stringify(contentsResult.contents, null, 2), showToast, 'Precon deck JSON')
+  }
+
+  function handleCopyManifestEntry() {
+    if (!key.trim()) {
+      showToast('Enter a key first (e.g. SOR-heroism).', 'warning')
+      return
+    }
+    const entry = { key: key.trim(), label: label.trim() || key.trim(), setKey: setKeyInput.trim().toUpperCase(), aspect, file: `${key.trim()}.json` }
+    copyToClipboard(JSON.stringify(entry, null, 2), showToast, 'Manifest entry')
+  }
+
+  return (
+    <div>
+      <p className="muted" style={{ marginTop: 0 }}>
+        Paste a precon's decklist to generate the JSON files for <code>public/precons/</code>. This is a
+        one-time authoring step per precon — nothing here is saved automatically; copy the output and commit
+        it yourself.
+      </p>
+      <textarea
+        value={text}
+        onChange={e => setText(e.target.value)}
+        placeholder="Paste the precon's decklist here…"
+        rows={6}
+        style={{ width: '100%', boxSizing: 'border-box', ...inputStyle, fontFamily: 'ui-monospace, monospace', fontSize: 13, resize: 'vertical' }}
+      />
+      <div className="row" style={{ marginTop: 8, gap: 8 }}>
+        <button type="button" className="tbtn" onClick={handleResolve}>
+          <span className="icon" aria-hidden="true">checklist</span>
+          <span>Resolve</span>
+        </button>
+      </div>
+
+      {resolution && (
+        <>
+          {resolution.unresolved.length > 0 && (
+            <p className="muted">{resolution.unresolved.length} line(s) couldn't be matched to a card.</p>
+          )}
+          {contentsResult && !contentsResult.ok && (
+            <p className="err">
+              Missing a {contentsResult.reason === 'missing-leader' ? 'leader' : 'base'} — this decklist can't
+              become a precon file yet.
+            </p>
+          )}
+          {contentsResult?.ok && (
+            <div className="row" style={{ marginTop: 12, gap: 12, flexWrap: 'wrap', alignItems: 'center' }}>
+              <input type="text" value={key} onChange={e => setKey(e.target.value)} placeholder="Key (e.g. SOR-heroism)" style={{ ...inputStyle, minWidth: 180 }} />
+              <input type="text" value={label} onChange={e => setLabel(e.target.value)} placeholder="Label" style={{ ...inputStyle, minWidth: 200 }} />
+              <input type="text" value={setKeyInput} onChange={e => setSetKeyInput(e.target.value)} placeholder="Set key (e.g. SOR)" style={{ ...inputStyle, width: 120 }} />
+              <input
+                type="text"
+                list="precon-aspect-options"
+                value={aspect}
+                onChange={e => setAspect(e.target.value)}
+                placeholder="Aspect (e.g. Heroism, Villainy, Twin Suns)"
+                style={{ ...inputStyle, minWidth: 160 }}
+              />
+              <datalist id="precon-aspect-options">
+                <option value="Heroism" />
+                <option value="Villainy" />
+                <option value="Twin Suns" />
+              </datalist>
+              <button type="button" className="tbtn" onClick={handleCopyFile}>
+                <span className="icon" aria-hidden="true">content_copy</span>
+                <span>Copy deck JSON</span>
+              </button>
+              <button type="button" className="tbtn" onClick={handleCopyManifestEntry}>
+                <span className="icon" aria-hidden="true">content_copy</span>
+                <span>Copy manifest entry</span>
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+}
+
+function SavedDeckRow({
+  deck,
+  needed,
+  expanded,
+  onToggleExpand,
+  onUpdateDeck,
+  onDeleteDeck,
+  rows,
+}: {
+  deck: SavedDeck
+  needed: number
+  expanded: boolean
+  onToggleExpand: () => void
+  onUpdateDeck: Props['onUpdateDeck']
+  onDeleteDeck: Props['onDeleteDeck']
+  rows: DeckRowWithNeed[]
+}) {
+  return (
+    <div className="card" style={{ padding: 12, marginTop: 8 }}>
+      <div className="row" style={{ justifyContent: 'space-between', flexWrap: 'wrap', gap: 8 }}>
+        <button type="button" className="tbtn" onClick={onToggleExpand} style={{ fontWeight: 700 }}>
+          <span className="icon" aria-hidden="true">{expanded ? 'expand_less' : 'expand_more'}</span>
+          <span>{deck.name}</span>
+        </button>
+        <div className="row" style={{ gap: 8, alignItems: 'center' }}>
+          <span className="pill">{deck.physical ? `Physical × ${deck.copies}` : 'Reference'}</span>
+          <span className="pill">Needed: {needed}</span>
+          <label className="row" style={{ gap: 6 }}>
+            <input
+              type="checkbox"
+              checked={deck.physical}
+              onChange={e => onUpdateDeck(deck.id, { physical: e.target.checked })}
+            />
+            <span>Physical</span>
+          </label>
+          {deck.physical && (
+            <input
+              type="number"
+              min={1}
+              value={deck.copies}
+              onChange={e => onUpdateDeck(deck.id, { copies: Math.max(1, Number(e.target.value) || 1) })}
+              style={{ ...inputStyle, width: 56 }}
+            />
+          )}
+          <button type="button" className="tbtn" onClick={() => onDeleteDeck(deck.id)} aria-label={`Delete ${deck.name}`}>
+            <span className="icon" aria-hidden="true">delete</span>
+          </button>
+        </div>
+      </div>
+      {expanded && <DeckRowsTable rows={rows} />}
+    </div>
+  )
+}
+
+export function DecksView({
+  preconCatalog,
+  deckLibrary,
+  onTogglePrecon,
+  onSaveDeck,
+  onUpdateDeck,
+  onDeleteDeck,
+  canonicalCatalog,
+  parsedSets,
+  trackedSetKeys,
+  buildOwnedLookup,
+  showToast,
+}: Props) {
+  const ownedByBase = React.useMemo(() => buildOwnedLookup(), [buildOwnedLookup])
+  const [expandedPrecon, setExpandedPrecon] = React.useState<string | null>(null)
+  const [expandedDeckId, setExpandedDeckId] = React.useState<string | null>(null)
+  const [showImport, setShowImport] = React.useState(false)
+
+  const preconsBySet = React.useMemo(() => {
+    const groups = new Map<SetKey, PreconCatalogEntry[]>()
+    for (const entry of preconCatalog) {
+      const list = groups.get(entry.setKey) ?? []
+      list.push(entry)
+      groups.set(entry.setKey, list)
+    }
+    return groups
+  }, [preconCatalog])
+
+  return (
+    <div>
+      <div className="card" style={{ padding: 16 }}>
+        <h3 style={{ marginTop: 0 }}>Precon decks I own</h3>
+        <p className="muted" style={{ marginTop: 0 }}>
+          Check off the preconstructed decks you own. Their cards count as "owned" in Deck Check, on top of
+          your binders — without being added to your binder inventory.
+        </p>
+        {preconCatalog.length === 0 ? (
+          <p className="muted">
+            No precon decks in the catalog yet. Use "Build precon JSON" below to add one to{' '}
+            <code>public/precons/</code>.
+          </p>
+        ) : (
+          [...preconsBySet.entries()].map(([setKey, entries]) => (
+            <div key={setKey} style={{ marginTop: 12 }}>
+              <div className="row" style={{ gap: 8, alignItems: 'center' }}>
+                <span className="pill">{setKey}</span>
+              </div>
+              {entries.map(entry => {
+                const owned = (deckLibrary.preconOwnership[entry.key] ?? 0) > 0
+                const isExpanded = expandedPrecon === entry.key
+                return (
+                  <div key={entry.key} style={{ marginTop: 6 }}>
+                    <div className="row" style={{ gap: 8, alignItems: 'center' }}>
+                      <label className="row" style={{ gap: 6 }}>
+                        <input type="checkbox" checked={owned} onChange={() => onTogglePrecon(entry.key)} />
+                        <span>{entry.label}</span>
+                      </label>
+                      <span className="pill">{entry.aspect}</span>
+                      <button
+                        type="button"
+                        className="tbtn"
+                        onClick={() => setExpandedPrecon(isExpanded ? null : entry.key)}
+                      >
+                        <span>{isExpanded ? 'Hide' : 'View'} contents</span>
+                      </button>
+                    </div>
+                    {isExpanded && <DeckRowsTable rows={contentsToRows(entry.contents, parsedSets, ownedByBase)} />}
+                  </div>
+                )
+              })}
+            </div>
+          ))
+        )}
+      </div>
+
+      <div className="card" style={{ padding: 16, marginTop: 16 }}>
+        <div className="row" style={{ justifyContent: 'space-between' }}>
+          <h3 style={{ margin: 0 }}>My decks</h3>
+          <button type="button" className="tbtn" onClick={() => setShowImport(v => !v)}>
+            <span className="icon" aria-hidden="true">add</span>
+            <span>Import deck</span>
+          </button>
+        </div>
+        <p className="muted" style={{ marginTop: 4 }}>
+          Save decklists for reuse. Reference decks don't add to your owned totals (their cards are assumed
+          to already be in your binder or a physical deck); mark a deck Physical if it's fully built/boxed
+          on its own.
+        </p>
+
+        {showImport && (
+          <DeckImportForm
+            canonicalCatalog={canonicalCatalog}
+            parsedSets={parsedSets}
+            trackedSetKeys={trackedSetKeys}
+            buildOwnedLookup={buildOwnedLookup}
+            onSaveDeck={deck => {
+              onSaveDeck(deck)
+              setShowImport(false)
+            }}
+            showToast={showToast}
+            onDone={() => setShowImport(false)}
+          />
+        )}
+
+        {deckLibrary.customDecks.length === 0 ? (
+          <p className="muted">No saved decks yet.</p>
+        ) : (
+          deckLibrary.customDecks.map(deck => (
+            <SavedDeckRow
+              key={deck.id}
+              deck={deck}
+              needed={cardsNeeded(deck, ownedByBase)}
+              expanded={expandedDeckId === deck.id}
+              onToggleExpand={() => setExpandedDeckId(expandedDeckId === deck.id ? null : deck.id)}
+              onUpdateDeck={onUpdateDeck}
+              onDeleteDeck={onDeleteDeck}
+              rows={contentsToRows(deck, parsedSets, ownedByBase)}
+            />
+          ))
+        )}
+      </div>
+
+      <details className="card" style={{ padding: 16, marginTop: 16 }}>
+        <summary style={{ cursor: 'pointer', fontWeight: 700 }}>Build precon JSON (data authoring helper)</summary>
+        <div style={{ marginTop: 12 }}>
+          <PreconJsonBuilder
+            canonicalCatalog={canonicalCatalog}
+            parsedSets={parsedSets}
+            trackedSetKeys={trackedSetKeys}
+            showToast={showToast}
+          />
+        </div>
+      </details>
+    </div>
+  )
+}

--- a/src/core/deckContents.test.ts
+++ b/src/core/deckContents.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import { addDeckContentsToTotals, deckContentsFromRows, type DeckContents } from './deckContents';
+import type { ResolvedDeckRow } from './decklist';
+
+function row(partial: Partial<ResolvedDeckRow> & Pick<ResolvedDeckRow, 'role' | 'setKey' | 'baseNumber' | 'count'>): ResolvedDeckRow {
+  return { name: 'Card', price: 0, ambiguous: false, ...partial };
+}
+
+describe('deckContentsFromRows', () => {
+  it('fails when there is no leader row', () => {
+    const rows = [row({ role: 'base', setKey: 'SOR', baseNumber: 1, count: 1 })];
+    expect(deckContentsFromRows(rows)).toEqual({ ok: false, reason: 'missing-leader' });
+  });
+
+  it('fails when there is no base row', () => {
+    const rows = [row({ role: 'leader', setKey: 'SOR', baseNumber: 1, count: 1 })];
+    expect(deckContentsFromRows(rows)).toEqual({ ok: false, reason: 'missing-base' });
+  });
+
+  it('groups a single-leader deck into leader/base/mainDeck/sideboard', () => {
+    const rows = [
+      row({ role: 'leader', setKey: 'SOR', baseNumber: 1, count: 1 }),
+      row({ role: 'base', setKey: 'SOR', baseNumber: 2, count: 1 }),
+      row({ role: 'deck', setKey: 'SOR', baseNumber: 3, count: 3 }),
+      row({ role: 'sideboard', setKey: 'SOR', baseNumber: 4, count: 2 }),
+    ];
+    const result = deckContentsFromRows(rows);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.contents).toEqual({
+      leader: { setKey: 'SOR', baseNumber: 1, count: 1 },
+      secondLeader: undefined,
+      base: { setKey: 'SOR', baseNumber: 2, count: 1 },
+      mainDeck: [{ setKey: 'SOR', baseNumber: 3, count: 3 }],
+      sideboard: [{ setKey: 'SOR', baseNumber: 4, count: 2 }],
+    });
+  });
+
+  it('captures a second leader row for Twin Suns decks', () => {
+    const rows = [
+      row({ role: 'leader', setKey: 'TS26', baseNumber: 1, count: 1 }),
+      row({ role: 'leader', setKey: 'TS26', baseNumber: 2, count: 1 }),
+      row({ role: 'base', setKey: 'TS26', baseNumber: 3, count: 1 }),
+    ];
+    const result = deckContentsFromRows(rows);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.contents.secondLeader).toEqual({ setKey: 'TS26', baseNumber: 2, count: 1 });
+  });
+});
+
+describe('addDeckContentsToTotals', () => {
+  const contents: DeckContents = {
+    leader: { setKey: 'SOR', baseNumber: 1, count: 1 },
+    base: { setKey: 'SOR', baseNumber: 2, count: 1 },
+    mainDeck: [{ setKey: 'SOR', baseNumber: 3, count: 3 }],
+    sideboard: [{ setKey: 'SOR', baseNumber: 4, count: 2 }],
+  };
+
+  it('does nothing for a zero or negative multiplier', () => {
+    const totals = {};
+    addDeckContentsToTotals(totals, contents, 0);
+    expect(totals).toEqual({});
+  });
+
+  it('multiplies every card by the given multiplier, uncapped', () => {
+    const totals = {};
+    addDeckContentsToTotals(totals, contents, 2);
+    expect(totals).toEqual({
+      SOR: { 1: 2, 2: 2, 3: 6, 4: 4 },
+    });
+  });
+
+  it('accumulates across multiple calls instead of overwriting', () => {
+    const totals = {};
+    addDeckContentsToTotals(totals, contents, 1);
+    addDeckContentsToTotals(totals, contents, 1);
+    expect(totals).toEqual({
+      SOR: { 1: 2, 2: 2, 3: 6, 4: 4 },
+    });
+  });
+
+  it('merges contributions across different sets', () => {
+    const totals = {};
+    addDeckContentsToTotals(totals, contents, 1);
+    addDeckContentsToTotals(
+      totals,
+      {
+        leader: { setKey: 'JTL', baseNumber: 1, count: 1 },
+        base: { setKey: 'JTL', baseNumber: 2, count: 1 },
+        mainDeck: [],
+        sideboard: [],
+      },
+      1,
+    );
+    expect(Object.keys(totals).sort()).toEqual(['JTL', 'SOR']);
+  });
+});

--- a/src/core/deckContents.ts
+++ b/src/core/deckContents.ts
@@ -1,0 +1,105 @@
+import type { SetKey } from './types'
+import type { ResolvedDeckRow } from './decklist'
+
+export type DeckCardRef = { setKey: SetKey; baseNumber: number; count: number }
+
+export type DeckContents = {
+  leader: DeckCardRef
+  secondLeader?: DeckCardRef
+  base: DeckCardRef
+  mainDeck: DeckCardRef[]
+  sideboard: DeckCardRef[]
+}
+
+export type DeckContentsResult =
+  | { ok: true; contents: DeckContents }
+  | { ok: false; reason: 'missing-leader' | 'missing-base' }
+
+function toRef(row: ResolvedDeckRow): DeckCardRef {
+  return { setKey: row.setKey, baseNumber: row.baseNumber, count: row.count }
+}
+
+/** Groups resolved rows (from decklist.ts) into a DeckContents shape, used by both the static precon catalog and the personal deck library. */
+export function deckContentsFromRows(rows: ResolvedDeckRow[]): DeckContentsResult {
+  const leaders = rows.filter(r => r.role === 'leader')
+  const bases = rows.filter(r => r.role === 'base')
+  if (leaders.length === 0) return { ok: false, reason: 'missing-leader' }
+  if (bases.length === 0) return { ok: false, reason: 'missing-base' }
+
+  const [leader, secondLeader] = leaders
+  const [base] = bases
+
+  return {
+    ok: true,
+    contents: {
+      leader: toRef(leader!),
+      secondLeader: secondLeader ? toRef(secondLeader) : undefined,
+      base: toRef(base!),
+      mainDeck: rows.filter(r => r.role === 'deck').map(toRef),
+      sideboard: rows.filter(r => r.role === 'sideboard').map(toRef),
+    },
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+export function isDeckCardRef(value: unknown): value is DeckCardRef {
+  return (
+    isRecord(value) &&
+    typeof value.setKey === 'string' &&
+    Number.isInteger(value.baseNumber) &&
+    Number.isInteger(value.count) &&
+    (value.count as number) > 0
+  )
+}
+
+function isDeckCardRefArray(value: unknown): value is DeckCardRef[] {
+  return Array.isArray(value) && value.every(isDeckCardRef)
+}
+
+export function isDeckContents(value: unknown): value is DeckContents {
+  if (
+    !isRecord(value) ||
+    !isDeckCardRef(value.leader) ||
+    !isDeckCardRef(value.base) ||
+    !isDeckCardRefArray(value.mainDeck) ||
+    !isDeckCardRefArray(value.sideboard)
+  ) {
+    return false
+  }
+  return value.secondLeader === undefined || isDeckCardRef(value.secondLeader)
+}
+
+export function parseDeckContents(payload: unknown): DeckContents {
+  if (!isDeckContents(payload)) throw new Error('Invalid deck contents payload.')
+  return {
+    leader: payload.leader,
+    secondLeader: payload.secondLeader,
+    base: payload.base,
+    mainDeck: payload.mainDeck,
+    sideboard: payload.sideboard,
+  }
+}
+
+export function allCardRefs(contents: DeckContents): DeckCardRef[] {
+  const refs = [contents.leader, contents.base, ...contents.mainDeck, ...contents.sideboard]
+  if (contents.secondLeader) refs.push(contents.secondLeader)
+  return refs
+}
+
+export type OwnedTotals = Record<SetKey, Record<number, number>>
+
+/** Adds `contents` (multiplied by `multiplier`, e.g. copies owned) into a running owned-cards total. Uncapped — physical/precon copies aren't subject to the binder's playset quota. */
+export function addDeckContentsToTotals(
+  totals: OwnedTotals,
+  contents: DeckContents,
+  multiplier: number,
+): void {
+  if (multiplier <= 0) return
+  for (const ref of allCardRefs(contents)) {
+    const bucket = totals[ref.setKey] ?? (totals[ref.setKey] = {})
+    bucket[ref.baseNumber] = (bucket[ref.baseNumber] ?? 0) + ref.count * multiplier
+  }
+}

--- a/src/core/deckSync.test.ts
+++ b/src/core/deckSync.test.ts
@@ -1,0 +1,234 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createDeckSync, type BroadcastPayload, type DeckSync, type DeckSyncEvent } from './deckSync'
+import type { DeckLibrary } from './decks'
+
+function memoryStorage(): Storage {
+  const map = new Map<string, string>()
+  return {
+    get length() {
+      return map.size
+    },
+    clear: () => map.clear(),
+    getItem: (k: string) => (map.has(k) ? map.get(k)! : null),
+    key: (i: number) => Array.from(map.keys())[i] ?? null,
+    removeItem: (k: string) => {
+      map.delete(k)
+    },
+    setItem: (k: string, v: string) => {
+      map.set(k, String(v))
+    },
+  }
+}
+
+type FetchStep = { status: number; json?: unknown }
+
+function makeFetch(steps: FetchStep[]) {
+  const calls: Array<{ url: string; init?: RequestInit }> = []
+  let i = 0
+  const fetchFn = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    calls.push({ url, init })
+    const step = steps[i++]
+    if (!step) throw new Error(`unexpected fetch: ${url}`)
+    return {
+      ok: step.status >= 200 && step.status < 300,
+      status: step.status,
+      json: async () => step.json ?? {},
+    } as unknown as Response
+  })
+  return { fetchFn, calls }
+}
+
+function fakeBroadcast() {
+  let handler: ((payload: BroadcastPayload) => void) | null = null
+  const posted: BroadcastPayload[] = []
+  return {
+    posted,
+    api: {
+      postMessage: (event: BroadcastPayload) => {
+        posted.push(event)
+      },
+      onMessage: (fn: (payload: BroadcastPayload) => void) => {
+        handler = fn
+        return () => {
+          handler = null
+        }
+      },
+    },
+    deliver: (payload: BroadcastPayload) => handler?.(payload),
+  }
+}
+
+const library: DeckLibrary = { customDecks: [], preconOwnership: { 'SOR-heroism': 1 } }
+
+let sync: DeckSync | null = null
+
+afterEach(() => {
+  sync?.dispose()
+  sync = null
+})
+
+describe('deckSync', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('debounces push and clears pending on success', async () => {
+    const storage = memoryStorage()
+    const { fetchFn, calls } = makeFetch([{ status: 200, json: { version: 1 } }])
+    sync = createDeckSync({ storage, fetch: fetchFn })
+    sync.setSignedIn(true)
+
+    sync.scheduleSync({ ...library, preconOwnership: { a: 1 } })
+    sync.scheduleSync({ ...library, preconOwnership: { a: 1, b: 1 } })
+
+    await vi.advanceTimersByTimeAsync(1000)
+    await vi.runOnlyPendingTimersAsync()
+
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+    const body = JSON.parse((calls[0]!.init!.body as string) || '{}')
+    expect(body).toEqual({ data: { customDecks: [], preconOwnership: { a: 1, b: 1 } } })
+
+    const state = sync.getState()
+    expect(state.pending).toBeNull()
+    expect(state.version).toBe(1)
+  })
+
+  it('persists pending edit when offline and flushes after signIn', async () => {
+    const storage = memoryStorage()
+    const { fetchFn } = makeFetch([{ status: 200, json: { version: 1 } }])
+    sync = createDeckSync({ storage, fetch: fetchFn })
+
+    sync.scheduleSync(library)
+    expect(sync.getState().pending).toEqual(library)
+    expect(fetchFn).not.toHaveBeenCalled()
+
+    sync.setSignedIn(true)
+    await vi.runOnlyPendingTimersAsync()
+    await Promise.resolve()
+
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+    expect(sync.getState().pending).toBeNull()
+  })
+
+  it('emits signout event and stops pushing on 401', async () => {
+    const storage = memoryStorage()
+    const { fetchFn } = makeFetch([{ status: 401 }])
+    sync = createDeckSync({ storage, fetch: fetchFn })
+    const events: DeckSyncEvent[] = []
+    sync.subscribe(e => events.push(e))
+    sync.setSignedIn(true)
+
+    sync.scheduleSync(library)
+    await vi.advanceTimersByTimeAsync(1000)
+    await vi.runOnlyPendingTimersAsync()
+
+    expect(events.some(e => e.type === 'signout')).toBe(true)
+    expect(sync.getState().pending).toEqual(library)
+  })
+
+  it('applies server version on 409 and calls onLocalApply', async () => {
+    const storage = memoryStorage()
+    const serverLibrary: DeckLibrary = { customDecks: [], preconOwnership: { c: 1 } }
+    const { fetchFn } = makeFetch([
+      { status: 409, json: { current: { data: serverLibrary, version: 7 } } },
+    ])
+    const onLocalApply = vi.fn()
+    sync = createDeckSync({ storage, fetch: fetchFn, onLocalApply })
+    const events: DeckSyncEvent[] = []
+    sync.subscribe(e => events.push(e))
+    sync.setSignedIn(true)
+
+    sync.scheduleSync(library)
+    await vi.advanceTimersByTimeAsync(1000)
+    await vi.runOnlyPendingTimersAsync()
+
+    expect(onLocalApply).toHaveBeenCalledWith(serverLibrary)
+    expect(sync.getState().version).toBe(7)
+    expect(sync.getState().pending).toBeNull()
+    expect(events.some(e => e.type === 'pulled')).toBe(true)
+  })
+
+  it('retries with backoff on 5xx and reports error after 3 attempts', async () => {
+    const storage = memoryStorage()
+    const { fetchFn } = makeFetch([{ status: 500 }, { status: 500 }, { status: 500 }])
+    sync = createDeckSync({ storage, fetch: fetchFn })
+    const errors: DeckSyncEvent[] = []
+    sync.subscribe(e => {
+      if (e.type === 'error') errors.push(e)
+    })
+    sync.setSignedIn(true)
+
+    sync.scheduleSync(library)
+    await vi.advanceTimersByTimeAsync(1000)
+    await vi.advanceTimersByTimeAsync(1000)
+    await vi.advanceTimersByTimeAsync(2000)
+
+    expect(fetchFn).toHaveBeenCalledTimes(3)
+    expect(errors.length).toBeGreaterThanOrEqual(1)
+    const last = errors[errors.length - 1]!
+    if (last.type === 'error') expect(last.consecutive).toBeGreaterThanOrEqual(3)
+  })
+
+  it('applies broadcast messages from other tabs', () => {
+    const storage = memoryStorage()
+    const { fetchFn } = makeFetch([])
+    const bc = fakeBroadcast()
+    const onLocalApply = vi.fn()
+    sync = createDeckSync({ storage, fetch: fetchFn, broadcast: bc.api, onLocalApply })
+    sync.setSignedIn(true)
+
+    bc.deliver({ type: 'pushed', data: library, version: 4 })
+    expect(onLocalApply).toHaveBeenCalledWith(library)
+    expect(sync.getState().version).toBe(4)
+  })
+
+  it('pull returns server state and updates the local version', async () => {
+    const storage = memoryStorage()
+    const { fetchFn } = makeFetch([
+      { status: 200, json: { data: library, version: 2, updatedAt: 100 } },
+    ])
+    sync = createDeckSync({ storage, fetch: fetchFn })
+    sync.setSignedIn(true)
+
+    const result = await sync.pull()
+    expect(result).toEqual({ data: library, version: 2 })
+    expect(sync.getState().version).toBe(2)
+  })
+
+  it('pull returns null and signs out on 401', async () => {
+    const storage = memoryStorage()
+    const { fetchFn } = makeFetch([{ status: 401 }])
+    sync = createDeckSync({ storage, fetch: fetchFn })
+    const events: DeckSyncEvent[] = []
+    sync.subscribe(e => events.push(e))
+    sync.setSignedIn(true)
+
+    const result = await sync.pull()
+    expect(result).toBeNull()
+    expect(events.some(e => e.type === 'signout')).toBe(true)
+  })
+
+  it('pull returns null when signed out', async () => {
+    const storage = memoryStorage()
+    const { fetchFn } = makeFetch([])
+    sync = createDeckSync({ storage, fetch: fetchFn })
+
+    expect(await sync.pull()).toBeNull()
+    expect(fetchFn).not.toHaveBeenCalled()
+  })
+
+  it('starts with an empty pending/version state and no-ops flushDirty when nothing pending', async () => {
+    const storage = memoryStorage()
+    const { fetchFn } = makeFetch([])
+    sync = createDeckSync({ storage, fetch: fetchFn })
+    sync.setSignedIn(true)
+    expect(sync.getState()).toEqual({ version: 0, pending: null })
+    await sync.flushDirty()
+    expect(fetchFn).not.toHaveBeenCalled()
+  })
+})

--- a/src/core/deckSync.ts
+++ b/src/core/deckSync.ts
@@ -1,0 +1,271 @@
+import { emptyDeckLibrary, type DeckLibrary } from './decks'
+
+export type DeckSyncStatus = 'off' | 'idle' | 'pushing' | 'error' | 'offline'
+
+export type DeckSyncEvent =
+  | { type: 'pulled'; data: DeckLibrary; version: number }
+  | { type: 'pushed'; version: number }
+  | { type: 'signout' }
+  | { type: 'status'; status: DeckSyncStatus }
+  | { type: 'error'; consecutive: number; message: string }
+
+export type DeckSyncListener = (event: DeckSyncEvent) => void
+
+export type DeckSyncState = {
+  version: number
+  pending: DeckLibrary | null
+}
+
+const STATE_KEY = 'deckSync:state'
+const RETRY_MS = [1000, 2000, 5000, 15000, 60000] as const
+const DEBOUNCE_MS = 1000
+
+const emptyState: DeckSyncState = { version: 0, pending: null }
+
+function readState(storage: Pick<Storage, 'getItem'>): DeckSyncState {
+  try {
+    const raw = storage.getItem(STATE_KEY)
+    if (!raw) return { ...emptyState }
+    const parsed = JSON.parse(raw) as Partial<DeckSyncState>
+    return { version: parsed.version ?? 0, pending: parsed.pending ?? null }
+  } catch {
+    return { ...emptyState }
+  }
+}
+
+function writeState(storage: Pick<Storage, 'setItem'>, state: DeckSyncState): void {
+  try {
+    storage.setItem(STATE_KEY, JSON.stringify(state))
+  } catch {
+    // If storage is full or blocked, we lose the sync intent — nothing to do.
+  }
+}
+
+export type DeckSyncDeps = {
+  storage: Storage
+  fetch: typeof fetch
+  now?: () => number
+  setTimeoutFn?: (fn: () => void, ms: number) => number
+  clearTimeoutFn?: (id: number) => void
+  broadcast?: {
+    postMessage: (event: BroadcastPayload) => void
+    onMessage: (handler: (event: BroadcastPayload) => void) => () => void
+  } | null
+  onLocalApply?: (data: DeckLibrary) => void
+}
+
+export type BroadcastPayload =
+  | { type: 'pushed'; data: DeckLibrary; version: number }
+  | { type: 'pulled'; data: DeckLibrary; version: number }
+
+export type DeckSync = ReturnType<typeof createDeckSync>
+
+export function createDeckSync(deps: DeckSyncDeps) {
+  const now = deps.now ?? (() => Date.now())
+  const schedule = deps.setTimeoutFn ?? ((fn: () => void, ms: number) =>
+    (setTimeout(fn, ms) as unknown) as number)
+  const cancel = deps.clearTimeoutFn ?? ((id: number) => clearTimeout(id))
+
+  const listeners = new Set<DeckSyncListener>()
+  let debounceTimer: number | null = null
+  let retryTimer: number | null = null
+  let retryAttempt = 0
+  let inFlight = false
+
+  let signedIn = false
+  let currentStatus: DeckSyncStatus = 'off'
+
+  const bcUnsub = deps.broadcast?.onMessage(handleBroadcast)
+
+  function emit(event: DeckSyncEvent) {
+    for (const listener of listeners) listener(event)
+  }
+
+  function setStatus(next: DeckSyncStatus) {
+    if (next === currentStatus) return
+    currentStatus = next
+    emit({ type: 'status', status: next })
+  }
+
+  function subscribe(listener: DeckSyncListener): () => void {
+    listeners.add(listener)
+    return () => {
+      listeners.delete(listener)
+    }
+  }
+
+  function getState(): DeckSyncState {
+    return readState(deps.storage)
+  }
+
+  function mutate(patch: (s: DeckSyncState) => DeckSyncState): DeckSyncState {
+    const next = patch(readState(deps.storage))
+    writeState(deps.storage, next)
+    return next
+  }
+
+  function setSignedIn(value: boolean): void {
+    signedIn = value
+    if (!value) {
+      setStatus('off')
+      return
+    }
+    setStatus('idle')
+    flushDirty().catch(() => {
+      /* errors surface via events */
+    })
+  }
+
+  function scheduleSync(data: DeckLibrary): void {
+    const snapshot = { customDecks: [...data.customDecks], preconOwnership: { ...data.preconOwnership } }
+    mutate(s => ({ ...s, pending: snapshot }))
+    if (debounceTimer != null) cancel(debounceTimer)
+    if (!signedIn) return
+    debounceTimer = schedule(() => {
+      debounceTimer = null
+      void push().catch(() => {})
+    }, DEBOUNCE_MS)
+  }
+
+  async function push(): Promise<void> {
+    if (!signedIn) return
+    if (inFlight) return
+    const state = readState(deps.storage)
+    const data = state.pending
+    if (!data) return
+    inFlight = true
+    setStatus('pushing')
+    const version = state.version
+    try {
+      const res = await deps.fetch('/api/decks', {
+        method: 'PUT',
+        credentials: 'include',
+        headers: {
+          'content-type': 'application/json',
+          'if-match': String(version),
+        },
+        body: JSON.stringify({ data }),
+      })
+      if (res.status === 401) {
+        signedIn = false
+        setStatus('off')
+        emit({ type: 'signout' })
+        return
+      }
+      if (res.status === 409) {
+        const body = await res.json().catch(() => ({}))
+        const current = body?.current as { data?: DeckLibrary; version?: number } | undefined
+        if (current && typeof current.version === 'number') {
+          applyServerVersion(current.data ?? emptyDeckLibrary, current.version)
+        }
+        retryAttempt = 0
+        setStatus('idle')
+        return
+      }
+      if (res.status >= 500) {
+        throw new Error(`sync_5xx_${res.status}`)
+      }
+      if (!res.ok) {
+        throw new Error(`sync_failed_${res.status}`)
+      }
+      const body = (await res.json()) as { version: number }
+      mutate(s => ({ ...s, pending: null, version: body.version }))
+      retryAttempt = 0
+      setStatus('idle')
+      emit({ type: 'pushed', version: body.version })
+      deps.broadcast?.postMessage({ type: 'pushed', data, version: body.version })
+    } catch (err) {
+      retryAttempt += 1
+      const delay = RETRY_MS[Math.min(retryAttempt - 1, RETRY_MS.length - 1)] ?? RETRY_MS[RETRY_MS.length - 1]!
+      if (retryTimer != null) cancel(retryTimer)
+      retryTimer = schedule(() => {
+        retryTimer = null
+        void push().catch(() => {})
+      }, delay)
+      setStatus('error')
+      if (retryAttempt >= 3) {
+        emit({
+          type: 'error',
+          consecutive: retryAttempt,
+          message: err instanceof Error ? err.message : 'sync_error',
+        })
+      }
+    } finally {
+      inFlight = false
+    }
+  }
+
+  function applyServerVersion(data: DeckLibrary, version: number): void {
+    mutate(s => ({ ...s, pending: null, version }))
+    deps.onLocalApply?.(data)
+    emit({ type: 'pulled', data, version })
+    deps.broadcast?.postMessage({ type: 'pulled', data, version })
+  }
+
+  async function pull(): Promise<{ data: DeckLibrary; version: number } | null> {
+    if (!signedIn) return null
+    const res = await deps.fetch('/api/decks', {
+      method: 'GET',
+      credentials: 'include',
+    })
+    if (res.status === 401) {
+      signedIn = false
+      setStatus('off')
+      emit({ type: 'signout' })
+      return null
+    }
+    if (!res.ok) return null
+    const body = (await res.json()) as { data: DeckLibrary; version: number; updatedAt: number }
+    mutate(s => ({ ...s, version: body.version }))
+    return { data: body.data, version: body.version }
+  }
+
+  async function flushDirty(): Promise<void> {
+    if (!signedIn) return
+    if (readState(deps.storage).pending) await push().catch(() => {})
+  }
+
+  function handleBroadcast(payload: BroadcastPayload): void {
+    if (payload.type !== 'pushed' && payload.type !== 'pulled') return
+    mutate(s => ({ ...s, pending: null, version: payload.version }))
+    deps.onLocalApply?.(payload.data)
+    emit({ type: 'pulled', data: payload.data, version: payload.version })
+  }
+
+  function dispose(): void {
+    if (debounceTimer != null) cancel(debounceTimer)
+    if (retryTimer != null) cancel(retryTimer)
+    debounceTimer = null
+    retryTimer = null
+    listeners.clear()
+    bcUnsub?.()
+  }
+
+  function status(): DeckSyncStatus {
+    return currentStatus
+  }
+
+  return {
+    subscribe,
+    scheduleSync,
+    pull,
+    flushDirty,
+    setSignedIn,
+    getState,
+    status,
+    dispose,
+  }
+}
+
+export function makeDeckBroadcast(): DeckSyncDeps['broadcast'] {
+  if (typeof BroadcastChannel === 'undefined') return null
+  const channel = new BroadcastChannel('swu-deck-sync')
+  return {
+    postMessage: event => channel.postMessage(event),
+    onMessage: handler => {
+      const listener = (ev: MessageEvent<BroadcastPayload>) => handler(ev.data)
+      channel.addEventListener('message', listener)
+      return () => channel.removeEventListener('message', listener)
+    },
+  }
+}

--- a/src/core/decklist.test.ts
+++ b/src/core/decklist.test.ts
@@ -338,6 +338,27 @@ describe('parseDeckGeneric', () => {
     expect(parsed.entries).toEqual([])
     expect(parsed.malformed).toEqual(['no count here'])
   })
+
+  it('parses the compact "qtyxSET_NUM" id shorthand with no space', () => {
+    const parsed = parseDeckGeneric('3xASH_140')
+    expect(parsed.entries).toEqual([
+      { role: 'deck', name: 'ASH_140', count: 3, exact: { setKey: 'ASH', printingNumber: 140 } },
+    ])
+    expect(parsed.malformed).toEqual([])
+  })
+
+  it('parses several compact id lines, one per line', () => {
+    const parsed = parseDeckGeneric('1xASH_010\n2xJTL_019')
+    expect(parsed.entries).toEqual([
+      { role: 'deck', name: 'ASH_010', count: 1, exact: { setKey: 'ASH', printingNumber: 10 } },
+      { role: 'deck', name: 'JTL_019', count: 2, exact: { setKey: 'JTL', printingNumber: 19 } },
+    ])
+  })
+
+  it('does not let the compact id shorthand swallow an ordinary "3x Card Name" line', () => {
+    const parsed = parseDeckGeneric('3x Vanquish')
+    expect(parsed.entries).toEqual([{ role: 'deck', name: 'Vanquish', subtitle: undefined, count: 3, setHint: undefined }])
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -501,6 +522,45 @@ describe('resolveDeckList', () => {
     const second = resolution.rows.find(r => r.baseNumber === 501)
     expect(first?.role).toBe('leader')
     expect(second?.role).toBe('base')
+  })
+
+  it('auto-promotes Leader/Base-typed cards out of a generic plain list, since it has no sections', () => {
+    const resolution = resolveDeckList(
+      {
+        format: 'generic',
+        entries: [
+          { role: 'deck', name: 'ASH_010', count: 1, exact: { setKey: 'ASH', printingNumber: 10 } },
+          { role: 'deck', name: 'JTL_019', count: 1, exact: { setKey: 'JTL', printingNumber: 19 } },
+          { role: 'deck', name: 'ASH_140', count: 2, exact: { setKey: 'ASH', printingNumber: 140 } },
+        ],
+        malformed: [],
+      },
+      CATALOG,
+      PARSED_SETS,
+      TRACKED_SET_KEYS,
+      NO_OWNERSHIP,
+    )
+    const leader = resolution.rows.find(r => r.baseNumber === 10)
+    const base = resolution.rows.find(r => r.baseNumber === 19)
+    const unit = resolution.rows.find(r => r.baseNumber === 140)
+    expect(leader?.role).toBe('leader')
+    expect(base?.role).toBe('base')
+    expect(unit?.role).toBe('deck')
+  })
+
+  it('does not promote Leader/Base-typed cards for non-generic formats — they must use explicit sections', () => {
+    const resolution = resolveDeckList(
+      {
+        format: 'melee',
+        entries: [{ role: 'deck', name: 'ASH_010', count: 1, exact: { setKey: 'ASH', printingNumber: 10 } }],
+        malformed: [],
+      },
+      CATALOG,
+      PARSED_SETS,
+      TRACKED_SET_KEYS,
+      NO_OWNERSHIP,
+    )
+    expect(resolution.rows[0].role).toBe('deck')
   })
 
   it('surfaces malformed parser lines in the unresolved list', () => {

--- a/src/core/decklist.ts
+++ b/src/core/decklist.ts
@@ -316,6 +316,8 @@ export function parseDeckPicklist(text: string): ParsedDeckList {
 const TRAILING_SET = /[([]([A-Za-z0-9]{2,6})[)\]]\s*$/
 const QTY_NAME = /^(\d+)\s*x?\s+(.+)$/i
 const NAME_SUBTITLE = /^(.*?)\s[-–]\s(.*)$/
+/** Compact "3xSET_042" shorthand — no space, so it can't be confused with a "3x Card Name" line. */
+const QTY_EXACT_ID = /^(\d+)x([A-Za-z0-9]{2,6})_(\d+)$/i
 
 export function parseDeckGeneric(text: string): ParsedDeckList {
   const lines = text.split(/\r\n|\r|\n/)
@@ -325,6 +327,22 @@ export function parseDeckGeneric(text: string): ParsedDeckList {
   for (const rawLine of lines) {
     const line = rawLine.trim()
     if (!line) continue
+
+    const idMatch = QTY_EXACT_ID.exec(line)
+    if (idMatch) {
+      const count = Number(idMatch[1])
+      const setKey = idMatch[2].toUpperCase()
+      const printingNumber = Number(idMatch[3])
+      if (Number.isFinite(count) && count > 0 && Number.isInteger(printingNumber) && printingNumber > 0) {
+        entries.push({
+          role: 'deck',
+          name: `${setKey}_${idMatch[3]}`,
+          count,
+          exact: { setKey, printingNumber },
+        })
+        continue
+      }
+    }
 
     let working = line
     let setHint: SetKey | undefined
@@ -513,6 +531,11 @@ export function resolveDeckList(
       else if (cardType === 'leader') role = 'leader'
       else role = leaderBaseOrdinal === 0 ? 'leader' : 'base'
       leaderBaseOrdinal++
+    } else if (entry.role === 'deck' && parsed.format === 'generic') {
+      // The generic format has no leader/base sections at all — a plain "one card per line"
+      // list is the only place a Leader/Base card can otherwise never be recognized as such.
+      const cardType = (resolved.card.Type ?? '').trim().toLowerCase()
+      role = cardType === 'leader' ? 'leader' : cardType === 'base' ? 'base' : 'deck'
     } else {
       role = entry.role
     }

--- a/src/core/decks.test.ts
+++ b/src/core/decks.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createSavedDeck,
+  deriveOwnedTotals,
+  emptyDeckLibrary,
+  loadDeckLibrary,
+  parseDeckLibrary,
+  persistDeckLibrary,
+  type DeckLibrary,
+  type SavedDeck,
+} from './decks';
+import type { ResolvedDeckRow } from './decklist';
+import type { PreconCatalogEntry } from './precons';
+
+function row(partial: Partial<ResolvedDeckRow> & Pick<ResolvedDeckRow, 'role' | 'setKey' | 'baseNumber' | 'count'>): ResolvedDeckRow {
+  return { name: 'Card', price: 0, ambiguous: false, ...partial };
+}
+
+function fakeStorage(initial: Record<string, string> = {}) {
+  const store = new Map(Object.entries(initial));
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+  };
+}
+
+describe('createSavedDeck', () => {
+  const validRows: ResolvedDeckRow[] = [
+    row({ role: 'leader', setKey: 'SOR', baseNumber: 1, count: 1 }),
+    row({ role: 'base', setKey: 'SOR', baseNumber: 2, count: 1 }),
+    row({ role: 'deck', setKey: 'SOR', baseNumber: 3, count: 3 }),
+  ];
+
+  it('fails when rows have no leader/base', () => {
+    const result = createSavedDeck([], { name: 'x', physical: false, copies: 1, sourceText: '' });
+    expect(result).toEqual({ ok: false, reason: 'missing-leader' });
+  });
+
+  it('builds a SavedDeck with generated id/timestamps and trimmed name', () => {
+    const result = createSavedDeck(validRows, { name: '  My Deck  ', physical: true, copies: 2, sourceText: 'raw' }, {
+      now: () => '2026-07-29T00:00:00.000Z',
+      makeId: () => 'deck-1',
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.deck).toEqual({
+      id: 'deck-1',
+      name: 'My Deck',
+      createdAt: '2026-07-29T00:00:00.000Z',
+      updatedAt: '2026-07-29T00:00:00.000Z',
+      physical: true,
+      copies: 2,
+      sourceText: 'raw',
+      leader: { setKey: 'SOR', baseNumber: 1, count: 1 },
+      secondLeader: undefined,
+      base: { setKey: 'SOR', baseNumber: 2, count: 1 },
+      mainDeck: [{ setKey: 'SOR', baseNumber: 3, count: 3 }],
+      sideboard: [],
+    });
+  });
+
+  it('defaults an untitled name and floors/clamps copies to at least 1', () => {
+    const result = createSavedDeck(validRows, { name: '   ', physical: false, copies: 0, sourceText: '' });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.deck.name).toBe('Untitled deck');
+    expect(result.deck.copies).toBe(1);
+  });
+});
+
+describe('deriveOwnedTotals', () => {
+  const preconCatalog: PreconCatalogEntry[] = [
+    {
+      key: 'SOR-heroism',
+      label: 'SOR Heroism',
+      setKey: 'SOR',
+      aspect: 'Heroism',
+      file: 'SOR-heroism.json',
+      contents: {
+        leader: { setKey: 'SOR', baseNumber: 1, count: 1 },
+        base: { setKey: 'SOR', baseNumber: 2, count: 1 },
+        mainDeck: [{ setKey: 'SOR', baseNumber: 3, count: 3 }],
+        sideboard: [],
+      },
+    },
+  ];
+
+  const physicalDeck: SavedDeck = {
+    id: 'd1',
+    name: 'Boxed deck',
+    createdAt: '',
+    updatedAt: '',
+    physical: true,
+    copies: 1,
+    sourceText: '',
+    leader: { setKey: 'JTL', baseNumber: 10, count: 1 },
+    base: { setKey: 'JTL', baseNumber: 11, count: 1 },
+    mainDeck: [{ setKey: 'JTL', baseNumber: 12, count: 2 }],
+    sideboard: [],
+  };
+
+  const referenceDeck: SavedDeck = { ...physicalDeck, id: 'd2', physical: false };
+
+  it('contributes nothing when nothing is owned or physical', () => {
+    const totals = deriveOwnedTotals({ customDecks: [referenceDeck], preconOwnership: {} }, preconCatalog);
+    expect(totals).toEqual({});
+  });
+
+  it('sums owned precon contents', () => {
+    const totals = deriveOwnedTotals({ customDecks: [], preconOwnership: { 'SOR-heroism': 1 } }, preconCatalog);
+    expect(totals).toEqual({ SOR: { 1: 1, 2: 1, 3: 3 } });
+  });
+
+  it('sums physical custom decks but ignores reference decks', () => {
+    const library: DeckLibrary = {
+      customDecks: [physicalDeck, referenceDeck],
+      preconOwnership: {},
+    };
+    const totals = deriveOwnedTotals(library, preconCatalog);
+    expect(totals).toEqual({ JTL: { 10: 1, 11: 1, 12: 2 } });
+  });
+
+  it('combines precon ownership and physical decks across sets', () => {
+    const library: DeckLibrary = {
+      customDecks: [physicalDeck],
+      preconOwnership: { 'SOR-heroism': 1 },
+    };
+    const totals = deriveOwnedTotals(library, preconCatalog);
+    expect(totals).toEqual({
+      SOR: { 1: 1, 2: 1, 3: 3 },
+      JTL: { 10: 1, 11: 1, 12: 2 },
+    });
+  });
+});
+
+describe('parseDeckLibrary / persistence', () => {
+  it('returns an empty library for null/invalid input', () => {
+    expect(parseDeckLibrary(null)).toEqual(emptyDeckLibrary);
+    expect(parseDeckLibrary('not json')).toEqual(emptyDeckLibrary);
+    expect(parseDeckLibrary('[]')).toEqual(emptyDeckLibrary);
+  });
+
+  it('filters out malformed saved decks but keeps valid ones', () => {
+    const valid: SavedDeck = {
+      id: 'd1',
+      name: 'Valid',
+      createdAt: '',
+      updatedAt: '',
+      physical: false,
+      copies: 1,
+      sourceText: '',
+      leader: { setKey: 'SOR', baseNumber: 1, count: 1 },
+      base: { setKey: 'SOR', baseNumber: 2, count: 1 },
+      mainDeck: [],
+      sideboard: [],
+    };
+    const raw = JSON.stringify({
+      customDecks: [valid, { id: 'bad' }],
+      preconOwnership: { 'SOR-heroism': 1, bad: 'x' },
+    });
+    expect(parseDeckLibrary(raw)).toEqual({ customDecks: [valid], preconOwnership: {} });
+  });
+
+  it('round-trips through loadDeckLibrary/persistDeckLibrary', () => {
+    const storage = fakeStorage();
+    const library: DeckLibrary = { customDecks: [], preconOwnership: { 'SOR-heroism': 1 } };
+    expect(persistDeckLibrary(storage, library)).toBe(true);
+    expect(loadDeckLibrary(storage)).toEqual(library);
+  });
+
+  it('loadDeckLibrary recovers to empty on a storage read error', () => {
+    const storage = {
+      getItem: () => {
+        throw new Error('boom');
+      },
+    };
+    expect(loadDeckLibrary(storage)).toEqual(emptyDeckLibrary);
+  });
+});

--- a/src/core/decks.ts
+++ b/src/core/decks.ts
@@ -1,0 +1,143 @@
+import type { ResolvedDeckRow } from './decklist'
+import {
+  addDeckContentsToTotals,
+  deckContentsFromRows,
+  isDeckContents,
+  type DeckContents,
+  type OwnedTotals,
+} from './deckContents'
+import type { PreconCatalogEntry } from './precons'
+
+export type SavedDeck = DeckContents & {
+  id: string
+  name: string
+  createdAt: string
+  updatedAt: string
+  /** True = these are real extra cards not already counted in the binder (e.g. a fully-built/boxed deck). */
+  physical: boolean
+  /** Physical copies owned; only meaningful when `physical` is true. */
+  copies: number
+  /** Original pasted text, kept so the deck can be re-parsed/edited later. */
+  sourceText: string
+}
+
+export type DeckLibrary = {
+  customDecks: SavedDeck[]
+  /** precon catalog key -> owned copies (0 or 1 in practice). */
+  preconOwnership: Record<string, number>
+}
+
+export const DECKS_STORAGE_KEY = 'decks:v1'
+
+export const emptyDeckLibrary: DeckLibrary = { customDecks: [], preconOwnership: {} }
+
+export type NewSavedDeckInput = {
+  name: string
+  physical: boolean
+  copies: number
+  sourceText: string
+}
+
+export type CreateSavedDeckResult =
+  | { ok: true; deck: SavedDeck }
+  | { ok: false; reason: 'missing-leader' | 'missing-base' }
+
+export function createSavedDeck(
+  rows: ResolvedDeckRow[],
+  input: NewSavedDeckInput,
+  deps: { now?: () => string; makeId?: () => string } = {},
+): CreateSavedDeckResult {
+  const now = deps.now ?? (() => new Date().toISOString())
+  const makeId = deps.makeId ?? (() => crypto.randomUUID())
+  const contentsResult = deckContentsFromRows(rows)
+  if (!contentsResult.ok) return { ok: false, reason: contentsResult.reason }
+
+  const timestamp = now()
+  return {
+    ok: true,
+    deck: {
+      ...contentsResult.contents,
+      id: makeId(),
+      name: input.name.trim() || 'Untitled deck',
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      physical: input.physical,
+      copies: Math.max(1, Math.floor(input.copies) || 1),
+      sourceText: input.sourceText,
+    },
+  }
+}
+
+/** Owned totals contributed by the deck library: owned precons + physical custom decks, uncapped. */
+export function deriveOwnedTotals(
+  library: DeckLibrary,
+  preconCatalog: PreconCatalogEntry[],
+): OwnedTotals {
+  const totals: OwnedTotals = {}
+
+  for (const entry of preconCatalog) {
+    const owned = library.preconOwnership[entry.key] ?? 0
+    addDeckContentsToTotals(totals, entry.contents, owned)
+  }
+
+  for (const deck of library.customDecks) {
+    if (!deck.physical) continue
+    addDeckContentsToTotals(totals, deck, deck.copies)
+  }
+
+  return totals
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+function isSavedDeck(value: unknown): value is SavedDeck {
+  if (!isRecord(value) || !isDeckContents(value)) return false
+  const v = value as Record<string, unknown>
+  return (
+    typeof v.id === 'string' &&
+    typeof v.name === 'string' &&
+    typeof v.createdAt === 'string' &&
+    typeof v.updatedAt === 'string' &&
+    typeof v.physical === 'boolean' &&
+    Number.isFinite(v.copies) &&
+    typeof v.sourceText === 'string'
+  )
+}
+
+function isPreconOwnership(value: unknown): value is Record<string, number> {
+  return isRecord(value) && Object.values(value).every(v => typeof v === 'number' && Number.isFinite(v))
+}
+
+export function parseDeckLibrary(raw: string | null): DeckLibrary {
+  if (!raw) return { ...emptyDeckLibrary }
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (!isRecord(parsed)) return { ...emptyDeckLibrary }
+    const customDecks = Array.isArray(parsed.customDecks)
+      ? parsed.customDecks.filter(isSavedDeck)
+      : []
+    const preconOwnership = isPreconOwnership(parsed.preconOwnership) ? parsed.preconOwnership : {}
+    return { customDecks, preconOwnership }
+  } catch {
+    return { ...emptyDeckLibrary }
+  }
+}
+
+export function loadDeckLibrary(storage: Pick<Storage, 'getItem'>): DeckLibrary {
+  try {
+    return parseDeckLibrary(storage.getItem(DECKS_STORAGE_KEY))
+  } catch {
+    return { ...emptyDeckLibrary }
+  }
+}
+
+export function persistDeckLibrary(storage: Pick<Storage, 'setItem'>, library: DeckLibrary): boolean {
+  try {
+    storage.setItem(DECKS_STORAGE_KEY, JSON.stringify(library))
+    return true
+  } catch {
+    return false
+  }
+}

--- a/src/core/precons.test.ts
+++ b/src/core/precons.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  fetchPreconCatalog,
+  fetchPreconEntry,
+  fetchPreconManifest,
+  parsePreconContents,
+  parsePreconManifest,
+  type PreconManifestEntry,
+} from './precons';
+
+function response(body: unknown, ok = true): Response {
+  return { ok, json: async () => body } as Response;
+}
+
+const manifestEntry: PreconManifestEntry = {
+  key: 'SOR-heroism',
+  label: 'Spark of Rebellion — Heroism',
+  setKey: 'SOR',
+  aspect: 'Heroism',
+  file: 'SOR-heroism.json',
+};
+
+const validContents = {
+  leader: { setKey: 'SOR', baseNumber: 1, count: 1 },
+  base: { setKey: 'SOR', baseNumber: 2, count: 1 },
+  mainDeck: [{ setKey: 'SOR', baseNumber: 3, count: 3 }],
+  sideboard: [],
+};
+
+describe('parsePreconManifest', () => {
+  it('rejects a payload without a precons array', () => {
+    expect(() => parsePreconManifest({})).toThrow('Invalid precon manifest');
+  });
+
+  it('filters out malformed entries and keeps valid ones', () => {
+    const result = parsePreconManifest({
+      precons: [manifestEntry, { key: 'bad' }, { ...manifestEntry, aspect: '' }, { ...manifestEntry, aspect: 42 }],
+    });
+    expect(result).toEqual([manifestEntry]);
+  });
+
+  it('accepts a free-text aspect beyond Heroism/Villainy (e.g. Twin Suns dual-leader decks)', () => {
+    const result = parsePreconManifest({
+      precons: [{ ...manifestEntry, key: 'TS26-blood-brothers', aspect: 'Twin Suns' }],
+    });
+    expect(result).toEqual([{ ...manifestEntry, key: 'TS26-blood-brothers', aspect: 'Twin Suns' }]);
+  });
+});
+
+describe('parsePreconContents', () => {
+  it('rejects a payload missing leader/base', () => {
+    expect(() => parsePreconContents({ mainDeck: [], sideboard: [] })).toThrow(
+      'Invalid precon deck',
+    );
+  });
+
+  it('accepts a valid single-leader deck', () => {
+    expect(parsePreconContents(validContents)).toEqual({
+      ...validContents,
+      secondLeader: undefined,
+    });
+  });
+
+  it('accepts a valid second leader for Twin Suns decks', () => {
+    const withSecond = { ...validContents, secondLeader: { setKey: 'TS26', baseNumber: 9, count: 1 } };
+    expect(parsePreconContents(withSecond)).toEqual(withSecond);
+  });
+
+  it('rejects a malformed second leader', () => {
+    expect(() => parsePreconContents({ ...validContents, secondLeader: {} })).toThrow(
+      'Invalid precon deck',
+    );
+  });
+});
+
+describe('fetchPreconManifest / fetchPreconEntry / fetchPreconCatalog', () => {
+  it('throws when the manifest fetch fails', async () => {
+    const fetcher = vi.fn(async () => response({}, false));
+    await expect(fetchPreconManifest(fetcher, '/precons/manifest.json')).rejects.toThrow(
+      'Failed to fetch precon manifest',
+    );
+  });
+
+  it('fetches a single precon entry and merges manifest metadata with contents', async () => {
+    const fetcher = vi.fn(async () => response(validContents));
+    const entry = await fetchPreconEntry(fetcher, manifestEntry);
+    expect(entry).toEqual({ ...manifestEntry, contents: { ...validContents, secondLeader: undefined } });
+    expect(fetcher).toHaveBeenCalledWith('/precons/SOR-heroism.json');
+  });
+
+  it('skips entries that fail to fetch when building the full catalog', async () => {
+    const fetcher = vi.fn(async (url: RequestInfo | URL) => {
+      if (url === '/precons/manifest.json') {
+        return response({ precons: [manifestEntry, { ...manifestEntry, key: 'broken', file: 'missing.json' }] });
+      }
+      if (url === '/precons/missing.json') return response({}, false);
+      return response(validContents);
+    });
+    const catalog = await fetchPreconCatalog(fetcher);
+    expect(catalog).toHaveLength(1);
+    expect(catalog[0]!.key).toBe('SOR-heroism');
+  });
+});

--- a/src/core/precons.ts
+++ b/src/core/precons.ts
@@ -1,0 +1,80 @@
+import type { SetKey } from './types'
+import type { DeckContents } from './deckContents'
+import { parseDeckContents } from './deckContents'
+
+// Free-text label, not a strict enum: most precons are Heroism/Villainy, but some products
+// (e.g. Twin Suns) ship dual-leader decks that don't split cleanly into either.
+export type PreconAspect = string
+
+export type PreconManifestEntry = {
+  key: string
+  label: string
+  setKey: SetKey
+  aspect: PreconAspect
+  file: string
+}
+
+export type PreconCatalogEntry = PreconManifestEntry & { contents: DeckContents }
+
+type Fetcher = (input: RequestInfo | URL) => Promise<Response>
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+export function parsePreconManifest(payload: unknown): PreconManifestEntry[] {
+  if (!isRecord(payload) || !Array.isArray(payload.precons)) {
+    throw new Error('Invalid precon manifest payload.')
+  }
+  return payload.precons.filter((entry): entry is PreconManifestEntry =>
+    isRecord(entry) &&
+    typeof entry.key === 'string' &&
+    typeof entry.label === 'string' &&
+    typeof entry.setKey === 'string' &&
+    typeof entry.aspect === 'string' && entry.aspect.trim().length > 0 &&
+    typeof entry.file === 'string',
+  )
+}
+
+export function parsePreconContents(payload: unknown): DeckContents {
+  try {
+    return parseDeckContents(payload)
+  } catch {
+    throw new Error('Invalid precon deck payload.')
+  }
+}
+
+export async function fetchPreconManifest(
+  fetcher: Fetcher,
+  url = '/precons/manifest.json',
+): Promise<PreconManifestEntry[]> {
+  const response = await fetcher(url)
+  if (!response.ok) throw new Error(`Failed to fetch precon manifest from ${url}.`)
+  return parsePreconManifest(await response.json())
+}
+
+export async function fetchPreconEntry(
+  fetcher: Fetcher,
+  manifestEntry: PreconManifestEntry,
+  baseUrl = '/precons/',
+): Promise<PreconCatalogEntry> {
+  const url = `${baseUrl}${manifestEntry.file}`
+  const response = await fetcher(url)
+  if (!response.ok) throw new Error(`Failed to fetch precon deck from ${url}.`)
+  const contents = parsePreconContents(await response.json())
+  return { ...manifestEntry, contents }
+}
+
+export async function fetchPreconCatalog(
+  fetcher: Fetcher,
+  manifestUrl = '/precons/manifest.json',
+  baseUrl = '/precons/',
+): Promise<PreconCatalogEntry[]> {
+  const manifest = await fetchPreconManifest(fetcher, manifestUrl)
+  const entries = await Promise.allSettled(
+    manifest.map(entry => fetchPreconEntry(fetcher, entry, baseUrl)),
+  )
+  return entries
+    .filter((r): r is PromiseFulfilledResult<PreconCatalogEntry> => r.status === 'fulfilled')
+    .map(r => r.value)
+}


### PR DESCRIPTION
## Summary

- New top-level **Binders / Decks** toggle in the nav bar.
- **Decks** view = two things kept separate from binder inventory but counted as "owned" wherever Deck Check runs:
  - a **precon checklist** — check off which preconstructed decks you own; contents come from static catalog data in `public/precons/` (22 decks: every set's Heroism/Villainy pair plus all four Twin Suns decks)
  - a **personal deck library** — import/save your own decklists (reusing the existing decklist parser), each flagged `physical` (adds to owned totals — e.g. a fully-built boxed deck) or reference-only (doesn't, since those cards are presumably already in your binder)
- **Deck Check**: adds a "Save as Deck" action, plus a Binders-only vs. Binders+Decks toggle controlling whether precon/physical-deck ownership counts toward "owned".
- **Cloud sync**: new `deck_library` server resource (table + `/api/decks` routes), mirroring the existing per-set `inventories` sync engine but as a single versioned blob per user. DB bootstrap bumped from schema v1 → v2 (idempotent — re-running `schema.sql` against an existing v1 DB only adds the new table).
- **`decklist.ts` parser fixes**, needed to parse the real precon decklist exports used to build the catalog data:
  - compact `3xSET_042` id shorthand (no space) as an addition to the existing `3x Card Name` format
  - auto-detect Leader/Base cards by their real card type in the generic plain-list format, which previously had no way to represent a leader/base at all

## Test plan

- [x] `npm test` (client): 175/175 passing
- [x] `npm test` (server): 30/30 passing
- [x] `tsc --noEmit` clean on both client and server
- [x] `npm run build` clean on both
- [x] All 22 `public/precons/*.json` entries verified end-to-end through the app's real parser/resolver (zero unresolved cards)
- [ ] Manual browser click-through — not done from this environment (headless Chromium unavailable in the sandbox this was built in); recommend a pass through the Decks tab, Save-as-Deck flow, and the ownership-scope toggle before/after merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)