### PR TITLE
feat(decks): add Construct/Deconstruct Deck picklist

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -213,6 +213,8 @@ type Filters = {
   rarity: string[];
   type: string[];
   status: CollectionStatusKey[];
+  /** Hide cards from the Missing list that are fully owned but currently pulled into a constructed deck. */
+  hidePulled: boolean;
 };
 
 type FilterControlsProps = {
@@ -222,7 +224,7 @@ type FilterControlsProps = {
 
 // --- FilterControls Component Definition (Used outside App function) ---
 function FilterControls({ filters, setFilters }: FilterControlsProps) {
-  const handleFilterChange = <K extends keyof Filters>(category: K, value: Filters[K][number]) => {
+  const handleFilterChange = <K extends 'aspect' | 'rarity' | 'type' | 'status'>(category: K, value: Filters[K][number]) => {
     setFilters(prev => {
       const cur = prev[category] as Array<Filters[K][number]>;
       const next: Array<Filters[K][number]> = cur.includes(value)
@@ -234,7 +236,7 @@ function FilterControls({ filters, setFilters }: FilterControlsProps) {
   };
 
   const handleClearFilters = () => {
-    setFilters({ aspect: [], rarity: [], type: [], status: [] });
+    setFilters({ aspect: [], rarity: [], type: [], status: [], hidePulled: false });
   };
 
   // ---- Color helpers ----
@@ -431,6 +433,14 @@ function FilterControls({ filters, setFilters }: FilterControlsProps) {
         {renderFilterGroup('rarity', ALL_RARITIES)}
         {renderFilterGroup('type', ALL_TYPES)}
         {renderStatusFilterGroup()}
+        <label className="row" style={{ gap: 6, alignItems: 'center', fontSize: 14 }}>
+          <input
+            type="checkbox"
+            checked={filters.hidePulled}
+            onChange={e => setFilters(prev => ({ ...prev, hidePulled: e.target.checked }))}
+          />
+          <span>Hide cards pulled into a deck</span>
+        </label>
         <button
           className="tbtn tbtn-danger"
           onClick={handleClearFilters}
@@ -1130,6 +1140,7 @@ export default function App() {
     rarity: [],
     type: [],
     status: [],
+    hidePulled: false,
   });
 
   type TcgCopyMode = 'fullNeeded' | 'oneEach';
@@ -1440,6 +1451,49 @@ export default function App() {
       (snapshot[targetSetKey]?.[baseNumber] ?? 0) + (deckOwnedTotals[targetSetKey]?.[baseNumber] ?? 0);
   }, [setKeys, setKey, inventory, canonicalCatalog, deckOwnedTotals]);
 
+  // Binder-only ownership (no precons/physical decks) — the baseline for what's physically printed
+  // into the binder, used by Construct/Deconstruct instead of the combined buildOwnedLookup above.
+  const buildBinderOwnedLookup = useCallback(() => {
+    const snapshot = createInventoryExportSnapshot(localStorage, setKeys, setKey, inventory, canonicalCatalog);
+    return (targetSetKey: SetKey, baseNumber: number) => snapshot[targetSetKey]?.[baseNumber] ?? 0;
+  }, [setKeys, setKey, inventory, canonicalCatalog]);
+
+  // Sum of every constructed deck's pulledCards, keyed by set then base number — what's currently
+  // reserved out of the binder for a physically-built deck.
+  const constructedReservations = useMemo(() => {
+    const totals: Record<SetKey, Record<number, number>> = {};
+    for (const deck of deckLibrary.customDecks) {
+      if (!deck.constructed) continue;
+      for (const ref of deck.pulledCards) {
+        const bucket = totals[ref.setKey] ?? (totals[ref.setKey] = {});
+        bucket[ref.baseNumber] = (bucket[ref.baseNumber] ?? 0) + ref.count;
+      }
+    }
+    return totals;
+  }, [deckLibrary]);
+
+  // Which deck(s) reserved a given card — feeds the "N pulled → DeckName" badge.
+  const reservationSources = useMemo(() => {
+    const totals: Record<SetKey, Record<number, string[]>> = {};
+    for (const deck of deckLibrary.customDecks) {
+      if (!deck.constructed) continue;
+      for (const ref of deck.pulledCards) {
+        const bucket = totals[ref.setKey] ?? (totals[ref.setKey] = {});
+        (bucket[ref.baseNumber] ?? (bucket[ref.baseNumber] = [])).push(deck.name);
+      }
+    }
+    return totals;
+  }, [deckLibrary]);
+
+  // What's actually sitting in the binder right now: binder-raw minus everything reserved by
+  // already-constructed decks. Drives the binder grid, the Inventory/Missing tab, and how many
+  // copies a new deck construction can pull.
+  const buildBinderAvailableLookup = useCallback(() => {
+    const raw = buildBinderOwnedLookup();
+    return (targetSetKey: SetKey, baseNumber: number) =>
+      Math.max(0, raw(targetSetKey, baseNumber) - (constructedReservations[targetSetKey]?.[baseNumber] ?? 0));
+  }, [buildBinderOwnedLookup, constructedReservations]);
+
   const togglePrecon = useCallback((key: string) => {
     setDeckLibrary(lib => {
       const owned = (lib.preconOwnership[key] ?? 0) > 0;
@@ -1452,7 +1506,7 @@ export default function App() {
   }, []);
 
   const updateDeck = useCallback(
-    (id: string, patch: Partial<Pick<SavedDeck, 'name' | 'physical' | 'copies'>>) => {
+    (id: string, patch: Partial<Pick<SavedDeck, 'name' | 'physical' | 'copies' | 'constructed' | 'pulledCards'>>) => {
       setDeckLibrary(lib => ({
         ...lib,
         customDecks: lib.customDecks.map(d =>
@@ -2044,19 +2098,22 @@ export default function App() {
 
   /** True if any card passes aspect/rarity/type filters and is not a complete playset (ignores status pills). */
   const hasIncompleteUnderCardFilters = useMemo(() => {
+    const reservedForSet = constructedReservations[setKey] ?? {};
     for (const baseCard of cardsBase) {
       if (!passesAllFilters(baseCard)) continue;
       const baseNum = baseCard.Number;
-      const have = inventory[baseNum] || 0;
+      const trueOwned = inventory[baseNum] || 0;
+      const qty = Math.max(0, trueOwned - (reservedForSet[baseNum] ?? 0));
       const max = quotaForType(baseCard.Type);
-      if (have < max) return true;
+      if (qty < max) return true;
     }
     return false;
-  }, [cardsBase, inventory, passesAllFilters]);
+  }, [cardsBase, inventory, passesAllFilters, constructedReservations, setKey]);
 
   // Build ONE list over base cards, then partition.
   // Each row has Qty (across base + alts), Max, Needed, and other fields you already use.
   const filteredAllRows = useMemo(() => {
+    const reservedForSet = constructedReservations[setKey] ?? {};
     const rows: Array<{
       Number: number;
       Name: string;
@@ -2064,20 +2121,25 @@ export default function App() {
       Type?: string;
       Rarity?: string;
       Price: number;    // MarketPrice (unit)
-      Qty: number;      // have across base+alts
+      Qty: number;      // binder-adjusted have (true owned minus pulled-for-deck), across base+alts
+      TrueOwned: number; // raw owned, unaffected by deck construction
+      PulledQty: number; // reserved by constructed decks
       Max: number;
-      Needed: number;   // Max - Qty
+      Needed: number;   // Max - TrueOwned (unaffected by pulls — you already own it)
     }> = [];
 
     for (const baseCard of cardsBase) {
       if (!passesAllFilters(baseCard)) continue;
 
       const baseNum = baseCard.Number;
-      const have = inventory[baseNum] || 0;
+      const trueOwned = inventory[baseNum] || 0;
+      const pulledQty = reservedForSet[baseNum] ?? 0;
+      const qty = Math.max(0, trueOwned - pulledQty);
       const max = quotaForType(baseCard.Type);
-      const needed = Math.max(0, max - have);
-      const collStatus = collectionStatusFromQty(have, max);
+      const needed = Math.max(0, max - trueOwned);
+      const collStatus = collectionStatusFromQty(qty, max);
       if (filters.status.length > 0 && !filters.status.includes(collStatus)) continue;
+      if (filters.hidePulled && pulledQty > 0 && trueOwned >= max) continue;
 
       rows.push({
         Number: baseNum,
@@ -2086,21 +2148,23 @@ export default function App() {
         Type: baseCard.Type,
         Rarity: baseCard.Rarity,
         Price: Number(baseCard?.MarketPrice ?? 0),
-        Qty: have,
+        Qty: qty,
+        TrueOwned: trueOwned,
+        PulledQty: pulledQty,
         Max: max,
         Needed: needed,
       });
     }
 
     return rows.sort((a, b) => a.Number - b.Number);
-  }, [cardsBase, inventory, passesAllFilters, filters.status]);
+  }, [cardsBase, inventory, passesAllFilters, filters.status, filters.hidePulled, constructedReservations, setKey]);
 
   // Projections for the two tabs (shape-compatible with your tables)
   const filteredInvRows = useMemo(() => {
     // rows with Qty > 0
     return filteredAllRows
       .filter(r => r.Qty > 0)
-      .map(r => ({ Number: r.Number, Name: r.Name, Type: r.Type, Qty: r.Qty, Max: r.Max }));
+      .map(r => ({ Number: r.Number, Name: r.Name, Type: r.Type, Qty: r.Qty, Max: r.Max, PulledQty: r.PulledQty }));
   }, [filteredAllRows]);
 
   const filteredMissingRows = useMemo(() => {
@@ -2111,6 +2175,8 @@ export default function App() {
         Name: r.Name,
         Type: r.Type,
         Have: r.Qty,
+        TrueOwned: r.TrueOwned,
+        PulledQty: r.PulledQty,
         Max: r.Max,
         Needed: r.Needed,
         Price: r.Price,
@@ -2120,7 +2186,8 @@ export default function App() {
 
   const invRows = filteredInvRows;
 
-  // Inventory Status Counts (Complete, Incomplete, Missing) from the single list
+  // Inventory Status Counts (Complete, Incomplete, Missing) from the single list — reflects
+  // binder-adjusted quantities, i.e. what's physically in the binder pages right now.
   const inventoryStatus = useMemo(() => {
     let complete = 0, incomplete = 0, missing = 0;
 
@@ -2138,8 +2205,10 @@ export default function App() {
     };
   }, [filteredAllRows]);
 
+  // Deliberately based on TrueOwned, not the binder-adjusted Qty: the dollar value of what you own
+  // shouldn't fluctuate based on which deck box a card is currently sitting in.
   const collectionValue = useMemo(
-    () => filteredAllRows.reduce((sum, r) => sum + r.Qty * r.Price, 0),
+    () => filteredAllRows.reduce((sum, r) => sum + r.TrueOwned * r.Price, 0),
     [filteredAllRows]
   );
 
@@ -2408,6 +2477,7 @@ export default function App() {
           numToAspectSpec={numToAspectSpec}
           byNumber={byNumber}
           inventory={inventory}
+          reservedByNumber={constructedReservations[setKey] ?? {}}
           inc={inc}
           dec={dec}
           setKey={setKey}
@@ -2666,7 +2736,18 @@ export default function App() {
                           subtitle={card?.Subtitle}
                           type={r.Type}
                         />
-                        <td className="mono qtycol">{r.Qty}</td>
+                        <td className="mono qtycol">
+                          {r.Qty}
+                          {r.PulledQty > 0 && (
+                            <span
+                              className="pill"
+                              style={{ marginLeft: 6, fontSize: 11 }}
+                              title={`${r.PulledQty} pulled → ${(reservationSources[setKey]?.[r.Number] ?? []).join(', ') || 'a constructed deck'}`}
+                            >
+                              {r.PulledQty} pulled
+                            </span>
+                          )}
+                        </td>
                         <td className="compcol">
                           <CollectionStatusBadge have={r.Qty} max={r.Max} />
                         </td>
@@ -2732,7 +2813,18 @@ export default function App() {
                           type={r.Type}
                         />
                         <td className="compcol">
-                          <CollectionStatusBadge have={r.Have} max={r.Max} />
+                          <div className="row" style={{ gap: 6, alignItems: 'center' }}>
+                            <CollectionStatusBadge have={r.Have} max={r.Max} />
+                            {r.PulledQty > 0 && (
+                              <span
+                                className="pill"
+                                style={{ fontSize: 11 }}
+                                title={`${r.PulledQty} pulled → ${(reservationSources[setKey]?.[r.Number] ?? []).join(', ') || 'a constructed deck'}`}
+                              >
+                                {r.PulledQty} pulled
+                              </span>
+                            )}
+                          </div>
                         </td>
                         <td className="mono qtycol">{r.Needed}</td>
                         <td className="mono moneycol">{fmtUSD(r.RowTotal)}</td>
@@ -2741,9 +2833,9 @@ export default function App() {
                             <button
                               className="plus"
                               aria-label={`Add one ${r.Name}`}
-                              onClick={(e) => { e.stopPropagation(); inc(r.Number); }} 
-                              disabled={r.Have >= r.Max}
-                              title={r.Have >= r.Max ? 'Complete' : 'Add one'}
+                              onClick={(e) => { e.stopPropagation(); inc(r.Number); }}
+                              disabled={r.TrueOwned >= r.Max}
+                              title={r.TrueOwned >= r.Max ? 'Complete' : 'Add one'}
                             >
                               +
                             </button>
@@ -2781,6 +2873,7 @@ export default function App() {
           parsedSets={deckCheckParsedSets}
           trackedSetKeys={setKeys}
           buildOwnedLookup={buildOwnedLookup}
+          buildBinderAvailableLookup={buildBinderAvailableLookup}
           showToast={showToast}
         />
       )}
@@ -3129,6 +3222,7 @@ export function Binder({
   numToAspectSpec,
   byNumber,
   inventory,
+  reservedByNumber,
   inc,
   dec,
   setKey,
@@ -3144,6 +3238,8 @@ export function Binder({
   numToAspectSpec: Map<number, AspectFillSpec>;
   byNumber: Map<number, Card>;
   inventory: Inventory;
+  /** Copies of each card number currently reserved by constructed decks, for the current set. */
+  reservedByNumber: Record<number, number>;
   inc: (n:number)=>void;
   dec: (n:number)=>void;
   setKey: SetKey;
@@ -3399,7 +3495,9 @@ export function Binder({
                     const labelColor = labelColorForAspectHexes(aspectHexes);
 
                     // data for this slot
-                    const qty = inventory[n] || 0;
+                    const rawQty = inventory[n] || 0;
+                    const reserved = reservedByNumber[n] ?? 0;
+                    const qty = Math.max(0, rawQty - reserved);
                     const max = quotaForType(cardAt?.Type);
                     const qtyText = `${qty}/${max}`;
 
@@ -3473,6 +3571,22 @@ export function Binder({
                         >
                           {qtyText}
                         </text>
+
+                        {reserved > 0 && (
+                          <text
+                            x={x + cellW / 2}
+                            y={y + cellH / 2 + QTY_SHIFT_DOWN - QTY_Y_OFFSET - QTY_FONT / 2 - 6}
+                            textAnchor="middle"
+                            dominantBaseline="middle"
+                            fontSize={10}
+                            fontWeight={600}
+                            fill={labelColor}
+                            opacity={0.85}
+                            style={{ pointerEvents: 'none' }}
+                          >
+                            −{reserved} in deck
+                          </text>
+                        )}
 
                         {/* CENTER-BOTTOM: +/- controls under qty (clicks don't bubble) */}
                         <g

--- a/src/components/BinderView.test.tsx
+++ b/src/components/BinderView.test.tsx
@@ -27,6 +27,7 @@ function renderBinder(viewSpread = 1, totalSpreads = 3) {
       numToAspectSpec={new Map()}
       byNumber={new Map([[25, card25]])}
       inventory={{}}
+      reservedByNumber={{}}
       inc={vi.fn()}
       dec={vi.fn()}
       setKey="SOR"

--- a/src/components/DecksView.tsx
+++ b/src/components/DecksView.tsx
@@ -14,18 +14,20 @@ import { allCardRefs, deckContentsFromRows, type DeckCardRef, type DeckContents 
 import { createSavedDeck, type DeckLibrary, type SavedDeck } from '../core/decks'
 import type { PreconCatalogEntry } from '../core/precons'
 import { DeckRowsTable } from './DeckRowsTable'
+import { PickListModal } from './PickListModal'
 
 type Props = {
   preconCatalog: PreconCatalogEntry[]
   deckLibrary: DeckLibrary
   onTogglePrecon: (key: string) => void
   onSaveDeck: (deck: SavedDeck) => void
-  onUpdateDeck: (id: string, patch: Partial<Pick<SavedDeck, 'name' | 'physical' | 'copies'>>) => void
+  onUpdateDeck: (id: string, patch: Partial<Pick<SavedDeck, 'name' | 'physical' | 'copies' | 'constructed' | 'pulledCards'>>) => void
   onDeleteDeck: (id: string) => void
   canonicalCatalog: CanonicalCatalog
   parsedSets: Map<SetKey, DeckLookupSet>
   trackedSetKeys: SetKey[]
   buildOwnedLookup: () => (setKey: SetKey, baseNumber: number) => number
+  buildBinderAvailableLookup: () => (setKey: SetKey, baseNumber: number) => number
   showToast: (message: string, kind?: 'success' | 'error' | 'warning') => void
 }
 
@@ -324,6 +326,7 @@ function SavedDeckRow({
   onToggleExpand,
   onUpdateDeck,
   onDeleteDeck,
+  onOpenPickList,
   rows,
   showToast,
 }: {
@@ -333,6 +336,7 @@ function SavedDeckRow({
   onToggleExpand: () => void
   onUpdateDeck: Props['onUpdateDeck']
   onDeleteDeck: Props['onDeleteDeck']
+  onOpenPickList: (id: string) => void
   rows: DeckRowWithNeed[]
   showToast: Props['showToast']
 }) {
@@ -354,7 +358,17 @@ function SavedDeckRow({
         </button>
         <div className="row" style={{ gap: 8, alignItems: 'center' }}>
           <span className="pill">{deck.physical ? `Physical × ${deck.copies}` : 'Reference'}</span>
+          <span className="pill">{deck.constructed ? 'Constructed' : 'Not built'}</span>
           <span className="pill">Needed: {needed}</span>
+          <button
+            type="button"
+            className="tbtn"
+            onClick={() => onOpenPickList(deck.id)}
+            aria-label={`${deck.constructed ? 'Deconstruct' : 'Construct'} ${deck.name}`}
+          >
+            <span className="icon" aria-hidden="true">{deck.constructed ? 'inventory_2' : 'checklist'}</span>
+            <span>{deck.constructed ? 'Deconstruct Deck' : 'Construct Deck'}</span>
+          </button>
           <label className="row" style={{ gap: 6 }}>
             <input
               type="checkbox"
@@ -397,12 +411,15 @@ export function DecksView({
   parsedSets,
   trackedSetKeys,
   buildOwnedLookup,
+  buildBinderAvailableLookup,
   showToast,
 }: Props) {
   const ownedByBase = React.useMemo(() => buildOwnedLookup(), [buildOwnedLookup])
   const [expandedPrecon, setExpandedPrecon] = React.useState<string | null>(null)
   const [expandedDeckId, setExpandedDeckId] = React.useState<string | null>(null)
   const [showImport, setShowImport] = React.useState(false)
+  const [pickListDeckId, setPickListDeckId] = React.useState<string | null>(null)
+  const pickListDeck = deckLibrary.customDecks.find(d => d.id === pickListDeckId) ?? null
 
   const preconsBySet = React.useMemo(() => {
     const groups = new Map<SetKey, PreconCatalogEntry[]>()
@@ -502,6 +519,7 @@ export function DecksView({
               onToggleExpand={() => setExpandedDeckId(expandedDeckId === deck.id ? null : deck.id)}
               onUpdateDeck={onUpdateDeck}
               onDeleteDeck={onDeleteDeck}
+              onOpenPickList={id => setPickListDeckId(id)}
               rows={contentsToRows(deck, parsedSets, ownedByBase)}
               showToast={showToast}
             />
@@ -520,6 +538,20 @@ export function DecksView({
           />
         </div>
       </details>
+
+      {pickListDeck && (
+        <PickListModal
+          deck={pickListDeck}
+          mode={pickListDeck.constructed ? 'deconstruct' : 'construct'}
+          parsedSets={parsedSets}
+          setOrder={trackedSetKeys}
+          buildBinderAvailableLookup={buildBinderAvailableLookup}
+          dealRows={contentsToRows(pickListDeck, parsedSets, ownedByBase)}
+          deckLibrary={deckLibrary}
+          onClose={() => setPickListDeckId(null)}
+          onUpdateDeck={onUpdateDeck}
+        />
+      )}
     </div>
   )
 }

--- a/src/components/PickListModal.tsx
+++ b/src/components/PickListModal.tsx
@@ -1,0 +1,310 @@
+import React from 'react'
+import type { DeckLookupSet, DeckRowWithNeed } from '../core/decklist'
+import { formatMissingCardsList } from '../core/decklist'
+import type { SetKey } from '../core/types'
+import { buildPickList, buildPutBackList, type PickListGroup, type PickListItem } from '../core/pickList'
+import type { DeckLibrary, SavedDeck } from '../core/decks'
+
+type Props = {
+  deck: SavedDeck
+  mode: 'construct' | 'deconstruct'
+  parsedSets: Map<SetKey, DeckLookupSet>
+  setOrder: SetKey[]
+  buildBinderAvailableLookup: () => (setKey: SetKey, baseNumber: number) => number
+  dealRows: DeckRowWithNeed[]
+  deckLibrary: DeckLibrary
+  onClose: () => void
+  onUpdateDeck: (id: string, patch: Partial<Pick<SavedDeck, 'constructed' | 'pulledCards'>>) => void
+}
+
+function copyToClipboard(text: string, onDone: (ok: boolean) => void) {
+  navigator.clipboard.writeText(text).then(
+    () => onDone(true),
+    () => onDone(false),
+  )
+}
+
+export function PickListModal({
+  deck,
+  mode,
+  parsedSets,
+  setOrder,
+  buildBinderAvailableLookup,
+  dealRows,
+  deckLibrary,
+  onClose,
+  onUpdateDeck,
+}: Props) {
+  const [includeSideboard, setIncludeSideboard] = React.useState(false)
+  const [acknowledgedShortfall, setAcknowledgedShortfall] = React.useState(false)
+  const [copyFeedback, setCopyFeedback] = React.useState<'idle' | 'copied' | 'failed'>('idle')
+
+  const ownedByBase = React.useMemo(() => buildBinderAvailableLookup(), [buildBinderAvailableLookup])
+
+  const groups: PickListGroup[] = React.useMemo(() => {
+    if (mode === 'deconstruct') return buildPutBackList(deck.pulledCards, parsedSets, setOrder)
+    return buildPickList(deck, parsedSets, ownedByBase, setOrder, includeSideboard)
+  }, [mode, deck, parsedSets, ownedByBase, setOrder, includeSideboard])
+
+  const allItems: PickListItem[] = React.useMemo(() => groups.flatMap(g => g.items), [groups])
+
+  const dealNeededByKey = React.useMemo(() => {
+    const map = new Map<string, number>()
+    for (const row of dealRows) map.set(`${row.setKey}:${row.baseNumber}`, row.needed)
+    return map
+  }, [dealRows])
+
+  const reservedBySources = React.useMemo(() => {
+    const map = new Map<string, string[]>()
+    for (const other of deckLibrary.customDecks) {
+      if (other.id === deck.id || !other.constructed) continue
+      for (const ref of other.pulledCards) {
+        const key = `${ref.setKey}:${ref.baseNumber}`
+        const list = map.get(key) ?? []
+        list.push(other.name)
+        map.set(key, list)
+      }
+    }
+    return map
+  }, [deckLibrary, deck.id])
+
+  const shortfalls = React.useMemo(() => {
+    return allItems
+      .filter(item => item.short > 0)
+      .map(item => {
+        const key = `${item.setKey}:${item.baseNumber}`
+        const buyNeeded = Math.min(item.short, dealNeededByKey.get(key) ?? 0)
+        const reservedNeeded = item.short - buyNeeded
+        return { item, buyNeeded, reservedNeeded, reservedBy: reservedBySources.get(key) ?? [] }
+      })
+  }, [allItems, dealNeededByKey, reservedBySources])
+
+  const totalShort = shortfalls.reduce((sum, s) => sum + s.item.short, 0)
+  const purchaseRows = dealRows.filter(r => r.needed > 0)
+  const reservedShortfalls = shortfalls.filter(s => s.reservedNeeded > 0)
+
+  const gated = mode === 'construct' && totalShort > 0 && !acknowledgedShortfall
+
+  function handleCopyPurchaseList() {
+    const list = formatMissingCardsList(purchaseRows, includeSideboard)
+    if (!list) return
+    copyToClipboard(list, ok => {
+      setCopyFeedback(ok ? 'copied' : 'failed')
+      window.setTimeout(() => setCopyFeedback('idle'), 2200)
+    })
+  }
+
+  function handleMarkConstructed() {
+    const pulledCards = allItems
+      .filter(item => item.pull > 0)
+      .map(item => ({ setKey: item.setKey, baseNumber: item.baseNumber, count: item.pull }))
+    onUpdateDeck(deck.id, { constructed: true, pulledCards })
+    onClose()
+  }
+
+  function handleMarkDeconstructed() {
+    onUpdateDeck(deck.id, { constructed: false, pulledCards: [] })
+    onClose()
+  }
+
+  const verb = mode === 'construct' ? 'Pull' : 'Put back'
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={`${mode === 'construct' ? 'Construct' : 'Deconstruct'} ${deck.name}`}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0,0,0,0.5)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 100,
+      }}
+    >
+      <div
+        className="card"
+        style={{
+          maxWidth: 900,
+          width: '92%',
+          maxHeight: '85vh',
+          overflowY: 'auto',
+          padding: 20,
+          background: '#141821',
+        }}
+      >
+        <div className="row" style={{ justifyContent: 'space-between', flexWrap: 'nowrap' }}>
+          <h2 style={{ marginTop: 0 }}>
+            {mode === 'construct' ? 'Construct' : 'Deconstruct'}: {deck.name}
+          </h2>
+          <button type="button" className="tbtn" onClick={onClose} aria-label="Close">
+            <span className="icon" aria-hidden="true">close</span>
+          </button>
+        </div>
+
+        <p className="muted" style={{ marginTop: 0 }}>
+          {mode === 'construct'
+            ? 'Flip through your binders front to back and pull each card below in order.'
+            : 'Flip through your binders front to back and put each card below back in its slot.'}
+        </p>
+
+        {mode === 'construct' && (
+          <label className="row" style={{ gap: 6, marginBottom: 12 }}>
+            <input
+              type="checkbox"
+              checked={includeSideboard}
+              onChange={e => {
+                setIncludeSideboard(e.target.checked)
+                setAcknowledgedShortfall(false)
+              }}
+            />
+            <span>Include sideboard</span>
+          </label>
+        )}
+
+        {gated ? (
+          <div className="card" style={{ padding: 16, background: '#1a1410', border: '1px solid #4a3a00' }}>
+            <p style={{ marginTop: 0 }}>
+              <span className="err">Missing complete copies of {shortfalls.length} card{shortfalls.length === 1 ? '' : 's'}.</span>
+            </p>
+            <p className="muted">
+              {purchaseRows.length > 0 && <>{purchaseRows.length} to buy. </>}
+              {reservedShortfalls.length > 0 && (
+                <>{reservedShortfalls.length} reserved by other built deck{reservedShortfalls.length === 1 ? '' : 's'}. </>
+              )}
+              A purchase list is included below once you continue.
+            </p>
+            <div className="row" style={{ gap: 8 }}>
+              <button type="button" className="tbtn" onClick={() => setAcknowledgedShortfall(true)}>
+                <span>Continue anyway</span>
+              </button>
+              <button type="button" className="tbtn" onClick={onClose}>
+                <span>Cancel</span>
+              </button>
+            </div>
+          </div>
+        ) : (
+          <>
+            <div className="row" style={{ gap: 16, marginBottom: 12 }}>
+              <span className="pill">
+                Total cards: {allItems.reduce((sum, i) => sum + (mode === 'construct' ? i.pull : i.count), 0)}
+              </span>
+              {totalShort > 0 && (
+                <span className="err">
+                  Short {totalShort} card{totalShort === 1 ? '' : 's'} — pull what you have
+                </span>
+              )}
+            </div>
+
+            {groups.length === 0 ? (
+              <p className="muted">Nothing to {verb.toLowerCase()} — this deck has no cards in tracked sets.</p>
+            ) : (
+              groups.map(group => (
+                <div key={group.setKey} style={{ marginTop: 16 }}>
+                  <h4 style={{ marginBottom: 6 }}>
+                    <span className="pill">{group.setKey}</span>
+                  </h4>
+                  <div style={{ overflowX: 'auto' }}>
+                    <table className="table">
+                      <thead>
+                        <tr>
+                          <th>Page</th>
+                          <th>Row</th>
+                          <th>Col</th>
+                          <th>Card</th>
+                          <th>Role</th>
+                          <th>{verb}</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {group.items.map(item => (
+                          <tr key={`${item.setKey}:${item.baseNumber}`}>
+                            <td className="mono">{item.page}</td>
+                            <td className="mono">{item.row}</td>
+                            <td className="mono">{item.column}</td>
+                            <td>
+                              {item.name}
+                              {item.subtitle && <span className="muted"> - {item.subtitle}</span>}
+                            </td>
+                            <td className="mono">{item.roles.join('+')}</td>
+                            <td className="mono">
+                              {mode === 'construct' && item.short > 0 ? (
+                                <span className="err">{item.pull} of {item.count}</span>
+                              ) : (
+                                mode === 'construct' ? item.pull : item.count
+                              )}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              ))
+            )}
+
+            {mode === 'construct' && purchaseRows.length > 0 && (
+              <div style={{ marginTop: 20 }}>
+                <h4 style={{ marginBottom: 6 }}>Purchase list</h4>
+                <p className="muted" style={{ marginTop: 0 }}>
+                  These cards aren't owned in enough quantity to complete the deck.
+                </p>
+                <ul style={{ margin: 0, padding: '0 0 0 18px' }}>
+                  {purchaseRows.map(r => (
+                    <li key={`${r.setKey}:${r.baseNumber}`}>
+                      {r.needed}x {r.name}
+                      {r.subtitle ? ` - ${r.subtitle}` : ''} ({r.setKey})
+                    </li>
+                  ))}
+                </ul>
+                <button type="button" className="tbtn" onClick={handleCopyPurchaseList}>
+                  <span className="icon" aria-hidden="true">
+                    {copyFeedback === 'copied' ? 'check_circle' : copyFeedback === 'failed' ? 'error' : 'content_paste'}
+                  </span>
+                  <span>
+                    {copyFeedback === 'copied' ? 'Copied!' : copyFeedback === 'failed' ? 'Copy failed' : 'Copy purchase list'}
+                  </span>
+                </button>
+              </div>
+            )}
+
+            {mode === 'construct' && reservedShortfalls.length > 0 && (
+              <div style={{ marginTop: 20 }}>
+                <h4 style={{ marginBottom: 6 }}>Reserved by other built decks</h4>
+                <p className="muted" style={{ marginTop: 0 }}>
+                  You own these, but they're currently pulled into another constructed deck. Deconstruct that
+                  deck or buy another copy.
+                </p>
+                <ul style={{ margin: 0, padding: '0 0 0 18px' }}>
+                  {reservedShortfalls.map(s => (
+                    <li key={`${s.item.setKey}:${s.item.baseNumber}`}>
+                      {s.reservedNeeded}x {s.item.name}
+                      {s.item.subtitle ? ` - ${s.item.subtitle}` : ''} ({s.item.setKey}) — held by{' '}
+                      {s.reservedBy.join(', ') || 'another deck'}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            <div className="row" style={{ marginTop: 16, gap: 8 }}>
+              {mode === 'construct' ? (
+                <button type="button" className="tbtn" onClick={handleMarkConstructed}>
+                  <span className="icon" aria-hidden="true">check_circle</span>
+                  <span>Mark as Constructed</span>
+                </button>
+              ) : (
+                <button type="button" className="tbtn" onClick={handleMarkDeconstructed}>
+                  <span className="icon" aria-hidden="true">inventory_2</span>
+                  <span>Mark as Deconstructed</span>
+                </button>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/core/decks.test.ts
+++ b/src/core/decks.test.ts
@@ -53,12 +53,22 @@ describe('createSavedDeck', () => {
       physical: true,
       copies: 2,
       sourceText: 'raw',
+      constructed: false,
+      pulledCards: [],
       leader: { setKey: 'SOR', baseNumber: 1, count: 1 },
       secondLeader: undefined,
       base: { setKey: 'SOR', baseNumber: 2, count: 1 },
       mainDeck: [{ setKey: 'SOR', baseNumber: 3, count: 3 }],
       sideboard: [],
     });
+  });
+
+  it('always starts a new deck as not constructed with no pulled cards', () => {
+    const result = createSavedDeck(validRows, { name: 'x', physical: false, copies: 1, sourceText: '' });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.deck.constructed).toBe(false);
+    expect(result.deck.pulledCards).toEqual([]);
   });
 
   it('defaults an untitled name and floors/clamps copies to at least 1', () => {
@@ -95,6 +105,8 @@ describe('deriveOwnedTotals', () => {
     physical: true,
     copies: 1,
     sourceText: '',
+    constructed: false,
+    pulledCards: [],
     leader: { setKey: 'JTL', baseNumber: 10, count: 1 },
     base: { setKey: 'JTL', baseNumber: 11, count: 1 },
     mainDeck: [{ setKey: 'JTL', baseNumber: 12, count: 2 }],
@@ -151,6 +163,8 @@ describe('parseDeckLibrary / persistence', () => {
       physical: false,
       copies: 1,
       sourceText: '',
+      constructed: false,
+      pulledCards: [],
       leader: { setKey: 'SOR', baseNumber: 1, count: 1 },
       base: { setKey: 'SOR', baseNumber: 2, count: 1 },
       mainDeck: [],
@@ -161,6 +175,27 @@ describe('parseDeckLibrary / persistence', () => {
       preconOwnership: { 'SOR-heroism': 1, bad: 'x' },
     });
     expect(parseDeckLibrary(raw)).toEqual({ customDecks: [valid], preconOwnership: {} });
+  });
+
+  it('defaults constructed/pulledCards for saved decks from before those fields existed', () => {
+    const oldShapeDeck = {
+      id: 'd1',
+      name: 'Old deck',
+      createdAt: '',
+      updatedAt: '',
+      physical: false,
+      copies: 1,
+      sourceText: '',
+      leader: { setKey: 'SOR', baseNumber: 1, count: 1 },
+      base: { setKey: 'SOR', baseNumber: 2, count: 1 },
+      mainDeck: [],
+      sideboard: [],
+    };
+    const raw = JSON.stringify({ customDecks: [oldShapeDeck], preconOwnership: {} });
+    const library = parseDeckLibrary(raw);
+    expect(library.customDecks).toHaveLength(1);
+    expect(library.customDecks[0]!.constructed).toBe(false);
+    expect(library.customDecks[0]!.pulledCards).toEqual([]);
   });
 
   it('round-trips through loadDeckLibrary/persistDeckLibrary', () => {

--- a/src/core/decks.ts
+++ b/src/core/decks.ts
@@ -2,7 +2,9 @@ import type { ResolvedDeckRow } from './decklist'
 import {
   addDeckContentsToTotals,
   deckContentsFromRows,
+  isDeckCardRef,
   isDeckContents,
+  type DeckCardRef,
   type DeckContents,
   type OwnedTotals,
 } from './deckContents'
@@ -19,6 +21,10 @@ export type SavedDeck = DeckContents & {
   copies: number
   /** Original pasted text, kept so the deck can be re-parsed/edited later. */
   sourceText: string
+  /** True once the user has pulled this deck's cards out of the binders and physically assembled it. */
+  constructed: boolean
+  /** Snapshot of exactly what was pulled from the binder at construct time. Only meaningful while constructed=true; cleared on deconstruct. */
+  pulledCards: DeckCardRef[]
 }
 
 export type DeckLibrary = {
@@ -64,6 +70,8 @@ export function createSavedDeck(
       physical: input.physical,
       copies: Math.max(1, Math.floor(input.copies) || 1),
       sourceText: input.sourceText,
+      constructed: false,
+      pulledCards: [],
     },
   }
 }
@@ -102,7 +110,9 @@ function isSavedDeck(value: unknown): value is SavedDeck {
     typeof v.updatedAt === 'string' &&
     typeof v.physical === 'boolean' &&
     Number.isFinite(v.copies) &&
-    typeof v.sourceText === 'string'
+    typeof v.sourceText === 'string' &&
+    (v.constructed === undefined || typeof v.constructed === 'boolean') &&
+    (v.pulledCards === undefined || (Array.isArray(v.pulledCards) && v.pulledCards.every(isDeckCardRef)))
   )
 }
 
@@ -116,7 +126,9 @@ export function parseDeckLibrary(raw: string | null): DeckLibrary {
     const parsed: unknown = JSON.parse(raw)
     if (!isRecord(parsed)) return { ...emptyDeckLibrary }
     const customDecks = Array.isArray(parsed.customDecks)
-      ? parsed.customDecks.filter(isSavedDeck)
+      ? parsed.customDecks
+          .filter(isSavedDeck)
+          .map(d => ({ ...d, constructed: d.constructed ?? false, pulledCards: d.pulledCards ?? [] }))
       : []
     const preconOwnership = isPreconOwnership(parsed.preconOwnership) ? parsed.preconOwnership : {}
     return { customDecks, preconOwnership }

--- a/src/core/pickList.test.ts
+++ b/src/core/pickList.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest'
+import type { Card, SetKey } from './types'
+import type { DeckContents } from './deckContents'
+import type { DeckLookupSet } from './decklist'
+import { buildPickList, buildPutBackList } from './pickList'
+
+function card(partial: Partial<Card> & { Name: string; Number: number; Set: SetKey }): Card {
+  return { MarketPrice: 0, ...partial }
+}
+
+// Number 1 -> page 1/row 1/col 1; 5 -> page 1/row 2/col 1; 13 -> page 2/row 1/col 1; 25 -> page 3/row 1/col 1.
+const SOR_CARDS: Card[] = [
+  card({ Set: 'SOR', Number: 1, Name: 'Leader Card', Type: 'Leader' }),
+  card({ Set: 'SOR', Number: 2, Name: 'Second Leader', Type: 'Leader' }),
+  card({ Set: 'SOR', Number: 3, Name: 'Base Card', Type: 'Base' }),
+  card({ Set: 'SOR', Number: 4, Name: 'Mid Card', Subtitle: 'Sub', Type: 'Unit' }),
+  card({ Set: 'SOR', Number: 5, Name: 'Row Two Card', Type: 'Unit' }),
+  card({ Set: 'SOR', Number: 13, Name: 'Page Two Card', Type: 'Unit' }),
+  card({ Set: 'SOR', Number: 25, Name: 'Page Three Card', Type: 'Unit' }),
+  card({ Set: 'SOR', Number: 30, Name: 'Sideboard Card', Type: 'Unit' }),
+  card({ Set: 'SOR', Number: 31, Name: 'Both Roles Card', Type: 'Unit' }),
+]
+
+const SHD_CARDS: Card[] = [card({ Set: 'SHD', Number: 1, Name: 'Other Set Card', Type: 'Unit' })]
+
+const PARSED_SETS: Map<SetKey, DeckLookupSet> = new Map([
+  ['SOR', { baseCards: SOR_CARDS, byNumber: new Map(SOR_CARDS.map(c => [c.Number, c])) }],
+  ['SHD', { baseCards: SHD_CARDS, byNumber: new Map(SHD_CARDS.map(c => [c.Number, c])) }],
+])
+
+function ownedAll(): (setKey: SetKey, baseNumber: number) => number {
+  return () => 3
+}
+
+const baseContents: DeckContents = {
+  leader: { setKey: 'SOR', baseNumber: 1, count: 1 },
+  base: { setKey: 'SOR', baseNumber: 3, count: 1 },
+  mainDeck: [
+    { setKey: 'SOR', baseNumber: 25, count: 2 },
+    { setKey: 'SOR', baseNumber: 5, count: 3 },
+    { setKey: 'SOR', baseNumber: 13, count: 3 },
+    { setKey: 'SOR', baseNumber: 4, count: 3 },
+  ],
+  sideboard: [],
+}
+
+describe('buildPickList', () => {
+  it('computes binder positions from collector numbers', () => {
+    const groups = buildPickList(baseContents, PARSED_SETS, ownedAll(), ['SOR'], false)
+    const bySlot = new Map(groups[0]!.items.map(i => [i.baseNumber, i]))
+    expect(bySlot.get(1)).toMatchObject({ page: 1, row: 1, column: 1 })
+    expect(bySlot.get(5)).toMatchObject({ page: 1, row: 2, column: 1 })
+    expect(bySlot.get(13)).toMatchObject({ page: 2, row: 1, column: 1 })
+    expect(bySlot.get(25)).toMatchObject({ page: 3, row: 1, column: 1 })
+  })
+
+  it('sorts items within a group by page, then row, then column regardless of input order', () => {
+    const groups = buildPickList(baseContents, PARSED_SETS, ownedAll(), ['SOR'], false)
+    expect(groups[0]!.items.map(i => i.baseNumber)).toEqual([1, 3, 4, 5, 13, 25])
+  })
+
+  it('orders groups by setOrder, not alphabetically or by insertion order', () => {
+    const contents: DeckContents = {
+      leader: { setKey: 'SOR', baseNumber: 1, count: 1 },
+      base: { setKey: 'SOR', baseNumber: 3, count: 1 },
+      mainDeck: [{ setKey: 'SHD', baseNumber: 1, count: 1 }],
+      sideboard: [],
+    }
+    const groups = buildPickList(contents, PARSED_SETS, ownedAll(), ['SHD', 'SOR'], false)
+    expect(groups.map(g => g.setKey)).toEqual(['SHD', 'SOR'])
+  })
+
+  it('omits sets that end up with no items', () => {
+    const contents: DeckContents = {
+      leader: { setKey: 'SOR', baseNumber: 1, count: 1 },
+      base: { setKey: 'SOR', baseNumber: 3, count: 1 },
+      mainDeck: [],
+      sideboard: [{ setKey: 'SHD', baseNumber: 1, count: 1 }],
+    }
+    const groups = buildPickList(contents, PARSED_SETS, ownedAll(), ['SOR', 'SHD'], false)
+    expect(groups.map(g => g.setKey)).toEqual(['SOR'])
+  })
+
+  describe('includeSideboard', () => {
+    const contents: DeckContents = {
+      leader: { setKey: 'SOR', baseNumber: 1, count: 1 },
+      base: { setKey: 'SOR', baseNumber: 3, count: 1 },
+      mainDeck: [{ setKey: 'SOR', baseNumber: 31, count: 1 }],
+      sideboard: [
+        { setKey: 'SOR', baseNumber: 30, count: 2 },
+        { setKey: 'SOR', baseNumber: 31, count: 1 },
+      ],
+    }
+
+    it('excludes sideboard-only cards and does not merge sideboard counts when false', () => {
+      const groups = buildPickList(contents, PARSED_SETS, ownedAll(), ['SOR'], false)
+      const numbers = groups[0]!.items.map(i => i.baseNumber)
+      expect(numbers).not.toContain(30)
+      const both = groups[0]!.items.find(i => i.baseNumber === 31)!
+      expect(both.count).toBe(1)
+      expect(both.roles).toEqual(['deck'])
+    })
+
+    it('includes sideboard cards and merges counts for cards in both mainDeck and sideboard when true', () => {
+      const groups = buildPickList(contents, PARSED_SETS, ownedAll(), ['SOR'], true)
+      const numbers = groups[0]!.items.map(i => i.baseNumber)
+      expect(numbers).toContain(30)
+      const both = groups[0]!.items.find(i => i.baseNumber === 31)!
+      expect(both.count).toBe(2)
+      expect(both.roles).toEqual(['deck', 'sideboard'])
+    })
+  })
+
+  it('computes shortfall when have < count, without dropping the item', () => {
+    const owned = (_setKey: SetKey, baseNumber: number) => (baseNumber === 5 ? 1 : 3)
+    const groups = buildPickList(baseContents, PARSED_SETS, owned, ['SOR'], false)
+    const item = groups[0]!.items.find(i => i.baseNumber === 5)!
+    expect(item).toMatchObject({ count: 3, have: 1, pull: 1, short: 2 })
+  })
+
+  it('treats an unowned card as a full shortfall rather than throwing', () => {
+    const owned = () => 0
+    const groups = buildPickList(baseContents, PARSED_SETS, owned, ['SOR'], false)
+    const item = groups[0]!.items.find(i => i.baseNumber === 1)!
+    expect(item).toMatchObject({ have: 0, pull: 0, short: 1 })
+  })
+
+  it('produces two leader-role items for a secondLeader (Twin Suns) deck', () => {
+    const contents: DeckContents = {
+      leader: { setKey: 'SOR', baseNumber: 1, count: 1 },
+      secondLeader: { setKey: 'SOR', baseNumber: 2, count: 1 },
+      base: { setKey: 'SOR', baseNumber: 3, count: 1 },
+      mainDeck: [],
+      sideboard: [],
+    }
+    const groups = buildPickList(contents, PARSED_SETS, ownedAll(), ['SOR'], false)
+    const leaders = groups[0]!.items.filter(i => i.roles.includes('leader'))
+    expect(leaders.map(i => i.baseNumber).sort()).toEqual([1, 2])
+  })
+
+  it('skips cards that cannot be resolved in parsedSets instead of throwing', () => {
+    const contents: DeckContents = {
+      leader: { setKey: 'SOR', baseNumber: 1, count: 1 },
+      base: { setKey: 'SOR', baseNumber: 3, count: 1 },
+      mainDeck: [{ setKey: 'SOR', baseNumber: 9999, count: 1 }],
+      sideboard: [],
+    }
+    expect(() => buildPickList(contents, PARSED_SETS, ownedAll(), ['SOR'], false)).not.toThrow()
+    const groups = buildPickList(contents, PARSED_SETS, ownedAll(), ['SOR'], false)
+    expect(groups[0]!.items.map(i => i.baseNumber)).not.toContain(9999)
+  })
+
+  describe('buildPutBackList', () => {
+    it('groups and sorts a pulledCards snapshot the same way as buildPickList, with no shortfall', () => {
+      const groups = buildPutBackList(
+        [
+          { setKey: 'SOR', baseNumber: 25, count: 2 },
+          { setKey: 'SOR', baseNumber: 1, count: 1 },
+        ],
+        PARSED_SETS,
+        ['SOR'],
+      )
+      expect(groups[0]!.items.map(i => i.baseNumber)).toEqual([1, 25])
+      const item = groups[0]!.items.find(i => i.baseNumber === 25)!
+      expect(item).toMatchObject({ count: 2, have: 2, pull: 2, short: 0, page: 3, row: 1, column: 1 })
+    })
+
+    it('skips cards that cannot be resolved without throwing', () => {
+      expect(() =>
+        buildPutBackList([{ setKey: 'SOR', baseNumber: 9999, count: 1 }], PARSED_SETS, ['SOR']),
+      ).not.toThrow()
+    })
+  })
+
+  it('sorts roles within an item by priority: leader, base, deck, sideboard', () => {
+    const contents: DeckContents = {
+      leader: { setKey: 'SOR', baseNumber: 31, count: 1 },
+      base: { setKey: 'SOR', baseNumber: 3, count: 1 },
+      mainDeck: [{ setKey: 'SOR', baseNumber: 31, count: 1 }],
+      sideboard: [{ setKey: 'SOR', baseNumber: 31, count: 1 }],
+    }
+    const groups = buildPickList(contents, PARSED_SETS, ownedAll(), ['SOR'], true)
+    const item = groups[0]!.items.find(i => i.baseNumber === 31)!
+    expect(item.roles).toEqual(['leader', 'deck', 'sideboard'])
+  })
+})

--- a/src/core/pickList.ts
+++ b/src/core/pickList.ts
@@ -1,0 +1,130 @@
+import { binderLayout } from './binder'
+import type { DeckCardRef, DeckContents } from './deckContents'
+import type { DeckLookupSet, DeckRole } from './decklist'
+import type { SetKey } from './types'
+
+export type PickListItem = {
+  setKey: SetKey
+  baseNumber: number
+  name: string
+  subtitle?: string
+  /** All roles this physical card serves in the deck, priority-sorted (leader, base, deck, sideboard). */
+  roles: DeckRole[]
+  /** Total copies the deck needs from this binder slot. */
+  count: number
+  /** Copies available to pull, per the ownedByBase lookup passed in. */
+  have: number
+  /** min(count, have) — how many to actually pull. */
+  pull: number
+  /** count - pull — how many couldn't be pulled. */
+  short: number
+  page: number
+  row: number
+  column: number
+}
+
+export type PickListGroup = { setKey: SetKey; items: PickListItem[] }
+
+const ROLE_PRIORITY: Record<DeckRole, number> = { leader: 0, base: 1, deck: 2, sideboard: 3 }
+
+type Bucket = { setKey: SetKey; baseNumber: number; roles: Set<DeckRole>; count: number }
+
+function addRef(buckets: Map<string, Bucket>, ref: DeckCardRef, role: DeckRole) {
+  const key = `${ref.setKey}:${ref.baseNumber}`
+  const existing = buckets.get(key)
+  if (existing) {
+    existing.roles.add(role)
+    existing.count += ref.count
+  } else {
+    buckets.set(key, { setKey: ref.setKey, baseNumber: ref.baseNumber, roles: new Set([role]), count: ref.count })
+  }
+}
+
+/** Builds a binder-ordered pull list for a deck: grouped by set (in setOrder), sorted by page/row/column within each group. */
+export function buildPickList(
+  contents: DeckContents,
+  parsedSets: Map<SetKey, DeckLookupSet>,
+  ownedByBase: (setKey: SetKey, baseNumber: number) => number,
+  setOrder: SetKey[],
+  includeSideboard: boolean,
+): PickListGroup[] {
+  const buckets = new Map<string, Bucket>()
+
+  addRef(buckets, contents.leader, 'leader')
+  if (contents.secondLeader) addRef(buckets, contents.secondLeader, 'leader')
+  addRef(buckets, contents.base, 'base')
+  for (const ref of contents.mainDeck) addRef(buckets, ref, 'deck')
+  if (includeSideboard) for (const ref of contents.sideboard) addRef(buckets, ref, 'sideboard')
+
+  const groups = new Map<SetKey, PickListItem[]>()
+  for (const bucket of buckets.values()) {
+    const card = parsedSets.get(bucket.setKey)?.byNumber.get(bucket.baseNumber)
+    if (!card) continue
+
+    const have = Math.max(0, ownedByBase(bucket.setKey, bucket.baseNumber))
+    const pull = Math.min(bucket.count, have)
+    const { page, row, column } = binderLayout(bucket.baseNumber)
+
+    const item: PickListItem = {
+      setKey: bucket.setKey,
+      baseNumber: bucket.baseNumber,
+      name: card.Name,
+      subtitle: card.Subtitle,
+      roles: [...bucket.roles].sort((a, b) => ROLE_PRIORITY[a] - ROLE_PRIORITY[b]),
+      count: bucket.count,
+      have,
+      pull,
+      short: bucket.count - pull,
+      page,
+      row,
+      column,
+    }
+
+    const list = groups.get(bucket.setKey) ?? []
+    list.push(item)
+    groups.set(bucket.setKey, list)
+  }
+
+  return groupAndSort(groups, setOrder)
+}
+
+function groupAndSort(groups: Map<SetKey, PickListItem[]>, setOrder: SetKey[]): PickListGroup[] {
+  for (const list of groups.values()) {
+    list.sort((a, b) => a.page - b.page || a.row - b.row || a.column - b.column)
+  }
+  return setOrder.filter(sk => groups.has(sk)).map(setKey => ({ setKey, items: groups.get(setKey)! }))
+}
+
+/** Builds the "put it back" list from a deck's pulledCards snapshot — no shortfall concept, since these are exactly the cards that were pulled. */
+export function buildPutBackList(
+  pulledCards: DeckCardRef[],
+  parsedSets: Map<SetKey, DeckLookupSet>,
+  setOrder: SetKey[],
+): PickListGroup[] {
+  const groups = new Map<SetKey, PickListItem[]>()
+  for (const ref of pulledCards) {
+    const card = parsedSets.get(ref.setKey)?.byNumber.get(ref.baseNumber)
+    if (!card) continue
+
+    const { page, row, column } = binderLayout(ref.baseNumber)
+    const item: PickListItem = {
+      setKey: ref.setKey,
+      baseNumber: ref.baseNumber,
+      name: card.Name,
+      subtitle: card.Subtitle,
+      roles: [],
+      count: ref.count,
+      have: ref.count,
+      pull: ref.count,
+      short: 0,
+      page,
+      row,
+      column,
+    }
+    const list = groups.get(ref.setKey) ?? []
+    list.push(item)
+    groups.set(ref.setKey, list)
+  }
+
+  return groupAndSort(groups, setOrder)
+}


### PR DESCRIPTION
## Summary
- Adds "Construct Deck" / "Deconstruct Deck" to each saved deck: a picklist sorted by binder (set) → page → row → column so you can flip through your binders once and pull every card in order.
- Missing cards trigger a confirmation before showing the full list, splitting shortfalls into a **purchase list** (truly need to buy) vs **reserved by other built decks** (owned, just tied up elsewhere).
- Binder pages and the Inventory/Missing tab now reflect cards currently pulled into a constructed deck (reduced quantity + "N pulled → DeckName" badge / "hide pulled" filter), while `Needed`/cost/collection value stay based on true ownership so nothing gets double-bought.
- New `constructed`/`pulledCards` fields on `SavedDeck` (back-compat defaulted for existing saved decks).

## Test plan
- [x] `npx vitest run` — 193 tests passing (new: `pickList.test.ts`, updated `decks.test.ts`)
- [x] `npx tsc --noEmit` — clean
- [x] Manually walked the full flow in a running dev server (Playwright-driven): import a deck, seed partial inventory, hit the shortfall confirmation, verify purchase list / reserved-by-other-deck split, mark constructed, confirm binder grid + Missing tab show the pulled indicator, deconstruct, confirm everything reverts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)