### PR TITLE
Clean up top toolbar; fix card-list qty-button click bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -376,20 +376,11 @@
         box-shadow:inset 0 1px 0 rgba(255,255,255,.05);
         pointer-events:none;
       }
-      /* small label above the button group */
-      .toolbar-block{
-        display:flex; flex-direction:column; gap:6px; align-items:flex-end;
-      }
-      .toolbar-label{
-        font-size:12px; color:#c8ccd9; opacity:.9;
-        text-transform:uppercase; letter-spacing:.04em;
-      }
-
       /* --- Top controls row (one source of truth) --- */
       .controls-row{
         /* layout */
         display:flex;
-        align-items:flex-end;           /* keeps select + input + button aligned */
+        align-items:center;
         gap:12px;
 
         /* shared sizing */
@@ -399,6 +390,16 @@
         --keycap-h-pad: 6px;
         --keycap-border: 1px;
         --search-max: 560px; 
+      }
+
+      /* Left cluster (set switcher + search) and right cluster (view/deck/account
+         buttons) each wrap as a single unit, so narrower widths drop to a clean
+         2-row layout instead of every control wrapping to its own line. */
+      .controls-row .left-controls{
+        display:flex; align-items:center; gap:12px;
+        flex: 1 1 480px;
+        flex-wrap: nowrap;   /* stay intact so right-controls wraps first, not this */
+        min-width: 630px;    /* set switcher + search floor, so it doesn't get squeezed */
       }
 
       /* “Set” label — no pill look */
@@ -465,8 +466,26 @@
         outline-offset: 2px;
       }
 
-      /* Right-side controls group sits at the end */
-      .controls-row .toolbar-block{ margin-left:auto; }
+      /* Right-side controls group sits at the end, wraps as one unit */
+      .controls-row .right-controls{
+        display:flex; align-items:center; gap:8px;
+        flex: 0 0 auto;
+        margin-left:auto;
+      }
+      .toolbar-divider{
+        width:1px; align-self:stretch;
+        background:#2b2d3d;
+        margin: 2px 2px;
+      }
+      /* Selected state for tabs/toggles, replacing ad hoc inline styles */
+      .tbtn[aria-selected="true"],
+      .tbtn[aria-pressed="true"]{
+        background:#213c6a; color:#fff;
+      }
+      .tbtn[aria-selected="true"]:hover,
+      .tbtn[aria-pressed="true"]:hover{
+        background:#264576;
+      }
 
       /* Make the “Go” button height match exactly */
       .controls-row .btn{
@@ -474,21 +493,28 @@
         padding-block:0;               /* remove extra vertical padding */
       }
 
-      /* Compact prev/next set switches (not spread / page navigation) */
+      /* Compact prev/next set switches — same dark pill look as .spread-nav-edge
+         (the binder page-turn buttons), just sized to fit the single-row toolbar. */
       .controls-row .set-switch-btn{
         min-width: 36px;
         padding-inline: 8px;
         font-size: 1.35rem;
         font-weight: 700;
         justify-content: center;
-        transition: background-color 0.15s ease-out;
+        border-radius: 999px;
+        border: 1px solid #2b2d3d;
+        background: #11121a;
+        color: #e5e7eb;
+        transition: background-color 0.15s ease-out, box-shadow 0.15s ease-out;
       }
       .controls-row .set-switch-btn:hover:not(:disabled){
-        background-color: #22242c;
+        background: #1a1c28;
+        box-shadow: 0 0 12px rgba(0,0,0,0.35);
       }
       .controls-row .set-switch-btn:disabled{
         opacity: 0.35;
         cursor: not-allowed;
+        box-shadow: none;
       }
       .controls-row .set-switch-btn:focus-visible{
         outline: 2px solid #8b5cf6;
@@ -515,6 +541,7 @@
       }
 
       @media (max-width: 760px) {
+        .controls-row .left-controls { flex-wrap: wrap; min-width: 0; }
         .controls-row .autocomplete { min-width: 100%; }
       }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2195,6 +2195,7 @@ export default function App() {
       <div className="card nav-bar" style={{ marginBottom: 16 }}>
         <h1 className="title">SWU Binder Organizer</h1>
         <div className="row controls-row" style={{ marginTop: 8 }} ref={boxRef}>
+          <div className="left-controls">
           <div
             className="set-switch-group"
             style={{ display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0 }}
@@ -2332,23 +2333,10 @@ export default function App() {
               </div>
             )}
           </div>
+          </div>
 
           {/* Right side controls */}
-          <AuthMenu
-            authStatus={auth.status}
-            email={auth.email}
-            syncStatus={syncStatus}
-            lastSyncedAt={lastSyncedAt}
-            onSignOut={auth.signOut}
-            onSyncNow={() => cloudSyncRef.current?.flushDirty() ?? Promise.resolve()}
-          />
-          <DataMenu
-            onImportFile={handleFileChange}
-            onExport={exportAllInv}
-            onReset={resetInv}
-          />
-          <div className="toolbar-block">
-            <div className="toolbar-label">View</div>
+          <div className="right-controls">
             <div className="toolbar-group" role="tablist" aria-label="Binders or Decks">
               <button
                 type="button"
@@ -2357,7 +2345,6 @@ export default function App() {
                 aria-selected={view === 'binder'}
                 onClick={() => setView('binder')}
                 title="Your card collection binders"
-                style={view === 'binder' ? { backgroundColor: '#213c6a', color: '#fff', border: '1px solid #213c6a' } : undefined}
               >
                 Binders
               </button>
@@ -2368,14 +2355,10 @@ export default function App() {
                 aria-selected={view === 'decks'}
                 onClick={() => setView('decks')}
                 title="Precon decks you own and your saved decklists"
-                style={view === 'decks' ? { backgroundColor: '#213c6a', color: '#fff', border: '1px solid #213c6a' } : undefined}
               >
                 Decks
               </button>
             </div>
-          </div>
-          <div className="toolbar-block">
-            <div className="toolbar-label">Deck</div>
             <div className="toolbar-group">
               <button
                 type="button"
@@ -2389,28 +2372,22 @@ export default function App() {
                 <span>Deck Check</span>
               </button>
             </div>
-            <div className="toolbar-group" role="group" aria-label="Ownership scope" style={{ marginTop: 4 }}>
-              <button
-                type="button"
-                className="tbtn"
-                aria-pressed={ownershipScope === 'combined'}
-                onClick={() => setOwnershipScope('combined')}
-                title="Count owned precons and physical decks as owned, on top of your binders"
-                style={ownershipScope === 'combined' ? { backgroundColor: '#213c6a', color: '#fff', border: '1px solid #213c6a' } : undefined}
-              >
-                Binders + Decks
-              </button>
-              <button
-                type="button"
-                className="tbtn"
-                aria-pressed={ownershipScope === 'bindersOnly'}
-                onClick={() => setOwnershipScope('bindersOnly')}
-                title="Only count what's in your binders as owned"
-                style={ownershipScope === 'bindersOnly' ? { backgroundColor: '#213c6a', color: '#fff', border: '1px solid #213c6a' } : undefined}
-              >
-                Binders only
-              </button>
-            </div>
+
+            <div className="toolbar-divider" aria-hidden="true" />
+
+            <AuthMenu
+              authStatus={auth.status}
+              email={auth.email}
+              syncStatus={syncStatus}
+              lastSyncedAt={lastSyncedAt}
+              onSignOut={auth.signOut}
+              onSyncNow={() => cloudSyncRef.current?.flushDirty() ?? Promise.resolve()}
+            />
+            <DataMenu
+              onImportFile={handleFileChange}
+              onExport={exportAllInv}
+              onReset={resetInv}
+            />
           </div>
 
           {error && <span className="err">{error}</span>}
@@ -2695,8 +2672,8 @@ export default function App() {
                         </td>
                         <td className="adjcol">
                           <div className="qtybtns circle">
-                            <button className="minus" aria-label="Decrease" onClick={()=>dec(r.Number)}>−</button>
-                            <button className="plus" aria-label="Increase" onClick={()=>inc(r.Number)}>+</button>
+                            <button className="minus" aria-label="Decrease" onClick={(e) => { e.stopPropagation(); dec(r.Number); }}>−</button>
+                            <button className="plus" aria-label="Increase" onClick={(e) => { e.stopPropagation(); inc(r.Number); }}>+</button>
                           </div>
                         </td>
                       </tr>
@@ -2707,7 +2684,7 @@ export default function App() {
             </div>
           ) : (
             <div className="muted">
-              {invRows.length ? 
+              {invRows.length ?
                 'No inventory entries match current filters.' : // NEW: Filtered empty message
                 'No entries yet. Click any slot’s +/− or use this table once you add cards.'
               }
@@ -2817,6 +2794,8 @@ export default function App() {
           showToast={showToast}
           onSaveDeck={saveDeck}
           onClose={() => setShowDeckCheckModal(false)}
+          ownershipScope={ownershipScope}
+          onOwnershipScopeChange={setOwnershipScope}
         />
       )}
 

--- a/src/components/AuthMenu.tsx
+++ b/src/components/AuthMenu.tsx
@@ -44,32 +44,28 @@ export function AuthMenu({ authStatus, email, syncStatus, lastSyncedAt, onSignOu
 
   if (authStatus === 'loading') {
     return (
-      <div className="toolbar-block">
-        <div className="toolbar-label">Cloud</div>
-        <div className="toolbar-group">
-          <span className="tbtn" style={{ cursor: 'default' }} title="Checking sign-in…" aria-label="Checking sign-in…">
-            <span className="icon icon-spin" aria-hidden="true">sync</span>
-          </span>
-        </div>
+      <div className="toolbar-group">
+        <span className="tbtn" style={{ cursor: 'default' }} title="Checking sign-in…" aria-label="Checking sign-in…">
+          <span className="icon icon-spin" aria-hidden="true">sync</span>
+          <span>Cloud</span>
+        </span>
       </div>
     )
   }
 
   if (authStatus === 'signedOut') {
     return (
-      <div className="toolbar-block">
-        <div className="toolbar-label">Cloud</div>
-        <div className="toolbar-group">
-          <button
-            type="button"
-            className="tbtn"
-            onClick={() => beginSignIn()}
-            title="Sign in with Google to enable cloud sync"
-            aria-label="Sign in with Google"
-          >
-            <span className="icon" aria-hidden="true">login</span>
-          </button>
-        </div>
+      <div className="toolbar-group">
+        <button
+          type="button"
+          className="tbtn"
+          onClick={() => beginSignIn()}
+          title="Sign in with Google to enable cloud sync"
+          aria-label="Sign in with Google"
+        >
+          <span className="icon" aria-hidden="true">login</span>
+          <span>Cloud</span>
+        </button>
       </div>
     )
   }
@@ -77,36 +73,35 @@ export function AuthMenu({ authStatus, email, syncStatus, lastSyncedAt, onSignOu
   const meta = statusMeta(syncStatus)
 
   return (
-    <div className="toolbar-block">
-      <div className="toolbar-label">Cloud</div>
-      <div className="toolbar-group" style={{ position: 'relative', overflow: 'visible' }}>
-        <button
-          type="button"
-          className="tbtn sync-status-trigger"
-          onClick={() => setMenuOpen(v => !v)}
-          aria-haspopup="menu"
-          aria-expanded={menuOpen}
-          title={`${email ?? 'Signed in'} — ${meta.label}`}
-          aria-label={`Cloud sync: ${meta.label}`}
-        >
-          <span style={{ position: 'relative', display: 'inline-flex' }}>
-            <span className="icon" aria-hidden="true">account_circle</span>
-            <span
-              aria-hidden="true"
-              style={{
-                position: 'absolute',
-                right: -2,
-                bottom: -2,
-                width: 8,
-                height: 8,
-                borderRadius: '50%',
-                background: meta.color,
-                border: '1.5px solid #14161f',
-              }}
-            />
-          </span>
-        </button>
-        {menuOpen && (
+    <div className="toolbar-group" style={{ position: 'relative', overflow: 'visible' }}>
+      <button
+        type="button"
+        className="tbtn sync-status-trigger"
+        onClick={() => setMenuOpen(v => !v)}
+        aria-haspopup="menu"
+        aria-expanded={menuOpen}
+        title={`${email ?? 'Signed in'} — ${meta.label}`}
+        aria-label={`Cloud sync: ${meta.label}`}
+      >
+        <span style={{ position: 'relative', display: 'inline-flex' }}>
+          <span className="icon" aria-hidden="true">account_circle</span>
+          <span
+            aria-hidden="true"
+            style={{
+              position: 'absolute',
+              right: -2,
+              bottom: -2,
+              width: 8,
+              height: 8,
+              borderRadius: '50%',
+              background: meta.color,
+              border: '1.5px solid #14161f',
+            }}
+          />
+        </span>
+        <span>Cloud</span>
+      </button>
+      {menuOpen && (
           <div
             role="menu"
             style={{
@@ -167,6 +162,6 @@ export function AuthMenu({ authStatus, email, syncStatus, lastSyncedAt, onSignOu
           </div>
         )}
       </div>
-    </div>
   )
 }
+

--- a/src/components/DataMenu.tsx
+++ b/src/components/DataMenu.tsx
@@ -11,21 +11,20 @@ export function DataMenu({ onImportFile, onExport, onReset }: Props) {
   const importRef = React.useRef<HTMLInputElement>(null)
 
   return (
-    <div className="toolbar-block">
-      <div className="toolbar-label">Data</div>
-      <div className="toolbar-group" style={{ position: 'relative', overflow: 'visible' }}>
-        <button
-          type="button"
-          className="tbtn"
-          onClick={() => setMenuOpen(v => !v)}
-          aria-haspopup="menu"
-          aria-expanded={menuOpen}
-          title="Import, export, or reset inventory data"
-          aria-label="Data menu"
-        >
-          <span className="icon" aria-hidden="true">database</span>
-        </button>
-        {menuOpen && (
+    <div className="toolbar-group" style={{ position: 'relative', overflow: 'visible' }}>
+      <button
+        type="button"
+        className="tbtn"
+        onClick={() => setMenuOpen(v => !v)}
+        aria-haspopup="menu"
+        aria-expanded={menuOpen}
+        title="Import, export, or reset inventory data"
+        aria-label="Data menu"
+      >
+        <span className="icon" aria-hidden="true">database</span>
+        <span>Data</span>
+      </button>
+      {menuOpen && (
           <div
             role="menu"
             style={{
@@ -94,6 +93,5 @@ export function DataMenu({ onImportFile, onExport, onReset }: Props) {
           </div>
         )}
       </div>
-    </div>
   )
 }

--- a/src/components/DeckCheckModal.tsx
+++ b/src/components/DeckCheckModal.tsx
@@ -23,6 +23,8 @@ type Props = {
   showToast: (message: string, kind?: 'success' | 'error' | 'warning') => void
   onSaveDeck: (deck: SavedDeck) => void
   onClose: () => void
+  ownershipScope: 'combined' | 'bindersOnly'
+  onOwnershipScopeChange: (scope: 'combined' | 'bindersOnly') => void
 }
 
 const FORMAT_LABEL: Record<DeckResolution['format'], string> = {
@@ -50,6 +52,8 @@ export function DeckCheckModal({
   showToast,
   onSaveDeck,
   onClose,
+  ownershipScope,
+  onOwnershipScopeChange,
 }: Props) {
   const [text, setText] = React.useState('')
   const [resolution, setResolution] = React.useState<DeckResolution | null>(null)
@@ -67,6 +71,13 @@ export function DeckCheckModal({
       if (copyFeedbackTimerRef.current != null) clearTimeout(copyFeedbackTimerRef.current)
     }
   }, [])
+
+  // Keep already-computed rows in sync when the ownership scope changes, without
+  // requiring the user to re-click "Check Deck".
+  React.useEffect(() => {
+    if (!resolution) return
+    setRows(computeDeckRows(resolution.rows, buildOwnedLookup()))
+  }, [resolution, buildOwnedLookup])
 
   function handleParse() {
     if (!text.trim()) {
@@ -181,6 +192,15 @@ export function DeckCheckModal({
           Paste a decklist (JSON, Melee, Picklist, or a plain "3x Card Name" list) to see which cards
           you own, which are missing, and what it would cost to complete the deck.
         </p>
+
+        <label className="row" style={{ gap: 6, marginBottom: 12 }}>
+          <input
+            type="checkbox"
+            checked={ownershipScope === 'combined'}
+            onChange={e => onOwnershipScopeChange(e.target.checked ? 'combined' : 'bindersOnly')}
+          />
+          <span className="muted">Count owned precons &amp; physical decks as owned, on top of your binders</span>
+        </label>
 
         <textarea
           value={text}


### PR DESCRIPTION
## Summary
- Consolidated the top nav bar into a single aligned row: dropped the uppercase SET/CLOUD/DATA/VIEW/DECK captions, gave Cloud/Data icon+text buttons matching Deck Check's style, and replaced ad hoc inline active-state styles with a shared CSS class.
- Toolbar now degrades cleanly into 2/3-row breakpoints at narrower widths instead of each control wrapping onto its own line independently.
- Moved the "Binders + Decks"/"Binders only" ownership-scope toggle out of the nav bar into the Deck Check modal as a single checkbox (it only affects Deck Check's numbers, and was reading as a confusing near-duplicate of the Binders/Decks view tabs). Already-computed rows refresh live when toggled.
- Restyled the Set prev/next buttons to match the binder page-turn buttons' dark pill look, instead of unstyled default browser buttons.
- Fixed a bug where the Inventory table's qty +/− buttons selected the card and jumped to it in the binder above on every click — they were missing the `stopPropagation()` the Missing table's equivalent button already had.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint .` clean (pre-existing unrelated warning only)
- [x] Full vitest suite passes (175/175, run serially to rule out sandbox worker-pool flakiness)
- [x] `vite build` production build succeeds
- [x] Manually verified via headless-Chromium screenshots: single-row toolbar at desktop widths, clean 2-row/3-row wrap at 950px/760px/600px, Deck Check modal checkbox, Data/Cloud dropdown menus, Decks view

🤖 Generated with [Claude Code](https://claude.com/claude-code)