### PR TITLE
Check decklists against Premier and Twin Suns format rules

### DIFF
--- a/src/components/DeckCheckModal.tsx
+++ b/src/components/DeckCheckModal.tsx
@@ -13,7 +13,9 @@ import {
   type DeckRowWithNeed,
 } from '../core/decklist'
 import { DeckRowsTable } from './DeckRowsTable'
-import { createSavedDeck, type SavedDeck } from '../core/decks'
+import { DeckLegalityPanel, FormatPicker } from './DeckLegalityPanel'
+import { checkDeckLegality, type FormatChoice } from '../core/deckLegality'
+import { createSavedDeck, deckContentsFailureMessage, type SavedDeck } from '../core/decks'
 
 type Props = {
   canonicalCatalog: CanonicalCatalog
@@ -65,6 +67,7 @@ export function DeckCheckModal({
   const [saveName, setSaveName] = React.useState('')
   const [savePhysical, setSavePhysical] = React.useState(false)
   const [saveCopies, setSaveCopies] = React.useState(1)
+  const [formatChoice, setFormatChoice] = React.useState<FormatChoice>('auto')
 
   React.useEffect(() => {
     return () => {
@@ -97,6 +100,7 @@ export function DeckCheckModal({
     setSaveName(resolved.deckName ?? '')
     setSavePhysical(false)
     setSaveCopies(1)
+    setFormatChoice('auto')
   }
 
   function handleSaveDeck() {
@@ -108,12 +112,7 @@ export function DeckCheckModal({
       sourceText: text,
     })
     if (!result.ok) {
-      showToast(
-        result.reason === 'missing-leader'
-          ? "This decklist doesn't have a leader — it can't be saved yet."
-          : "This decklist doesn't have a base — it can't be saved yet.",
-        'warning',
-      )
+      showToast(`${deckContentsFailureMessage(result.reason)} It can't be saved yet.`, 'warning')
       return
     }
     onSaveDeck(result.deck)
@@ -122,6 +121,10 @@ export function DeckCheckModal({
   }
 
   const summary = React.useMemo(() => summarizeDeck(rows, includeSideboard), [rows, includeSideboard])
+  const legality = React.useMemo(
+    () => (resolution ? checkDeckLegality(resolution.rows, formatChoice) : null),
+    [resolution, formatChoice],
+  )
   const mainRows = rows.filter(r => r.role !== 'sideboard')
   const sideboardRows = rows.filter(r => r.role === 'sideboard')
   const detectedFormat = text.trim() ? FORMAT_LABEL[detectDeckFormat(text)] : null
@@ -187,7 +190,8 @@ export function DeckCheckModal({
 
         <p className="muted" style={{ marginTop: 0 }}>
           Paste a decklist (JSON, Melee, Picklist, or a plain "3x Card Name" list) to see which cards
-          you own, which are missing, and what it would cost to complete the deck.
+          you own, which are missing, and what it would cost to complete the deck. Premier and Twin
+          Suns (two leaders, 80 cards, no repeats) decks are both checked against their format rules.
         </p>
 
         <label className="row" style={{ gap: 6, marginBottom: 12 }}>
@@ -230,27 +234,34 @@ export function DeckCheckModal({
           <>
             <div className="row" style={{ marginTop: 20, justifyContent: 'space-between' }}>
               <h3 style={{ margin: 0 }}>{resolution.deckName ?? 'Pasted decklist'}</h3>
-              <label className="row" style={{ gap: 6 }}>
-                <input
-                  type="checkbox"
-                  checked={includeSideboard}
-                  onChange={e => setIncludeSideboard(e.target.checked)}
-                />
-                <span>Include sideboard in totals &amp; export</span>
-              </label>
+              <div className="row" style={{ gap: 12, flexWrap: 'wrap', alignItems: 'center' }}>
+                <FormatPicker id="deck-check-format" value={formatChoice} onChange={setFormatChoice} />
+                <label className="row" style={{ gap: 6 }}>
+                  <input
+                    type="checkbox"
+                    checked={includeSideboard}
+                    onChange={e => setIncludeSideboard(e.target.checked)}
+                  />
+                  <span>Include sideboard in totals &amp; export</span>
+                </label>
+              </div>
             </div>
+
+            {legality && <DeckLegalityPanel legality={legality} />}
 
             <div className="row" style={{ marginTop: 8, gap: 16 }}>
               <span className="pill">Needed cards: {summary.totalNeededCards}</span>
               <span className="pill">Cost to complete: {money(summary.totalCost)}</span>
+              {/* "owned" spelled out so these don't read as a second opinion on the legality
+                  panel's leader/base counts sitting directly above them. */}
               {summary.leaderOwned !== null && (
                 <span className="pill">
-                  {rows.filter(r => r.role === 'leader').length > 1 ? 'Leaders' : 'Leader'}:{' '}
-                  {summary.leaderOwned ? 'Owned ✓' : 'Missing'}
+                  {rows.filter(r => r.role === 'leader').length > 1 ? 'Leaders' : 'Leader'}{' '}
+                  {summary.leaderOwned ? 'owned ✓' : 'not owned'}
                 </span>
               )}
               {summary.baseOwned !== null && (
-                <span className="pill">Base: {summary.baseOwned ? 'Owned ✓' : 'Missing'}</span>
+                <span className="pill">Base {summary.baseOwned ? 'owned ✓' : 'not owned'}</span>
               )}
             </div>
 

--- a/src/components/DeckLegalityPanel.tsx
+++ b/src/components/DeckLegalityPanel.tsx
@@ -1,0 +1,105 @@
+import React from 'react'
+import { FORMAT_RULES, type DeckLegality, type FormatChoice } from '../core/deckLegality'
+
+const CHOICES: Array<{ value: FormatChoice; label: string }> = [
+  { value: 'auto', label: 'Auto-detect' },
+  { value: 'premier', label: FORMAT_RULES.premier.label },
+  { value: 'twinSuns', label: FORMAT_RULES.twinSuns.label },
+]
+
+export function FormatPicker({
+  value,
+  onChange,
+  id,
+}: {
+  value: FormatChoice
+  onChange: (choice: FormatChoice) => void
+  id?: string
+}) {
+  return (
+    <label className="row" style={{ gap: 6, alignItems: 'center' }}>
+      <span className="muted">Format</span>
+      <select
+        id={id}
+        value={value}
+        onChange={e => onChange(e.target.value as FormatChoice)}
+        style={{
+          background: '#0f1017',
+          color: '#eaeaf0',
+          border: '1px solid #2b2d3d',
+          borderRadius: 8,
+          padding: '6px 10px',
+        }}
+      >
+        {CHOICES.map(choice => (
+          <option key={choice.value} value={choice.value}>
+            {choice.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  )
+}
+
+/** Compact "Premier" / "Twin Suns" badge, for places that list decks rather than inspect one. */
+export function FormatPill({ legality }: { legality: DeckLegality }) {
+  return (
+    <span className="pill" title={legality.autoDetected ? 'Format detected from the decklist' : undefined}>
+      {legality.rules.label}
+    </span>
+  )
+}
+
+export function DeckLegalityPanel({ legality }: { legality: DeckLegality }) {
+  const { stats, rules, issues } = legality
+  const errors = issues.filter(i => i.severity === 'error')
+  const warnings = issues.filter(i => i.severity === 'warning')
+
+  return (
+    <div style={{ marginTop: 12 }}>
+      <div className="row" style={{ gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>
+        <span className="pill">
+          {rules.label}
+          {legality.autoDetected ? ' (detected)' : ''}
+        </span>
+        <span className="pill">
+          {legality.legal ? 'Legal ✓' : `${errors.length} rule issue${errors.length === 1 ? '' : 's'}`}
+        </span>
+        <span className="pill">
+          Leaders: {stats.leaderCount}/{rules.leaders}
+        </span>
+        <span className="pill">Base: {stats.baseCount}/1</span>
+        <span className="pill">
+          Deck: {stats.mainDeckSize}/{rules.minDeck}
+        </span>
+        {stats.sideboardSize > 0 && (
+          <span className="pill">
+            Sideboard: {stats.sideboardSize}/{rules.maxSideboard}
+          </span>
+        )}
+        <span className="pill" title="Copies allowed per card title, unless the card's own text says otherwise">
+          Max copies: {rules.copyLimit}
+        </span>
+      </div>
+
+      {errors.length > 0 && (
+        <ul style={{ margin: '8px 0 0', padding: '0 0 0 18px' }}>
+          {errors.map((issue, i) => (
+            <li key={i} className="err">
+              {issue.message}
+            </li>
+          ))}
+        </ul>
+      )}
+      {warnings.length > 0 && (
+        <ul style={{ margin: '8px 0 0', padding: '0 0 0 18px' }}>
+          {warnings.map((issue, i) => (
+            <li key={i} className="muted">
+              {issue.message}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src/components/DecksView.tsx
+++ b/src/components/DecksView.tsx
@@ -11,9 +11,11 @@ import {
   type DeckRowWithNeed,
 } from '../core/decklist'
 import { allCardRefs, deckContentsFromRows, type DeckCardRef, type DeckContents } from '../core/deckContents'
-import { createSavedDeck, type DeckLibrary, type SavedDeck } from '../core/decks'
+import { createSavedDeck, deckContentsFailureMessage, type DeckLibrary, type SavedDeck } from '../core/decks'
+import { FORMAT_RULES, checkDeckLegality, type FormatChoice } from '../core/deckLegality'
 import type { PreconCatalogEntry } from '../core/precons'
 import { DeckRowsTable } from './DeckRowsTable'
+import { DeckLegalityPanel, FormatPicker } from './DeckLegalityPanel'
 import { PickListModal } from './PickListModal'
 
 type Props = {
@@ -85,6 +87,11 @@ function contentsToRows(
   return rows
 }
 
+/** Two leaders is what makes a deck Twin Suns; derived from the stored contents so it needs no card lookup. */
+function formatLabel(contents: DeckContents): string {
+  return contents.secondLeader ? FORMAT_RULES.twinSuns.label : FORMAT_RULES.premier.label
+}
+
 function cardsNeeded(contents: DeckContents, ownedByBase: (setKey: SetKey, baseNumber: number) => number): number {
   let needed = 0
   for (const ref of allCardRefs(contents)) needed += Math.max(0, ref.count - ownedByBase(ref.setKey, ref.baseNumber))
@@ -114,6 +121,7 @@ function DeckImportForm({
   const [name, setName] = React.useState('')
   const [physical, setPhysical] = React.useState(false)
   const [copies, setCopies] = React.useState(1)
+  const [formatChoice, setFormatChoice] = React.useState<FormatChoice>('auto')
 
   function handleResolve() {
     if (!text.trim()) {
@@ -129,18 +137,14 @@ function DeckImportForm({
     const resolved = resolveDeckList(parsed, canonicalCatalog, parsedSets, trackedSetKeys, owned)
     setResolution(resolved)
     setName(resolved.deckName ?? '')
+    setFormatChoice('auto')
   }
 
   function handleSave() {
     if (!resolution) return
     const result = createSavedDeck(resolution.rows, { name, physical, copies, sourceText: text })
     if (!result.ok) {
-      showToast(
-        result.reason === 'missing-leader'
-          ? "This decklist doesn't have a leader — it can't be saved yet."
-          : "This decklist doesn't have a base — it can't be saved yet.",
-        'warning',
-      )
+      showToast(`${deckContentsFailureMessage(result.reason)} It can't be saved yet.`, 'warning')
       return
     }
     onSaveDeck(result.deck)
@@ -150,6 +154,10 @@ function DeckImportForm({
 
   const owned = React.useMemo(() => buildOwnedLookup(), [buildOwnedLookup])
   const previewRows = resolution ? computeDeckRows(resolution.rows, owned) : []
+  const legality = React.useMemo(
+    () => (resolution ? checkDeckLegality(resolution.rows, formatChoice) : null),
+    [resolution, formatChoice],
+  )
 
   return (
     <div className="card" style={{ padding: 12, marginTop: 8 }}>
@@ -169,6 +177,10 @@ function DeckImportForm({
 
       {resolution && (
         <>
+          <div className="row" style={{ marginTop: 8 }}>
+            <FormatPicker id="deck-import-format" value={formatChoice} onChange={setFormatChoice} />
+          </div>
+          {legality && <DeckLegalityPanel legality={legality} />}
           {previewRows.length > 0 && <DeckRowsTable rows={previewRows} />}
           {resolution.unresolved.length > 0 && (
             <p className="muted">{resolution.unresolved.length} line(s) couldn't be matched to a card.</p>
@@ -222,6 +234,7 @@ function PreconJsonBuilder({
   const [label, setLabel] = React.useState('')
   const [setKeyInput, setSetKeyInput] = React.useState('')
   const [aspect, setAspect] = React.useState('Heroism')
+  const [formatChoice, setFormatChoice] = React.useState<FormatChoice>('auto')
 
   function handleResolve() {
     if (!text.trim()) {
@@ -235,9 +248,11 @@ function PreconJsonBuilder({
     const parsed = parseDeckList(text)
     const resolved = resolveDeckList(parsed, canonicalCatalog, parsedSets, trackedSetKeys, () => 0)
     setResolution(resolved)
+    setFormatChoice('auto')
   }
 
   const contentsResult = resolution ? deckContentsFromRows(resolution.rows) : null
+  const legality = resolution ? checkDeckLegality(resolution.rows, formatChoice) : null
 
   function handleCopyFile() {
     if (!contentsResult?.ok) return
@@ -276,13 +291,16 @@ function PreconJsonBuilder({
 
       {resolution && (
         <>
+          <div className="row" style={{ marginTop: 8 }}>
+            <FormatPicker id="precon-builder-format" value={formatChoice} onChange={setFormatChoice} />
+          </div>
+          {legality && <DeckLegalityPanel legality={legality} />}
           {resolution.unresolved.length > 0 && (
             <p className="muted">{resolution.unresolved.length} line(s) couldn't be matched to a card.</p>
           )}
           {contentsResult && !contentsResult.ok && (
             <p className="err">
-              Missing a {contentsResult.reason === 'missing-leader' ? 'leader' : 'base'} — this decklist can't
-              become a precon file yet.
+              {deckContentsFailureMessage(contentsResult.reason)} It can't become a precon file yet.
             </p>
           )}
           {contentsResult?.ok && (
@@ -357,6 +375,7 @@ function SavedDeckRow({
           <span>{deck.name}</span>
         </button>
         <div className="row" style={{ gap: 8, alignItems: 'center' }}>
+          <span className="pill">{formatLabel(deck)}</span>
           <span className="pill">{deck.physical ? `Physical × ${deck.copies}` : 'Reference'}</span>
           <span className="pill">{deck.constructed ? 'Constructed' : 'Not built'}</span>
           <span className="pill">Needed: {needed}</span>

--- a/src/core/deckContents.test.ts
+++ b/src/core/deckContents.test.ts
@@ -36,6 +36,33 @@ describe('deckContentsFromRows', () => {
     });
   });
 
+  it('rejects a third leader instead of silently dropping it', () => {
+    const rows = [
+      row({ role: 'leader', setKey: 'TS26', baseNumber: 1, count: 1 }),
+      row({ role: 'leader', setKey: 'TS26', baseNumber: 2, count: 1 }),
+      row({ role: 'leader', setKey: 'TS26', baseNumber: 3, count: 1 }),
+      row({ role: 'base', setKey: 'TS26', baseNumber: 4, count: 1 }),
+    ];
+    expect(deckContentsFromRows(rows)).toEqual({ ok: false, reason: 'too-many-leaders' });
+  });
+
+  it('rejects the same leader listed twice, which is not a legal Twin Suns pair', () => {
+    const rows = [
+      row({ role: 'leader', setKey: 'TS26', baseNumber: 1, count: 2 }),
+      row({ role: 'base', setKey: 'TS26', baseNumber: 4, count: 1 }),
+    ];
+    expect(deckContentsFromRows(rows)).toEqual({ ok: false, reason: 'too-many-leaders' });
+  });
+
+  it('rejects a second base instead of silently dropping it', () => {
+    const rows = [
+      row({ role: 'leader', setKey: 'SOR', baseNumber: 1, count: 1 }),
+      row({ role: 'base', setKey: 'SOR', baseNumber: 2, count: 1 }),
+      row({ role: 'base', setKey: 'SOR', baseNumber: 3, count: 1 }),
+    ];
+    expect(deckContentsFromRows(rows)).toEqual({ ok: false, reason: 'too-many-bases' });
+  });
+
   it('captures a second leader row for Twin Suns decks', () => {
     const rows = [
       row({ role: 'leader', setKey: 'TS26', baseNumber: 1, count: 1 }),

--- a/src/core/deckContents.ts
+++ b/src/core/deckContents.ts
@@ -11,9 +11,15 @@ export type DeckContents = {
   sideboard: DeckCardRef[]
 }
 
+export type DeckContentsFailureReason =
+  | 'missing-leader'
+  | 'missing-base'
+  | 'too-many-leaders'
+  | 'too-many-bases'
+
 export type DeckContentsResult =
   | { ok: true; contents: DeckContents }
-  | { ok: false; reason: 'missing-leader' | 'missing-base' }
+  | { ok: false; reason: DeckContentsFailureReason }
 
 function toRef(row: ResolvedDeckRow): DeckCardRef {
   return { setKey: row.setKey, baseNumber: row.baseNumber, count: row.count }
@@ -25,6 +31,12 @@ export function deckContentsFromRows(rows: ResolvedDeckRow[]): DeckContentsResul
   const bases = rows.filter(r => r.role === 'base')
   if (leaders.length === 0) return { ok: false, reason: 'missing-leader' }
   if (bases.length === 0) return { ok: false, reason: 'missing-base' }
+  // A deck holds at most two leaders (Twin Suns) and one base; anything more would be silently
+  // dropped by the destructuring below, so reject it instead of losing cards.
+  if (leaders.length > 2 || leaders.some(r => r.count > 1)) {
+    return { ok: false, reason: 'too-many-leaders' }
+  }
+  if (bases.length > 1 || bases[0].count > 1) return { ok: false, reason: 'too-many-bases' }
 
   const [leader, secondLeader] = leaders
   const [base] = bases

--- a/src/core/deckLegality.test.ts
+++ b/src/core/deckLegality.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from 'vitest';
+import { checkDeckLegality, deckStats, detectPlayFormat } from './deckLegality';
+import type { ResolvedDeckRow } from './decklist';
+
+function row(
+  partial: Partial<ResolvedDeckRow> &
+    Pick<ResolvedDeckRow, 'role' | 'setKey' | 'baseNumber' | 'count'>,
+): ResolvedDeckRow {
+  return { name: `Card ${partial.baseNumber}`, price: 0, ambiguous: false, ...partial };
+}
+
+/** A main deck of `size` cards spread over distinct singleton titles, starting at card #100. */
+function singletonDeck(size: number, setKey = 'TS26'): ResolvedDeckRow[] {
+  return Array.from({ length: size }, (_, i) =>
+    row({ role: 'deck', setKey, baseNumber: 100 + i, count: 1 }),
+  );
+}
+
+/** A main deck of `size` cards using 3-ofs, the Premier default. */
+function playsetDeck(size: number, setKey = 'SOR'): ResolvedDeckRow[] {
+  return Array.from({ length: size / 3 }, (_, i) =>
+    row({ role: 'deck', setKey, baseNumber: 100 + i, count: 3 }),
+  );
+}
+
+const premierDeck: ResolvedDeckRow[] = [
+  row({ role: 'leader', setKey: 'SOR', baseNumber: 1, count: 1 }),
+  row({ role: 'base', setKey: 'SOR', baseNumber: 2, count: 1 }),
+  ...playsetDeck(51),
+];
+
+const twinSunsDeck: ResolvedDeckRow[] = [
+  row({ role: 'leader', setKey: 'TS26', baseNumber: 1, count: 1 }),
+  row({ role: 'leader', setKey: 'TS26', baseNumber: 2, count: 1 }),
+  row({ role: 'base', setKey: 'TS26', baseNumber: 3, count: 1 }),
+  ...singletonDeck(80),
+];
+
+function codes(rows: ResolvedDeckRow[], choice?: 'auto' | 'premier' | 'twinSuns') {
+  return checkDeckLegality(rows, choice).issues.map(i => i.code);
+}
+
+describe('detectPlayFormat', () => {
+  it('reads a single leader as Premier', () => {
+    expect(detectPlayFormat(premierDeck)).toBe('premier');
+  });
+
+  it('reads two leaders as Twin Suns', () => {
+    expect(detectPlayFormat(twinSunsDeck)).toBe('twinSuns');
+  });
+
+  it('reads a leaderless list as Premier rather than guessing from deck size', () => {
+    expect(detectPlayFormat(singletonDeck(80))).toBe('premier');
+  });
+});
+
+describe('deckStats', () => {
+  it('counts copies for deck size but distinct rows for title count', () => {
+    expect(deckStats(premierDeck)).toEqual({
+      leaderCount: 1,
+      baseCount: 1,
+      mainDeckSize: 51,
+      sideboardSize: 0,
+      distinctMainDeckCards: 17,
+    });
+  });
+
+  it('counts sideboard cards separately from the main deck', () => {
+    const rows = [...premierDeck, row({ role: 'sideboard', setKey: 'SOR', baseNumber: 900, count: 2 })];
+    expect(deckStats(rows).sideboardSize).toBe(2);
+    expect(deckStats(rows).mainDeckSize).toBe(51);
+  });
+});
+
+describe('checkDeckLegality — Premier', () => {
+  it('passes a 1-leader, 1-base, 51-card deck', () => {
+    const result = checkDeckLegality(premierDeck);
+    expect(result.format).toBe('premier');
+    expect(result.autoDetected).toBe(true);
+    expect(result.issues).toEqual([]);
+    expect(result.legal).toBe(true);
+  });
+
+  it('flags a deck under 50 cards', () => {
+    const rows = [premierDeck[0], premierDeck[1], ...playsetDeck(48)];
+    expect(codes(rows)).toEqual(['deck-size']);
+  });
+
+  it('flags a 4th copy of a card', () => {
+    const rows = [...premierDeck, row({ role: 'deck', setKey: 'SOR', baseNumber: 100, count: 1 })];
+    expect(codes(rows)).toContain('copy-limit');
+  });
+
+  it('allows a card whose own text raises its limit', () => {
+    const rows = [
+      premierDeck[0],
+      premierDeck[1],
+      ...playsetDeck(36),
+      row({ role: 'deck', setKey: 'SOR', baseNumber: 500, count: 15, maxCopies: 15 }),
+    ];
+    expect(codes(rows)).toEqual([]);
+  });
+
+  it('warns, but stays legal, when the sideboard is over 10 cards', () => {
+    const sideboard = Array.from({ length: 11 }, (_, i) =>
+      row({ role: 'sideboard', setKey: 'SOR', baseNumber: 900 + i, count: 1 }),
+    );
+    const result = checkDeckLegality([...premierDeck, ...sideboard]);
+    expect(result.issues.map(i => i.severity)).toEqual(['warning']);
+    expect(result.legal).toBe(true);
+  });
+});
+
+describe('checkDeckLegality — Twin Suns', () => {
+  it('passes a 2-leader, 1-base, 80-card singleton deck', () => {
+    const result = checkDeckLegality(twinSunsDeck);
+    expect(result.format).toBe('twinSuns');
+    expect(result.issues).toEqual([]);
+    expect(result.legal).toBe(true);
+  });
+
+  it('flags a deck under 80 cards', () => {
+    const rows = [twinSunsDeck[0], twinSunsDeck[1], twinSunsDeck[2], ...singletonDeck(60)];
+    expect(codes(rows)).toEqual(['deck-size']);
+  });
+
+  it('flags a repeated card, since Twin Suns is singleton', () => {
+    const rows = [
+      twinSunsDeck[0],
+      twinSunsDeck[1],
+      twinSunsDeck[2],
+      ...singletonDeck(78),
+      row({ role: 'deck', setKey: 'TS26', baseNumber: 500, count: 2 }),
+    ];
+    const result = checkDeckLegality(rows);
+    expect(result.issues.map(i => i.code)).toEqual(['copy-limit']);
+    expect(result.issues[0].message).toContain('only 1 copy');
+  });
+
+  it('counts main deck and sideboard together against the copy limit', () => {
+    const rows = [
+      twinSunsDeck[0],
+      twinSunsDeck[1],
+      twinSunsDeck[2],
+      ...singletonDeck(80),
+      row({ role: 'sideboard', setKey: 'TS26', baseNumber: 100, count: 1 }),
+    ];
+    expect(codes(rows)).toEqual(['copy-limit']);
+  });
+
+  it('treats the same card from two sets as one card', () => {
+    const rows = [
+      twinSunsDeck[0],
+      twinSunsDeck[1],
+      twinSunsDeck[2],
+      ...singletonDeck(79),
+      row({ role: 'deck', setKey: 'SOR', baseNumber: 700, name: 'Vanquish', count: 1 }),
+      row({ role: 'deck', setKey: 'TS26', baseNumber: 701, name: 'Vanquish', count: 1 }),
+    ];
+    expect(codes(rows)).toEqual(['copy-limit']);
+  });
+
+  it('keeps a subtitle-distinguished card separate from its namesake', () => {
+    const rows = [
+      twinSunsDeck[0],
+      twinSunsDeck[1],
+      twinSunsDeck[2],
+      ...singletonDeck(78),
+      row({ role: 'deck', setKey: 'TS26', baseNumber: 700, name: 'Luke Skywalker', subtitle: 'Faithful Friend', count: 1 }),
+      row({ role: 'deck', setKey: 'TS26', baseNumber: 701, name: 'Luke Skywalker', subtitle: 'Jedi Knight', count: 1 }),
+    ];
+    expect(codes(rows)).toEqual([]);
+  });
+
+  it('flags a third leader', () => {
+    const rows = [...twinSunsDeck, row({ role: 'leader', setKey: 'TS26', baseNumber: 4, count: 1 })];
+    expect(codes(rows)).toContain('leader-count');
+  });
+
+  it('flags the same leader listed twice rather than two different ones', () => {
+    const rows = [
+      row({ role: 'leader', setKey: 'TS26', baseNumber: 1, count: 2 }),
+      twinSunsDeck[2],
+      ...singletonDeck(80),
+    ];
+    expect(codes(rows)).toEqual(['leader-copies']);
+  });
+
+  it('flags a second base', () => {
+    const rows = [...twinSunsDeck, row({ role: 'base', setKey: 'TS26', baseNumber: 4, count: 1 })];
+    expect(codes(rows)).toContain('base-count');
+  });
+});
+
+describe('checkDeckLegality — explicit format choice', () => {
+  it('judges a Premier-shaped deck against Twin Suns rules when asked', () => {
+    const result = checkDeckLegality(premierDeck, 'twinSuns');
+    expect(result.autoDetected).toBe(false);
+    expect(result.issues.map(i => i.code)).toContain('leader-count');
+    expect(result.issues.map(i => i.code)).toContain('deck-size');
+    expect(result.issues.map(i => i.code)).toContain('copy-limit');
+  });
+
+  it('judges a Twin Suns deck against Premier rules when asked', () => {
+    const result = checkDeckLegality(twinSunsDeck, 'premier');
+    expect(result.issues.map(i => i.code)).toEqual(['leader-count']);
+  });
+});

--- a/src/core/deckLegality.ts
+++ b/src/core/deckLegality.ts
@@ -1,0 +1,193 @@
+import type { ResolvedDeckRow } from './decklist'
+import { normalize } from './search'
+
+export type PlayFormat = 'premier' | 'twinSuns'
+/** What the user picked in the UI; 'auto' infers the format from the decklist's leader count. */
+export type FormatChoice = 'auto' | PlayFormat
+
+export type FormatRules = {
+  label: string
+  /** Exact number of leader cards the format requires. */
+  leaders: number
+  /** Minimum main-deck size. */
+  minDeck: number
+  /** Default copies allowed per card title, across main deck and sideboard combined. */
+  copyLimit: number
+  maxSideboard: number
+}
+
+export const FORMAT_RULES: Record<PlayFormat, FormatRules> = {
+  premier: { label: 'Premier', leaders: 1, minDeck: 50, copyLimit: 3, maxSideboard: 10 },
+  twinSuns: { label: 'Twin Suns', leaders: 2, minDeck: 80, copyLimit: 1, maxSideboard: 10 },
+}
+
+export type DeckLegalityIssueCode =
+  | 'leader-count'
+  | 'base-count'
+  | 'leader-copies'
+  | 'base-copies'
+  | 'deck-size'
+  | 'copy-limit'
+  | 'sideboard-size'
+
+export type DeckLegalityIssue = {
+  code: DeckLegalityIssueCode
+  /** Errors make the deck illegal; warnings are advisory only. */
+  severity: 'error' | 'warning'
+  message: string
+}
+
+export type DeckStats = {
+  leaderCount: number
+  baseCount: number
+  /** Total main-deck cards (sum of counts, not distinct titles). */
+  mainDeckSize: number
+  sideboardSize: number
+  distinctMainDeckCards: number
+}
+
+export type DeckLegality = {
+  format: PlayFormat
+  /** True when the format was inferred from the decklist rather than chosen explicitly. */
+  autoDetected: boolean
+  rules: FormatRules
+  stats: DeckStats
+  issues: DeckLegalityIssue[]
+  /** True when there are no error-severity issues. */
+  legal: boolean
+}
+
+/** Cards are unique by title (name + subtitle), not by printing — the same card from two sets is still one card. */
+function titleKey(row: ResolvedDeckRow): string {
+  return `${normalize(row.name)}|${normalize(row.subtitle ?? '')}`
+}
+
+function displayTitle(row: ResolvedDeckRow): string {
+  return row.subtitle ? `${row.name} - ${row.subtitle}` : row.name
+}
+
+/**
+ * Infers the play format from the decklist itself. Two leaders is the one unambiguous Twin Suns
+ * signal — deck size can't be trusted, since an in-progress list is short of both minimums.
+ */
+export function detectPlayFormat(rows: ResolvedDeckRow[]): PlayFormat {
+  const leaderCopies = rows
+    .filter(r => r.role === 'leader')
+    .reduce((sum, r) => sum + r.count, 0)
+  return leaderCopies >= 2 ? 'twinSuns' : 'premier'
+}
+
+export function deckStats(rows: ResolvedDeckRow[]): DeckStats {
+  let leaderCount = 0
+  let baseCount = 0
+  let mainDeckSize = 0
+  let sideboardSize = 0
+  let distinctMainDeckCards = 0
+
+  for (const row of rows) {
+    if (row.role === 'leader') leaderCount += row.count
+    else if (row.role === 'base') baseCount += row.count
+    else if (row.role === 'deck') {
+      mainDeckSize += row.count
+      distinctMainDeckCards++
+    } else if (row.role === 'sideboard') sideboardSize += row.count
+  }
+
+  return { leaderCount, baseCount, mainDeckSize, sideboardSize, distinctMainDeckCards }
+}
+
+/**
+ * Checks a resolved decklist against a format's deck-building rules.
+ *
+ * The copy limit is applied per card title across main deck and sideboard combined, and a card
+ * whose own text overrides the limit (`maxCopies`, e.g. Swarming Vulture Droid) keeps its override
+ * in both formats — card text beats the format's default.
+ */
+export function checkDeckLegality(
+  rows: ResolvedDeckRow[],
+  choice: FormatChoice = 'auto',
+): DeckLegality {
+  const format = choice === 'auto' ? detectPlayFormat(rows) : choice
+  const rules = FORMAT_RULES[format]
+  const stats = deckStats(rows)
+  const issues: DeckLegalityIssue[] = []
+
+  if (stats.leaderCount !== rules.leaders) {
+    issues.push({
+      code: 'leader-count',
+      severity: 'error',
+      message: `${rules.label} needs exactly ${rules.leaders} leader${rules.leaders === 1 ? '' : 's'} — this deck has ${stats.leaderCount}.`,
+    })
+  }
+  if (stats.baseCount !== 1) {
+    issues.push({
+      code: 'base-count',
+      severity: 'error',
+      message: `A deck needs exactly 1 base — this deck has ${stats.baseCount}.`,
+    })
+  }
+
+  // A leader/base row with count > 1 means the same card was listed twice; in Twin Suns that also
+  // means the two leaders aren't two different cards.
+  for (const row of rows) {
+    if (row.role !== 'leader' && row.role !== 'base') continue
+    if (row.count <= 1) continue
+    issues.push({
+      code: row.role === 'leader' ? 'leader-copies' : 'base-copies',
+      severity: 'error',
+      message: `${displayTitle(row)} is listed ${row.count}× as a ${row.role} — only 1 copy of a ${row.role} is allowed.`,
+    })
+  }
+
+  if (stats.mainDeckSize < rules.minDeck) {
+    issues.push({
+      code: 'deck-size',
+      severity: 'error',
+      message: `${rules.label} needs at least ${rules.minDeck} cards in the main deck — this deck has ${stats.mainDeckSize}.`,
+    })
+  }
+
+  if (stats.sideboardSize > rules.maxSideboard) {
+    issues.push({
+      code: 'sideboard-size',
+      severity: 'warning',
+      message: `Sideboard has ${stats.sideboardSize} cards — the limit is ${rules.maxSideboard}.`,
+    })
+  }
+
+  const byTitle = new Map<string, { title: string; count: number; limit: number }>()
+  for (const row of rows) {
+    if (row.role !== 'deck' && row.role !== 'sideboard') continue
+    const key = titleKey(row)
+    const existing = byTitle.get(key)
+    const limit = row.maxCopies ?? rules.copyLimit
+    if (existing) {
+      existing.count += row.count
+      // Printings of one card should agree, but if they don't, the most permissive text wins.
+      existing.limit = Math.max(existing.limit, limit)
+    } else {
+      byTitle.set(key, { title: displayTitle(row), count: row.count, limit })
+    }
+  }
+
+  for (const entry of byTitle.values()) {
+    if (entry.count <= entry.limit) continue
+    issues.push({
+      code: 'copy-limit',
+      severity: 'error',
+      message:
+        entry.limit === 1
+          ? `${entry.title} appears ${entry.count}× — ${rules.label} allows only 1 copy of each card.`
+          : `${entry.title} appears ${entry.count}× — the limit is ${entry.limit}.`,
+    })
+  }
+
+  return {
+    format,
+    autoDetected: choice === 'auto',
+    rules,
+    stats,
+    issues,
+    legal: !issues.some(i => i.severity === 'error'),
+  }
+}

--- a/src/core/decklist.test.ts
+++ b/src/core/decklist.test.ts
@@ -165,6 +165,21 @@ describe('parseDeckJson', () => {
       { role: 'leader', name: 'ASH_001', count: 1, exact: { setKey: 'ASH', printingNumber: 1 } },
     ])
   })
+
+  it.each(['secondLeader', 'leader2'])(
+    'also accepts %s as the second leader key',
+    key => {
+      const parsed = parseDeckJson(
+        JSON.stringify({
+          leader: { id: 'SHD_012', count: 1 },
+          [key]: { id: 'ASH_001', count: 1 },
+          base: { id: 'SOR_030', count: 1 },
+          deck: [],
+        }),
+      )
+      expect(parsed.entries.filter(e => e.role === 'leader')).toHaveLength(2)
+    },
+  )
 })
 
 // ---------------------------------------------------------------------------

--- a/src/core/decklist.ts
+++ b/src/core/decklist.ts
@@ -40,6 +40,8 @@ export type ResolvedDeckRow = {
   subtitle?: string
   type?: string
   price: number
+  /** Per-card deck-building override from the card's own text (e.g. Swarming Vulture Droid's 15), when it has one. */
+  maxCopies?: number
   /** True if this row's set was guessed because the same name matched more than one tracked set. */
   ambiguous: boolean
   ambiguousOtherSets?: SetKey[]
@@ -121,6 +123,8 @@ function parseCardId(id: unknown): DeckEntryCandidate | null {
   return { setKey, printingNumber }
 }
 
+const SECOND_LEADER_KEYS = ['secondleader', 'secondLeader', 'leader2'] as const
+
 export function parseDeckJson(text: string): ParsedDeckList {
   const payload: unknown = JSON.parse(text)
   if (!isRecord(payload)) throw new Error('Invalid decklist JSON payload.')
@@ -146,8 +150,10 @@ export function parseDeckJson(text: string): ParsedDeckList {
   }
 
   pushRef('leader', payload.leader, 'leader')
-  // Twin Suns decks run two leaders; swudb-style exports carry the second under `secondleader`.
-  pushRef('leader', payload.secondleader, 'secondleader')
+  // Twin Suns decks run two leaders. Exporters disagree on the key for the second one, so accept
+  // the spellings seen in the wild rather than only swudb's `secondleader`.
+  const secondLeaderKey = SECOND_LEADER_KEYS.find(key => payload[key] !== undefined)
+  if (secondLeaderKey) pushRef('leader', payload[secondLeaderKey], secondLeaderKey)
   pushRef('base', payload.base, 'base')
   if (Array.isArray(payload.deck)) {
     payload.deck.forEach((item, i) => pushRef('deck', item, `deck[${i}]`))
@@ -572,6 +578,7 @@ export function resolveDeckList(
         subtitle: resolved.card.Subtitle,
         type: resolved.card.Type,
         price: Number(resolved.card.MarketPrice ?? 0),
+        maxCopies: resolved.card.MaxCopies,
         ambiguous,
         ambiguousOtherSets,
       })

--- a/src/core/decks.ts
+++ b/src/core/decks.ts
@@ -6,6 +6,7 @@ import {
   isDeckContents,
   type DeckCardRef,
   type DeckContents,
+  type DeckContentsFailureReason,
   type OwnedTotals,
 } from './deckContents'
 import type { PreconCatalogEntry } from './precons'
@@ -46,7 +47,20 @@ export type NewSavedDeckInput = {
 
 export type CreateSavedDeckResult =
   | { ok: true; deck: SavedDeck }
-  | { ok: false; reason: 'missing-leader' | 'missing-base' }
+  | { ok: false; reason: DeckContentsFailureReason }
+
+/** Describes the problem only; callers add what it blocks ("it can't be saved yet", etc.). */
+const DECK_CONTENTS_FAILURE_MESSAGE: Record<DeckContentsFailureReason, string> = {
+  'missing-leader': "This decklist doesn't have a leader.",
+  'missing-base': "This decklist doesn't have a base.",
+  'too-many-leaders':
+    "This decklist's leaders don't fit a deck — Premier takes one leader, Twin Suns takes two different ones.",
+  'too-many-bases': 'This decklist has more than one base.',
+}
+
+export function deckContentsFailureMessage(reason: DeckContentsFailureReason): string {
+  return DECK_CONTENTS_FAILURE_MESSAGE[reason]
+}
 
 export function createSavedDeck(
   rows: ResolvedDeckRow[],


### PR DESCRIPTION
## What

Deck Check, the deck importer, and the precon JSON builder resolved a decklist to cards and priced it, but never said whether the list was a *legal deck*. Twin Suns had no real support beyond the parsers carrying a second leader through.

This adds a `deckLegality` core module that infers the format from the leader count and validates the deck against it:

| | Premier | Twin Suns |
|---|---|---|
| Leaders | 1 | **2** (must be different cards) |
| Base | 1 | 1 |
| Main deck min | 50 | **80** |
| Copies per card | 3 | **1** |

The shared `DeckLegalityPanel` renders the rules row plus any issues, and a **Format** dropdown (Auto-detect / Premier / Twin Suns) re-judges a list against the other format when auto-detection isn't what you want. Saved decks get a Premier/Twin Suns pill.

## Why these rule details

- **Detection keys off leader count**, not deck size — an in-progress list is short of both minimums, so size can't distinguish the formats.
- **Copy limits apply per card title**, so the same card from two different sets counts as one card, and main deck + sideboard are counted together (which is also correct for Premier's 3-of limit).
- **A card whose own text overrides the limit keeps its override in both formats.** The existing `MaxCopies` field (e.g. Swarming Vulture Droid's 15) is derived from card text, and card text beats the format default.
- **An oversized sideboard warns rather than failing the deck** — capped at 10 for both formats.

The last two are judgment calls worth a look; happy to make either strict instead.

## Bugs fixed along the way

- `deckContentsFromRows` silently dropped a 3rd+ leader and a 2nd base — those cards vanished from saved decks. It now rejects them with specific reasons, shared through `deckContentsFailureMessage` so all three call sites stay in sync.
- JSON imports only recognized swudb's `secondleader`; now also accept `secondLeader` and `leader2`.
- Deck Check's ownership pills read "Leaders: Missing" directly under the new "Leaders: 2/2" count. Reworded to "Leaders not owned" so the two rows don't look like conflicting claims.

## Testing

`tsc --noEmit` clean, 188 tests pass (24 new in `deckLegality.test.ts` plus additions to `deckContents`/`decklist`), lint clean apart from a pre-existing warning in `deckSync.ts`, production build succeeds.

Also driven end-to-end against the running app with a real Twin Suns list built from `TS26-blood-brothers.json`: detected Twin Suns, reported `Leaders 2/2 · Base 1/1 · Deck 80/80 · Legal ✓`, correctly flagged a tampered version (`76 cards`, `Village Tender appears 2×`), and round-tripped a save with both leaders intact.

### Pre-existing failures, not introduced here

`npm test` also fails on `App.test.tsx` / `App.keyboard.test.tsx` (`localStorage.clear is not a function`) and the `server/test/*` suites (missing `supertest` / `better-sqlite3`). Both fail identically on a clean `main` checkout.

`npm run format:check` flags the two new files — but it already flags all 109 files in the repo, so these match the surrounding code style rather than introducing an island of Prettier-formatted code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
